### PR TITLE
Fix unbounded scheduled execution publishing

### DIFF
--- a/src/Appwrite/Platform/Tasks/Schedule.php
+++ b/src/Appwrite/Platform/Tasks/Schedule.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Platform\Tasks;
 
+use Appwrite\Event\Publisher\Func as FunctionPublisher;
 use Swoole\Coroutine as Co;
 use Utopia\Console;
 use Utopia\Database\Database;
@@ -22,7 +23,7 @@ class Schedule extends Action
             ->desc('Execute functions, executions, and messages scheduled in Appwrite')
             ->inject('publisher')
             ->inject('publisherMigrations')
-            ->inject('publisherFunctions')
+            ->inject('publisherForFunctions')
             ->inject('publisherMessaging')
             ->inject('getIsResourceBlocked')
             ->inject('dbForPlatform')
@@ -34,7 +35,7 @@ class Schedule extends Action
     public function action(
         BrokerPool $publisher,
         BrokerPool $publisherMigrations,
-        BrokerPool $publisherFunctions,
+        FunctionPublisher $publisherForFunctions,
         BrokerPool $publisherMessaging,
         callable $getIsResourceBlocked,
         Database $dbForPlatform,
@@ -66,7 +67,7 @@ class Schedule extends Action
             $task->setup(
                 $publisher,
                 $publisherMigrations,
-                $publisherFunctions,
+                $publisherForFunctions,
                 $publisherMessaging,
                 $telemetry,
             );

--- a/src/Appwrite/Platform/Tasks/ScheduleBase.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleBase.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Platform\Tasks;
 
+use Appwrite\Event\Publisher\Func as FunctionPublisher;
 use Swoole\Timer;
 use Utopia\Console;
 use Utopia\Database\Database;
@@ -32,7 +33,7 @@ abstract class ScheduleBase extends Action
 
     protected BrokerPool $publisher;
     protected BrokerPool $publisherMigrations;
-    protected BrokerPool $publisherFunctions;
+    protected FunctionPublisher $publisherForFunctions;
     protected BrokerPool $publisherMessaging;
 
     private ?Histogram $collectSchedulesTelemetryDuration = null;
@@ -70,7 +71,7 @@ abstract class ScheduleBase extends Action
             ->desc("Execute {$type}s scheduled in Appwrite")
             ->inject('publisher')
             ->inject('publisherMigrations')
-            ->inject('publisherFunctions')
+            ->inject('publisherForFunctions')
             ->inject('publisherMessaging')
             ->inject('getIsResourceBlocked')
             ->inject('dbForPlatform')
@@ -98,12 +99,12 @@ abstract class ScheduleBase extends Action
      * 2. Create timer that sync all changes from 'schedules' collection to local copy. Only reading changes thanks to 'resourceUpdatedAt' attribute
      * 3. Create timer that prepares coroutines for soon-to-execute schedules. When it's ready, coroutine sleeps until exact time before sending request to worker.
      */
-    public function action(BrokerPool $publisher, BrokerPool $publisherMigrations, BrokerPool $publisherFunctions, BrokerPool $publisherMessaging, callable $getIsResourceBlocked, Database $dbForPlatform, callable $getProjectDB, Telemetry $telemetry): never
+    public function action(BrokerPool $publisher, BrokerPool $publisherMigrations, FunctionPublisher $publisherForFunctions, BrokerPool $publisherMessaging, callable $getIsResourceBlocked, Database $dbForPlatform, callable $getProjectDB, Telemetry $telemetry): never
     {
         $this->setup(
             $publisher,
             $publisherMigrations,
-            $publisherFunctions,
+            $publisherForFunctions,
             $publisherMessaging,
             $telemetry,
         );
@@ -117,13 +118,13 @@ abstract class ScheduleBase extends Action
     public function setup(
         BrokerPool $publisher,
         BrokerPool $publisherMigrations,
-        BrokerPool $publisherFunctions,
+        FunctionPublisher $publisherForFunctions,
         BrokerPool $publisherMessaging,
         Telemetry $telemetry,
     ): void {
         $this->publisher = $publisher;
         $this->publisherMigrations = $publisherMigrations;
-        $this->publisherFunctions = $publisherFunctions;
+        $this->publisherForFunctions = $publisherForFunctions;
         $this->publisherMessaging = $publisherMessaging;
 
         $this->scheduleTelemetryCount = $telemetry->createGauge('task.schedule.count');

--- a/src/Appwrite/Platform/Tasks/ScheduleExecutions.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleExecutions.php
@@ -69,6 +69,7 @@ class ScheduleExecutions extends ScheduleBase
                 new \Utopia\Queue\Queue(\Utopia\System\System::getEnv('_APP_FUNCTIONS_QUEUE_NAME', \Appwrite\Event\Event::FUNCTIONS_QUEUE_NAME), 'utopia-queue', \Appwrite\Event\Event::FUNCTIONS_QUEUE_TTL)
             );
 
+            $schedules = [];
             foreach ($this->schedules as $schedule) {
                 if (!$schedule['active']) {
                     unset($this->schedules[$schedule['$sequence']]);
@@ -80,6 +81,12 @@ class ScheduleExecutions extends ScheduleBase
                     continue;
                 }
 
+                $schedules[] = [$scheduledAt, $schedule];
+            }
+
+            usort($schedules, static fn (array $first, array $second) => $first[0] <=> $second[0]);
+
+            foreach ($schedules as [$scheduledAt, $schedule]) {
                 $delay = $scheduledAt->getTimestamp() - (new \DateTime())->getTimestamp();
 
                 try {

--- a/src/Appwrite/Platform/Tasks/ScheduleExecutions.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleExecutions.php
@@ -20,6 +20,8 @@ class ScheduleExecutions extends ScheduleBase
     public const UPDATE_TIMER = 3; // seconds
     public const ENQUEUE_TIMER = 4; // seconds
 
+    private bool $enqueuing = false;
+
     public static function getName(): string
     {
         return 'schedule-executions';
@@ -53,27 +55,33 @@ class ScheduleExecutions extends ScheduleBase
 
     protected function enqueueResources(Database $dbForPlatform, callable $getProjectDB): void
     {
-        $intervalEnd = (new \DateTime())->modify('+' . self::ENQUEUE_TIMER . ' seconds');
+        if ($this->enqueuing) {
+            return;
+        }
 
-        $publisherForFunctions = new FunctionPublisher(
-            $this->publisherFunctions,
-            new \Utopia\Queue\Queue(\Utopia\System\System::getEnv('_APP_FUNCTIONS_QUEUE_NAME', \Appwrite\Event\Event::FUNCTIONS_QUEUE_NAME), 'utopia-queue', \Appwrite\Event\Event::FUNCTIONS_QUEUE_TTL)
-        );
+        $this->enqueuing = true;
 
-        foreach ($this->schedules as $schedule) {
-            if (!$schedule['active']) {
-                unset($this->schedules[$schedule['$sequence']]);
-                continue;
-            }
+        try {
+            $intervalEnd = (new \DateTime())->modify('+' . self::ENQUEUE_TIMER . ' seconds');
 
-            $scheduledAt = new \DateTime($schedule['schedule']);
-            if ($scheduledAt > $intervalEnd) {
-                continue;
-            }
+            $publisherForFunctions = new FunctionPublisher(
+                $this->publisherFunctions,
+                new \Utopia\Queue\Queue(\Utopia\System\System::getEnv('_APP_FUNCTIONS_QUEUE_NAME', \Appwrite\Event\Event::FUNCTIONS_QUEUE_NAME), 'utopia-queue', \Appwrite\Event\Event::FUNCTIONS_QUEUE_TTL)
+            );
 
-            $delay = $scheduledAt->getTimestamp() - (new \DateTime())->getTimestamp();
+            foreach ($this->schedules as $schedule) {
+                if (!$schedule['active']) {
+                    unset($this->schedules[$schedule['$sequence']]);
+                    continue;
+                }
 
-            \go(function () use ($publisherForFunctions, $schedule, $scheduledAt, $delay) {
+                $scheduledAt = new \DateTime($schedule['schedule']);
+                if ($scheduledAt > $intervalEnd) {
+                    continue;
+                }
+
+                $delay = $scheduledAt->getTimestamp() - (new \DateTime())->getTimestamp();
+
                 try {
                     if ($delay > 0) {
                         Co::sleep($delay);
@@ -93,8 +101,11 @@ class ScheduleExecutions extends ScheduleBase
                     unset($this->schedules[$schedule['$sequence']]);
                 } catch (\Throwable $th) {
                     Console::error("Failed to enqueue scheduled execution {$schedule['resourceId']}: {$th->getMessage()}");
+                    break;
                 }
-            });
+            }
+        } finally {
+            $this->enqueuing = false;
         }
     }
 }

--- a/src/Appwrite/Platform/Tasks/ScheduleExecutions.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleExecutions.php
@@ -3,7 +3,6 @@
 namespace Appwrite\Platform\Tasks;
 
 use Appwrite\Event\Message\Func as FunctionMessage;
-use Appwrite\Event\Publisher\Func as FunctionPublisher;
 use Swoole\Coroutine as Co;
 use Utopia\Console;
 use Utopia\Database\Database;
@@ -64,11 +63,6 @@ class ScheduleExecutions extends ScheduleBase
         try {
             $intervalEnd = (new \DateTime())->modify('+' . self::ENQUEUE_TIMER . ' seconds');
 
-            $publisherForFunctions = new FunctionPublisher(
-                $this->publisherFunctions,
-                new \Utopia\Queue\Queue(\Utopia\System\System::getEnv('_APP_FUNCTIONS_QUEUE_NAME', \Appwrite\Event\Event::FUNCTIONS_QUEUE_NAME), 'utopia-queue', \Appwrite\Event\Event::FUNCTIONS_QUEUE_TTL)
-            );
-
             $schedules = [];
             foreach ($this->schedules as $schedule) {
                 if (!$schedule['active']) {
@@ -94,7 +88,7 @@ class ScheduleExecutions extends ScheduleBase
                         Co::sleep($delay);
                     }
 
-                    $publisherForFunctions->enqueue(new FunctionMessage(
+                    $this->publisherForFunctions->enqueue(new FunctionMessage(
                         project: $schedule['project'],
                         functionId: $schedule['resource']->getAttribute('resourceId', ''),
                         execution: new Document([

--- a/src/Appwrite/Platform/Tasks/ScheduleFunctions.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleFunctions.php
@@ -3,7 +3,6 @@
 namespace Appwrite\Platform\Tasks;
 
 use Appwrite\Event\Message\Func as FunctionMessage;
-use Appwrite\Event\Publisher\Func as FunctionPublisher;
 use Cron\CronExpression;
 use Utopia\Console;
 use Utopia\Database\Database;
@@ -117,18 +116,13 @@ class ScheduleFunctions extends ScheduleBase
 
                     $this->updateProjectAccess($schedule['project'], $dbForPlatform);
 
-                    $publisherForFunctions = new FunctionPublisher(
-                        $this->publisherFunctions,
-                        new \Utopia\Queue\Queue(\Utopia\System\System::getEnv('_APP_FUNCTIONS_QUEUE_NAME', \Appwrite\Event\Event::FUNCTIONS_QUEUE_NAME), 'utopia-queue', \Appwrite\Event\Event::FUNCTIONS_QUEUE_TTL)
-                    );
-
                     Span::init('schedule.functions.enqueue');
                     try {
                         Span::add('project.id', $schedule['project']->getId());
                         Span::add('function.id', $schedule['resource']->getId());
                         Span::add('schedule.id', $schedule['$id'] ?? '');
 
-                        $publisherForFunctions->enqueue(new FunctionMessage(
+                        $this->publisherForFunctions->enqueue(new FunctionMessage(
                             project: $schedule['project'],
                             function: $schedule['resource'],
                             type: 'schedule',


### PR DESCRIPTION
## Summary

- publish scheduled executions serially inside the coroutine already created by the scheduler loop
- order due executions by scheduled time before draining
- skip overlapping drain ticks while a backlog is still publishing
- stop the current drain after a queue publish failure and retry on a later tick
- inject the existing typed functions publisher into separate and combined schedulers

## Why

The execution scheduler created one coroutine for every due schedule. In NYC, more than 16,000 due schedules exhausted the 24-connection publisher pool. Failed schedules were retried by the next tick, which increased memory until the task was OOM-killed.

## Validation

- composer test -- tests/unit/Platform/Tasks
- composer test -- tests/unit/Platform/Workers/FunctionsTest.php
- composer lint -- scheduler files changed by this PR
- composer check -- src/Appwrite/Platform/Tasks/Schedule*.php
- git diff --check