### PR TITLE
refactor(specs): use standard nullable field

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -881,7 +881,7 @@ class OpenAPI3 extends Format
                         }
 
                         if ($parameter['nullable']) {
-                            $body['content'][$consumes[0]]['schema']['properties'][$name]['x-nullable'] = true;
+                            $body['content'][$consumes[0]]['schema']['properties'][$name]['nullable'] = true;
                         }
                     }
                 }

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -564,7 +564,7 @@ final class FormatTest extends TestCase
 
         $this->assertSame('password', $openApiProperties['password']['format']);
         $this->assertSame('password', $openApiProperties['nullablePassword']['format']);
-        $this->assertTrue($openApiProperties['nullablePassword']['x-nullable']);
+        $this->assertTrue($openApiProperties['nullablePassword']['nullable']);
         $this->assertArrayNotHasKey('format', $openApiProperties['name']);
         $this->assertSame('password', $openApi['components']['schemas']['webhook']['properties']['authPassword']['format']);
 


### PR DESCRIPTION
## What does this PR do?

Replaces the legacy `x-nullable` extension on generated request-body properties with OpenAPI 3.0's standard `nullable` field.

Response model schemas already use `nullable`, and `utopia-php/openapi` already parses the standard field while retaining fallback support for historical specs that contain `x-nullable`.

## Tests

- `vendor/bin/phpunit tests/unit/SDK/Specification/FormatTest.php`
- `composer lint src/Appwrite/SDK/Specification/Format/OpenAPI3.php tests/unit/SDK/Specification/FormatTest.php`
- `vendor/bin/rector process --dry-run --config tests/tools/rector.php src/Appwrite/SDK/Specification/Format/OpenAPI3.php tests/unit/SDK/Specification/FormatTest.php`
- Generated client, server, and console specs locally and confirmed they contain no `x-nullable`
