### PR TITLE
refactor(specs): use standard typed examples

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -31,6 +31,76 @@ class OpenAPI3 extends Format
         return 'Open API 3';
     }
 
+    private function normalizeExample(mixed $example, string $type): mixed
+    {
+        return match ($type) {
+            'array' => $this->normalizeArrayExample($example),
+            'object' => $this->normalizeObjectExample($example),
+            'integer' => \is_int($example) ? $example : (int) $example,
+            'number' => \is_int($example) || \is_float($example) ? $example : (float) $example,
+            'boolean' => \is_bool($example) ? $example : \filter_var($example, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE),
+            'string' => \is_string($example) ? $example : (string) $example,
+            default => $example,
+        };
+    }
+
+    private function normalizeArrayExample(mixed $example): array
+    {
+        if (\is_array($example)) {
+            return \array_is_list($example) ? $example : [$example];
+        }
+
+        if (\is_object($example)) {
+            $example = (array) $example;
+            return empty($example) ? [] : [$example];
+        }
+
+        if (\is_string($example)) {
+            if ($example === '') {
+                return [];
+            }
+
+            try {
+                $decoded = \json_decode($example, true, flags: JSON_THROW_ON_ERROR);
+                if (\is_array($decoded)) {
+                    return \array_is_list($decoded) ? $decoded : [$decoded];
+                }
+            } catch (\JsonException) {
+                // A scalar example for an array parameter represents one item.
+            }
+        }
+
+        return [$example];
+    }
+
+    private function normalizeObjectExample(mixed $example): object
+    {
+        if (\is_object($example)) {
+            return $example;
+        }
+
+        if (\is_array($example)) {
+            if (!empty($example) && \array_is_list($example)) {
+                throw new \InvalidArgumentException('Object schema examples cannot be lists.');
+            }
+
+            return (object) $example;
+        }
+
+        if (\is_string($example)) {
+            try {
+                $decoded = \json_decode($example, flags: JSON_THROW_ON_ERROR);
+                if (\is_object($decoded)) {
+                    return $decoded;
+                }
+            } catch (\JsonException) {
+                // Throw the schema-specific error below.
+            }
+        }
+
+        throw new \InvalidArgumentException('Object schema examples must be JSON objects.');
+    }
+
     public function parse(): array
     {
         /**
@@ -484,7 +554,7 @@ class OpenAPI3 extends Format
                     case \Utopia\Database\Validator\UID::class:
                     case \Utopia\Validator\Text::class:
                         $node['schema']['type'] = $validator->getType();
-                        $node['schema']['x-example'] = ($param['example'] ?? '') ?: '<' . \strtoupper(Template::fromCamelCaseToSnake($node['name'])) . '>';
+                        $node['schema']['example'] = ($param['example'] ?? '') ?: '<' . \strtoupper(Template::fromCamelCaseToSnake($node['name'])) . '>';
                         break;
                     case \Utopia\Database\Validator\BigInt::class:
                         // BigInt validator reports Database::VAR_BIGINT, but OpenAPI expects scalar types.
@@ -492,12 +562,12 @@ class OpenAPI3 extends Format
                         $node['schema']['type'] = 'integer';
                         $node['schema']['format'] = 'int64';
                         if (!empty($param['example'])) {
-                            $node['schema']['x-example'] = $param['example'];
+                            $node['schema']['example'] = $param['example'];
                         }
                         break;
                     case \Utopia\Validator\Boolean::class:
                         $node['schema']['type'] = $validator->getType();
-                        $node['schema']['x-example'] = ($param['example'] ?? '') ?: false;
+                        $node['schema']['example'] = ($param['example'] ?? '') ?: false;
                         break;
                     case \Appwrite\Utopia\Database\Validator\CustomId::class:
                         if ($sdk->getType() === MethodType::UPLOAD) {
@@ -507,12 +577,12 @@ class OpenAPI3 extends Format
                         $node['schema']['x-appwrite'] = [
                             'idGenerator' => 'ID.unique',
                         ];
-                        $node['schema']['x-example'] = ($param['example'] ?? '') ?: '<' . \strtoupper(Template::fromCamelCaseToSnake($node['name'])) . '>';
+                        $node['schema']['example'] = ($param['example'] ?? '') ?: '<' . \strtoupper(Template::fromCamelCaseToSnake($node['name'])) . '>';
                         break;
                     case \Utopia\Database\Validator\Datetime::class:
                         $node['schema']['type'] = $validator->getType();
                         $node['schema']['format'] = 'datetime';
-                        $node['schema']['x-example'] = ($param['example'] ?? '') ?: Model::TYPE_DATETIME_EXAMPLE;
+                        $node['schema']['example'] = ($param['example'] ?? '') ?: Model::TYPE_DATETIME_EXAMPLE;
                         break;
                     case \Utopia\Database\Validator\Spatial::class:
                         /** @var Spatial $validator */
@@ -547,7 +617,7 @@ class OpenAPI3 extends Format
                                 ],
                             ],
                         };
-                        $node['schema']['x-example'] = ($param['example'] ?? '') ?: match ($validator->getSpatialType()) {
+                        $node['schema']['example'] = ($param['example'] ?? '') ?: match ($validator->getSpatialType()) {
                             Database::VAR_POINT => '[1, 2]',
                             Database::VAR_LINESTRING => '[[1, 2], [3, 4], [5, 6]]',
                             Database::VAR_POLYGON => '[[[1, 2], [3, 4], [5, 6], [1, 2]]]',
@@ -557,25 +627,25 @@ class OpenAPI3 extends Format
                     case \Utopia\Emails\Validator\Email::class:
                         $node['schema']['type'] = $validator->getType();
                         $node['schema']['format'] = 'email';
-                        $node['schema']['x-example'] = ($param['example'] ?? '') ?: 'email@example.com';
+                        $node['schema']['example'] = ($param['example'] ?? '') ?: 'email@example.com';
                         break;
                     case \Utopia\Validator\Host::class:
                     case \Utopia\Validator\URL::class:
                     case \Appwrite\Network\Validator\Redirect::class:
                         $node['schema']['type'] = $validator->getType();
                         $node['schema']['format'] = 'url';
-                        $node['schema']['x-example'] = ($param['example'] ?? '') ?: 'https://example.com';
+                        $node['schema']['example'] = ($param['example'] ?? '') ?: 'https://example.com';
                         break;
                     case \Utopia\Validator\JSON::class:
                     case \Utopia\Validator\JSON\ObjectValidator::class:
                     case \Utopia\Validator\Assoc::class:
                         $node['schema']['type'] = 'object';
                         $node['schema']['default'] = (empty($param['default'])) ? new \stdClass() : $param['default'];
-                        $node['schema']['x-example'] = ($param['example'] ?? '') ?: '{}';
+                        $node['schema']['example'] = ($param['example'] ?? '') ?: '{}';
                         break;
                     case \Utopia\Validator\JSON\ArrayValidator::class:
                         $node['schema']['type'] = 'array';
-                        $node['schema']['x-example'] = ($param['example'] ?? '') ?: '[]';
+                        $node['schema']['example'] = ($param['example'] ?? '') ?: '[]';
                         break;
                     case \Appwrite\Utopia\Request\Validator\File::class:
                         $consumes = ['multipart/form-data'];
@@ -589,7 +659,7 @@ class OpenAPI3 extends Format
                             'type' => $validator->getValidator()->getType(),
                         ];
                         if (!empty($param['example'])) {
-                            $node['schema']['x-example'] = $param['example'];
+                            $node['schema']['example'] = $param['example'];
                         }
                         break;
                     case Queries::class:
@@ -603,37 +673,37 @@ class OpenAPI3 extends Format
                         $node['schema']['items'] = [
                             'type' => 'string',
                         ];
-                        $node['schema']['x-example'] = ($param['example'] ?? '') ?: '["' . Permission::read(Role::any()) . '"]';
+                        $node['schema']['example'] = ($param['example'] ?? '') ?: [Permission::read(Role::any())];
                         break;
                     case \Utopia\Database\Validator\Roles::class:
                         $node['schema']['type'] = $validator->getType();
                         $node['schema']['items'] = [
                             'type' => 'string',
                         ];
-                        $node['schema']['x-example'] = ($param['example'] ?? '') ?: '["' . Role::any()->toString() . '"]';
+                        $node['schema']['example'] = ($param['example'] ?? '') ?: '["' . Role::any()->toString() . '"]';
                         break;
                     case \Appwrite\Auth\Validator\Password::class:
                     case \Appwrite\SDK\Specification\Validator\PasswordFormat::class:
                         $node['schema']['type'] = $validator->getType();
                         $node['schema']['format'] = 'password';
-                        $node['schema']['x-example'] = ($param['example'] ?? '') ?: 'password';
+                        $node['schema']['example'] = ($param['example'] ?? '') ?: 'password';
                         break;
                     case \Appwrite\Auth\Validator\Phone::class:
                         $node['schema']['type'] = $validator->getType();
                         $node['schema']['format'] = 'phone';
-                        $node['schema']['x-example'] = ($param['example'] ?? '') ?: '+12065550100'; // In the US, 555 is reserved like example.com
+                        $node['schema']['example'] = ($param['example'] ?? '') ?: '+12065550100'; // In the US, 555 is reserved like example.com
                         break;
                     case \Utopia\Validator\Range::class:
                         /** @var Range $validator */
                         $node['schema']['type'] = $validator->getType() === Validator::TYPE_FLOAT ? 'number' : $validator->getType();
                         $node['schema']['format'] = $validator->getType() == Validator::TYPE_INTEGER ? 'int32' : 'float';
-                        $node['schema']['x-example'] = ($param['example'] ?? '') ?: $validator->getMin();
+                        $node['schema']['example'] = ($param['example'] ?? '') ?: $validator->getMin();
                         break;
                     case \Utopia\Validator\Integer::class:
                         $node['schema']['type'] = $validator->getType();
                         $node['schema']['format'] = $validator->getFormat();
                         if (!empty($param['example'])) {
-                            $node['schema']['x-example'] = $param['example'];
+                            $node['schema']['example'] = $param['example'];
                         }
                         break;
                     case \Utopia\Validator\Numeric::class:
@@ -641,7 +711,7 @@ class OpenAPI3 extends Format
                         $node['schema']['type'] = 'number';
                         $node['schema']['format'] = 'float';
                         if (!empty($param['example'])) {
-                            $node['schema']['x-example'] = $param['example'];
+                            $node['schema']['example'] = $param['example'];
                         }
                         break;
                     case \Utopia\Validator\WhiteList::class:
@@ -653,7 +723,7 @@ class OpenAPI3 extends Format
                                 'type' => $validator->getType(),
                             ];
                             if (!empty($param['example'])) {
-                                $node['schema']['x-example'] = $param['example'];
+                                $node['schema']['example'] = $param['example'];
                             }
 
                             if ($validator->getType() === 'string') {
@@ -691,7 +761,7 @@ class OpenAPI3 extends Format
                             }
                         } else {
                             $node['schema']['type'] = $validator->getType();
-                            $node['schema']['x-example'] = ($param['example'] ?? '') ?: $validator->getList()[0];
+                            $node['schema']['example'] = ($param['example'] ?? '') ?: $validator->getList()[0];
 
                             if ($validator->getType() === 'string') {
                                 $enum = $param['enum'] ?? null;
@@ -730,7 +800,7 @@ class OpenAPI3 extends Format
                         break;
                     case \Appwrite\Utopia\Database\Validator\CompoundUID::class:
                         $node['schema']['type'] = $validator->getType();
-                        $node['schema']['x-example'] = ($param['example'] ?? '') ?: '<ID1:ID2>';
+                        $node['schema']['example'] = ($param['example'] ?? '') ?: '<ID1:ID2>';
                         break;
                     case \Appwrite\Utopia\Database\Validator\Operation::class:
                         if ($array) {
@@ -759,17 +829,21 @@ class OpenAPI3 extends Format
                             if ($array) {
                                 $example = [$example];
                             }
-                            $node['schema']['x-example'] = \str_replace("\n", "\n\t", \json_encode($example, JSON_PRETTY_PRINT));
+                            $node['schema']['example'] = \str_replace("\n", "\n\t", \json_encode($example, JSON_PRETTY_PRINT));
                         } else {
-                            $node['schema']['x-example'] = $param['example'];
+                            $node['schema']['example'] = $param['example'];
                         }
                         break;
                     default:
                         $node['schema']['type'] = 'string';
                         if (!empty($param['example'])) {
-                            $node['schema']['x-example'] = $param['example'];
+                            $node['schema']['example'] = $param['example'];
                         }
                         break;
+                }
+
+                if (\array_key_exists('example', $node['schema'])) {
+                    $node['schema']['example'] = $this->normalizeExample($node['schema']['example'], $node['schema']['type']);
                 }
 
                 if ($parameter['emitDefault'] && $this->shouldEmitDefaultForSchema($param['default'], $node['schema'])) { // Param has default value
@@ -855,7 +929,9 @@ class OpenAPI3 extends Format
                             $body['content'][$consumes[0]]['schema']['properties'][$name]['default'] = $node['schema']['default'];
                         }
 
-                        $body['content'][$consumes[0]]['schema']['properties'][$name]['x-example'] = $node['schema']['x-example'] ?? null;
+                        if (\array_key_exists('example', $node['schema'])) {
+                            $body['content'][$consumes[0]]['schema']['properties'][$name]['example'] = $node['schema']['example'];
+                        }
 
                         if (isset($node['schema']['format'])) {
                             $body['content'][$consumes[0]]['schema']['properties'][$name]['format'] = $node['schema']['format'];
@@ -1021,14 +1097,16 @@ class OpenAPI3 extends Format
                 }
 
                 $readOnly = $rule['readOnly'] ?? false;
-                if ($rule['type'] == 'json') {
+                if ($rule['type'] == 'json' && !$rule['array']) {
                     $output['components']['schemas'][$model->getType()]['properties'][$name] = [
                         'type' => $type,
                         'additionalProperties' => true,
                         'description' => $rule['description'] ?? '',
-                        'x-example' => $rule['example'] ?? null,
                     ];
 
+                    if (isset($rule['example'])) {
+                        $output['components']['schemas'][$model->getType()]['properties'][$name]['example'] = $this->normalizeExample($rule['example'], $type);
+                    }
                     if ($readOnly) {
                         $output['components']['schemas'][$model->getType()]['properties'][$name]['readOnly'] = true;
                     }
@@ -1042,7 +1120,6 @@ class OpenAPI3 extends Format
                         'items' => [
                             'type' => $type,
                         ],
-                        'x-example' => $rule['example'] ?? null,
                     ];
 
                     if ($format) {
@@ -1055,7 +1132,6 @@ class OpenAPI3 extends Format
                     $output['components']['schemas'][$model->getType()]['properties'][$name] = [
                         'type' => $type,
                         'description' => $rule['description'] ?? '',
-                        'x-example' => $rule['example'] ?? null,
                     ];
 
                     if ($format) {
@@ -1064,6 +1140,11 @@ class OpenAPI3 extends Format
                     if ($readOnly) {
                         $output['components']['schemas'][$model->getType()]['properties'][$name]['readOnly'] = true;
                     }
+                }
+
+                if (isset($rule['example'])) {
+                    $propertyType = $rule['array'] ? 'array' : $type;
+                    $output['components']['schemas'][$model->getType()]['properties'][$name]['example'] = $this->normalizeExample($rule['example'], $propertyType);
                 }
                 if ($items) {
                     if ($rule['array'] || $rule['type'] === 'array') {
@@ -1103,7 +1184,7 @@ class OpenAPI3 extends Format
                 $examples = array_merge($examples, $model->getSampleData());
             }
 
-            $output['components']['schemas'][$model->getType()]['example'] = $examples;
+            $output['components']['schemas'][$model->getType()]['example'] = (object) $examples;
         }
 
         \ksort($output['paths']);

--- a/src/Appwrite/Utopia/Response/Model/Migration.php
+++ b/src/Appwrite/Utopia/Response/Model/Migration.php
@@ -134,6 +134,7 @@ class Migration extends Model
                 'description' => 'An array of objects containing the report data of the resources that were migrated.',
                 'default' => [],
                 'example' => '[{"resource":"Database","id":"public","status":"SUCCESS","message":""}]',
+                'array' => true,
             ])
             ->addRule('errors', [
                 'type' => self::TYPE_STRING,

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -23,6 +23,7 @@ use Appwrite\Utopia\Response\Model\AttributeLine;
 use Appwrite\Utopia\Response\Model\Error as ErrorModel;
 use Appwrite\Utopia\Response\Model\HealthStatus;
 use Appwrite\Utopia\Response\Model\Metric;
+use Appwrite\Utopia\Response\Model\Migration;
 use Appwrite\Utopia\Response\Model\None as NoneModel;
 use Appwrite\Utopia\Response\Model\PlatformAndroid;
 use Appwrite\Utopia\Response\Model\PlatformApple;
@@ -44,8 +45,12 @@ use Utopia\Database\Validator\Query\Offset;
 use Utopia\Database\Validator\Spatial;
 use Utopia\DI\Container;
 use Utopia\Http\Route;
+use Utopia\Validator\ArrayList;
+use Utopia\Validator\Assoc;
+use Utopia\Validator\Boolean as BooleanValidator;
 use Utopia\Validator\JSON;
 use Utopia\Validator\Nullable;
+use Utopia\Validator\Range;
 use Utopia\Validator\Text;
 
 class TestFormat extends Format
@@ -136,10 +141,46 @@ final class FormatTest extends TestCase
 
         $spec = (new OpenAPI3(new Container(), [], [$route], [], [], 0, 'console'))->parse();
 
-        $this->assertSame(
-            ['idGenerator' => 'ID.unique'],
-            $spec['paths']['/tests']['post']['requestBody']['content']['application/json']['schema']['properties']['userId']['x-appwrite']
-        );
+        $userId = $spec['paths']['/tests']['post']['requestBody']['content']['application/json']['schema']['properties']['userId'];
+
+        $this->assertSame(['idGenerator' => 'ID.unique'], $userId['x-appwrite']);
+        $this->assertSame('<USER_ID>', $userId['example']);
+        $this->assertArrayNotHasKey('x-example', $userId);
+    }
+
+    public function testOpenApiExamplesUseNativeSchemaTypes(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route('POST', '/v1/tests'))
+            ->desc('Create test')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'createTest',
+                description: 'Create test.',
+                auth: [],
+                responses: [],
+            ))
+            ->param('metadata', [], new Assoc(), 'Metadata.', example: '{"enabled":true}')
+            ->param('labels', [], new ArrayList(new Text(16)), 'Labels.', example: '["one","two"]')
+            ->param('singleLabel', [], new ArrayList(new Text(16)), 'Single label.', example: 'one')
+            ->param('count', 0, new Range(0, 100), 'Count.', example: '42')
+            ->param('ratio', 0, new Range(0, 10, Range::TYPE_FLOAT), 'Ratio.', example: '2.5')
+            ->param('enabled', false, new BooleanValidator(true), 'Enabled.', example: 'true')
+            ->param('text', '', new Text(64), 'Text.', example: '["one","two"]');
+
+        $spec = (new OpenAPI3(new Container(), [], [$route], [], [], 0, 'console'))->parse();
+        $properties = $spec['paths']['/tests']['post']['requestBody']['content']['application/json']['schema']['properties'];
+
+        $this->assertEquals((object) ['enabled' => true], $properties['metadata']['example']);
+        $this->assertSame(['one', 'two'], $properties['labels']['example']);
+        $this->assertSame(['one'], $properties['singleLabel']['example']);
+        $this->assertSame(42, $properties['count']['example']);
+        $this->assertEqualsWithDelta(2.5, $properties['ratio']['example'], PHP_FLOAT_EPSILON);
+        $this->assertTrue($properties['enabled']['example']);
+        $this->assertSame('["one","two"]', $properties['text']['example']);
     }
 
     public function testMethodParameterOverridesFilterAndReplaceRouteParams(): void
@@ -411,6 +452,42 @@ final class FormatTest extends TestCase
         }
     }
 
+    public function testJsonArrayModelExamplesUseArraySchemas(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route('GET', '/v1/tests/migration'))
+            ->desc('Get migration')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'getMigration',
+                description: 'Get migration.',
+                auth: [],
+                responses: [
+                    new SDKResponse(
+                        code: 200,
+                        model: Response::MODEL_MIGRATION,
+                    ),
+                ],
+            ));
+
+        $openApi = (new OpenAPI3(new Container(), [], [$route], [new Migration()], [], 0, 'console'))->parse();
+        $resourceData = $openApi['components']['schemas']['migration']['properties']['resourceData'];
+
+        $this->assertSame('array', $resourceData['type']);
+        $this->assertSame(['type' => 'object'], $resourceData['items']);
+        $this->assertSame([
+            [
+                'resource' => 'Database',
+                'id' => 'public',
+                'status' => 'SUCCESS',
+                'message' => '',
+            ],
+        ], $resourceData['example']);
+    }
+
     public function testArrayItemsSchemaInfersTypesFromJsonStringExamples(): void
     {
         $this->assertSame(
@@ -532,6 +609,8 @@ final class FormatTest extends TestCase
             $this->assertSame('number', $default['items']['items']['type']);
             $this->assertSame('double', $default['items']['items']['format']);
         }
+
+        $this->assertSame([[1, 2], [3, 4], [5, 6]], $openApiRequestDefault['example']);
     }
 
     public function testPasswordFormatMarksOnlyExplicitPasswordFields(): void
@@ -563,10 +642,16 @@ final class FormatTest extends TestCase
         $openApiProperties = $openApi['paths']['/tests']['post']['requestBody']['content']['application/json']['schema']['properties'];
 
         $this->assertSame('password', $openApiProperties['password']['format']);
+        $this->assertSame('password', $openApiProperties['password']['example']);
+        $this->assertArrayNotHasKey('x-example', $openApiProperties['password']);
         $this->assertSame('password', $openApiProperties['nullablePassword']['format']);
         $this->assertTrue($openApiProperties['nullablePassword']['x-nullable']);
         $this->assertArrayNotHasKey('format', $openApiProperties['name']);
-        $this->assertSame('password', $openApi['components']['schemas']['webhook']['properties']['authPassword']['format']);
+
+        $authPassword = $openApi['components']['schemas']['webhook']['properties']['authPassword'];
+        $this->assertSame('password', $authPassword['format']);
+        $this->assertSame('webhook-password', $authPassword['example']);
+        $this->assertArrayNotHasKey('x-example', $authPassword);
 
     }
 


### PR DESCRIPTION
## What does this PR do?

Replaces the legacy `x-example` extension in generated OpenAPI schemas with OpenAPI 3.0's standard `example` field.

Examples are also emitted using the JSON type declared by their schema:

- arrays as arrays instead of JSON-encoded strings
- objects as objects instead of JSON-encoded strings
- integers and numbers as numbers
- booleans as booleans
- strings remain strings, even when their contents look like JSON

Missing examples are omitted instead of being emitted as `null`. The migration report's `resourceData` schema is corrected to an array of objects so its schema and example agree.

SDK Generator compatibility for native array and object examples is handled by appwrite/sdk-generator#1812. Historical `x-example` values remain supported there.

## Validation

- `vendor/bin/phpunit tests/unit/SDK/Specification/FormatTest.php` — 22 tests, 120 assertions
- `composer lint src/Appwrite/SDK/Specification/Format/OpenAPI3.php src/Appwrite/Utopia/Response/Model/Migration.php tests/unit/SDK/Specification/FormatTest.php`
- `vendor/bin/rector process --dry-run --config tests/tools/rector.php src/Appwrite/SDK/Specification/Format/OpenAPI3.php src/Appwrite/Utopia/Response/Model/Migration.php tests/unit/SDK/Specification/FormatTest.php`
- Generated client, server, and console specs locally
- Confirmed all generated schema examples match their declared type, including nested array items
- Confirmed generated specs contain no `x-example` and no `example: null`
- Validated all three generated specs with Swagger Validator: zero errors and warnings
