### PR TITLE
fix(workers): restore Swoole hook flags

### DIFF
--- a/src/Appwrite/Platform/Workers/Blocking.php
+++ b/src/Appwrite/Platform/Workers/Blocking.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Appwrite\Platform\Workers;
+
+use Swoole\Runtime;
+use Utopia\Platform\Action;
+
+abstract class Blocking extends Action
+{
+    private static int $jobs = 0;
+    private static ?int $hookFlags = null;
+
+    protected function disableTcpHook(): void
+    {
+        if (!\class_exists(Runtime::class)) {
+            return;
+        }
+
+        if (self::$jobs === 0) {
+            self::$hookFlags = Runtime::getHookFlags();
+            Runtime::setHookFlags(SWOOLE_HOOK_ALL ^ SWOOLE_HOOK_TCP);
+        }
+
+        self::$jobs++;
+    }
+
+    protected function restoreTcpHook(): void
+    {
+        if (!\class_exists(Runtime::class)) {
+            return;
+        }
+
+        self::$jobs--;
+
+        if (self::$jobs === 0 && self::$hookFlags !== null) {
+            Runtime::setHookFlags(self::$hookFlags);
+            self::$hookFlags = null;
+        }
+    }
+}

--- a/src/Appwrite/Platform/Workers/Mails.php
+++ b/src/Appwrite/Platform/Workers/Mails.php
@@ -4,21 +4,19 @@ namespace Appwrite\Platform\Workers;
 
 use Appwrite\Template\Template;
 use Exception;
-use Swoole\Runtime;
 use Utopia\Database\Document;
 use Utopia\Logger\Log;
 use Utopia\Messaging\Adapter\Email as EmailAdapter;
 use Utopia\Messaging\Adapter\Email\SMTP;
 use Utopia\Messaging\Messages\Email as EmailMessage;
 use Utopia\Messaging\Messages\Email\Attachment;
-use Utopia\Platform\Action;
 use Utopia\Queue\Message;
 use Utopia\Registry\Registry;
 use Utopia\Span\Span;
 use Utopia\System\System;
 use Utopia\Telemetry\Adapter as Telemetry;
 
-class Mails extends Action
+class Mails extends Blocking
 {
     protected int $previewMaxLen = 150;
 
@@ -64,13 +62,12 @@ class Mails extends Action
      */
     public function action(Message $message, Document $project, Registry $register, Log $log, Telemetry $telemetry): void
     {
-        $previousHookFlags = Runtime::getHookFlags();
-        Runtime::setHookFlags(SWOOLE_HOOK_ALL ^ SWOOLE_HOOK_TCP);
+        $this->disableTcpHook();
 
         try {
             $this->process($message, $project, $register, $log, $telemetry);
         } finally {
-            Runtime::setHookFlags($previousHookFlags);
+            $this->restoreTcpHook();
         }
     }
 

--- a/src/Appwrite/Platform/Workers/Mails.php
+++ b/src/Appwrite/Platform/Workers/Mails.php
@@ -64,7 +64,18 @@ class Mails extends Action
      */
     public function action(Message $message, Document $project, Registry $register, Log $log, Telemetry $telemetry): void
     {
+        $previousHookFlags = Runtime::getHookFlags();
         Runtime::setHookFlags(SWOOLE_HOOK_ALL ^ SWOOLE_HOOK_TCP);
+
+        try {
+            $this->process($message, $project, $register, $log, $telemetry);
+        } finally {
+            Runtime::setHookFlags($previousHookFlags);
+        }
+    }
+
+    private function process(Message $message, Document $project, Registry $register, Log $log, Telemetry $telemetry): void
+    {
         $payload = $message->getPayload();
 
         if (empty($payload)) {

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -101,8 +101,25 @@ class Messaging extends Action
         UsagePublisher $publisherForUsage,
         Telemetry $telemetry
     ): void {
+        $previousHookFlags = Runtime::getHookFlags();
         Runtime::setHookFlags(SWOOLE_HOOK_ALL ^ SWOOLE_HOOK_TCP);
 
+        try {
+            $this->process($message, $project, $log, $dbForProject, $deviceForFiles, $publisherForUsage, $telemetry);
+        } finally {
+            Runtime::setHookFlags($previousHookFlags);
+        }
+    }
+
+    private function process(
+        Message $message,
+        Document $project,
+        Log $log,
+        Database $dbForProject,
+        Device $deviceForFiles,
+        UsagePublisher $publisherForUsage,
+        Telemetry $telemetry
+    ): void {
         $this->telemetry = $telemetry;
         $payload = $message->getPayload();
 

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -6,7 +6,6 @@ use Appwrite\Event\Message\Usage;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
 use Appwrite\Messaging\Status as MessageStatus;
 use Appwrite\Usage\Context as UsageContext;
-use Swoole\Runtime;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
@@ -42,7 +41,6 @@ use Utopia\Messaging\Messages\Email\Attachment;
 use Utopia\Messaging\Messages\Push;
 use Utopia\Messaging\Messages\SMS;
 use Utopia\Messaging\Priority;
-use Utopia\Platform\Action;
 use Utopia\Queue\Message;
 use Utopia\Span\Span;
 use Utopia\Storage\Device;
@@ -53,7 +51,7 @@ use Utopia\Telemetry\Adapter as Telemetry;
 
 use function Swoole\Coroutine\batch;
 
-class Messaging extends Action
+class Messaging extends Blocking
 {
     private ?SMSAdapter $adapter = null;
 
@@ -101,13 +99,12 @@ class Messaging extends Action
         UsagePublisher $publisherForUsage,
         Telemetry $telemetry
     ): void {
-        $previousHookFlags = Runtime::getHookFlags();
-        Runtime::setHookFlags(SWOOLE_HOOK_ALL ^ SWOOLE_HOOK_TCP);
+        $this->disableTcpHook();
 
         try {
             $this->process($message, $project, $log, $dbForProject, $deviceForFiles, $publisherForUsage, $telemetry);
         } finally {
-            Runtime::setHookFlags($previousHookFlags);
+            $this->restoreTcpHook();
         }
     }
 

--- a/src/Appwrite/Platform/Workers/Notifications.php
+++ b/src/Appwrite/Platform/Workers/Notifications.php
@@ -59,9 +59,22 @@ class Notifications extends Action
 
     public function action(Message $message, Document $project, Registry $register, Database $dbForPlatform, Log $log): void
     {
+        $previousHookFlags = \class_exists(Runtime::class) ? Runtime::getHookFlags() : null;
         if (\class_exists(Runtime::class)) {
             Runtime::setHookFlags(SWOOLE_HOOK_ALL ^ SWOOLE_HOOK_TCP);
         }
+
+        try {
+            $this->process($message, $project, $register, $dbForPlatform, $log);
+        } finally {
+            if ($previousHookFlags !== null) {
+                Runtime::setHookFlags($previousHookFlags);
+            }
+        }
+    }
+
+    private function process(Message $message, Document $project, Registry $register, Database $dbForPlatform, Log $log): void
+    {
         $payload = $message->getPayload();
 
         if (empty($payload)) {

--- a/src/Appwrite/Platform/Workers/Notifications.php
+++ b/src/Appwrite/Platform/Workers/Notifications.php
@@ -9,7 +9,6 @@ use Appwrite\Utopia\Messaging\Adapter\Webhook as WebhookAdapter;
 use Appwrite\Utopia\Messaging\Messages\Console as ConsoleMessage;
 use Appwrite\Utopia\Messaging\Messages\Webhook as WebhookMessage;
 use Exception;
-use Swoole\Runtime;
 use Throwable;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
@@ -22,12 +21,11 @@ use Utopia\Messaging\Adapter\Email as EmailAdapter;
 use Utopia\Messaging\Adapter\Email\SMTP;
 use Utopia\Messaging\Messages\Email as EmailMessage;
 use Utopia\Messaging\Messages\Email\Attachment;
-use Utopia\Platform\Action;
 use Utopia\Queue\Message;
 use Utopia\Registry\Registry;
 use Utopia\System\System;
 
-class Notifications extends Action
+class Notifications extends Blocking
 {
     protected int $previewMaxLen = 150;
     protected string $whitespaceCodes = '&#xa0;&#x200C;&#x200B;&#x200D;&#x200E;&#x200F;&#xFEFF;';
@@ -59,17 +57,12 @@ class Notifications extends Action
 
     public function action(Message $message, Document $project, Registry $register, Database $dbForPlatform, Log $log): void
     {
-        $previousHookFlags = \class_exists(Runtime::class) ? Runtime::getHookFlags() : null;
-        if (\class_exists(Runtime::class)) {
-            Runtime::setHookFlags(SWOOLE_HOOK_ALL ^ SWOOLE_HOOK_TCP);
-        }
+        $this->disableTcpHook();
 
         try {
             $this->process($message, $project, $register, $dbForPlatform, $log);
         } finally {
-            if ($previousHookFlags !== null) {
-                Runtime::setHookFlags($previousHookFlags);
-            }
+            $this->restoreTcpHook();
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Restores the process-wide Swoole hook flags after the mails, messaging, and notifications workers finish handling a job.

These workers disable `SWOOLE_HOOK_TCP` for adapter compatibility. This was isolated when each queue ran in its own process, but the default combined worker now runs all queues together. Leaving TCP hooks disabled can therefore block unrelated Redis receives and webhook deliveries, delaying mail and SMS jobs until Account E2E polling expires.

The shared `Blocking` action base reference-counts overlapping jobs. TCP hooks remain disabled until the last affected job finishes, then the original flags are restored. This prevents jobs that finish out of order from restoring a stale TCP-disabled snapshot. Each action uses a `finally` block so failure paths release their reference too.

This addresses the clustered mail/SMS timeouts seen in [Account E2E job 95985719222](https://github.com/appwrite/appwrite/actions/runs/32225808458/job/95985719222), where worker processing paused for about 11 seconds and delayed messages arrived immediately after the assertions timed out.

## Tests

- `composer lint src/Appwrite/Platform/Workers/Blocking.php`
- `composer lint src/Appwrite/Platform/Workers/Mails.php`
- `composer lint src/Appwrite/Platform/Workers/Messaging.php`
- `composer lint src/Appwrite/Platform/Workers/Notifications.php`
- `php -l src/Appwrite/Platform/Workers/Blocking.php`
- `php -l src/Appwrite/Platform/Workers/Mails.php`
- `php -l src/Appwrite/Platform/Workers/Messaging.php`
- `php -l src/Appwrite/Platform/Workers/Notifications.php`
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G src/Appwrite/Platform/Workers/Blocking.php src/Appwrite/Platform/Workers/Mails.php src/Appwrite/Platform/Workers/Messaging.php src/Appwrite/Platform/Workers/Notifications.php`
- Manual overlap probe: enter two blocking jobs, finish them out of order, assert hooks remain disabled until the final job exits and then return to their initial value
