### PR TITLE
fix(workers): limit TCP hook override to SMTP

### DIFF
--- a/src/Appwrite/Platform/Workers/Blocking.php
+++ b/src/Appwrite/Platform/Workers/Blocking.php
@@ -3,6 +3,9 @@
 namespace Appwrite\Platform\Workers;
 
 use Swoole\Runtime;
+use Utopia\Messaging\Adapter;
+use Utopia\Messaging\Adapter\Email\SMTP;
+use Utopia\Messaging\Message;
 use Utopia\Platform\Action;
 
 abstract class Blocking extends Action
@@ -10,10 +13,10 @@ abstract class Blocking extends Action
     private static int $jobs = 0;
     private static ?int $hookFlags = null;
 
-    protected function disableTcpHook(): void
+    protected function send(Adapter $adapter, Message $message): array
     {
-        if (!\class_exists(Runtime::class)) {
-            return;
+        if (!$adapter instanceof SMTP || !\class_exists(Runtime::class)) {
+            return $adapter->send($message);
         }
 
         if (self::$jobs === 0) {
@@ -22,19 +25,16 @@ abstract class Blocking extends Action
         }
 
         self::$jobs++;
-    }
 
-    protected function restoreTcpHook(): void
-    {
-        if (!\class_exists(Runtime::class)) {
-            return;
-        }
+        try {
+            return $adapter->send($message);
+        } finally {
+            self::$jobs--;
 
-        self::$jobs--;
-
-        if (self::$jobs === 0 && self::$hookFlags !== null) {
-            Runtime::setHookFlags(self::$hookFlags);
-            self::$hookFlags = null;
+            if (self::$jobs === 0 && self::$hookFlags !== null) {
+                Runtime::setHookFlags(self::$hookFlags);
+                self::$hookFlags = null;
+            }
         }
     }
 }

--- a/src/Appwrite/Platform/Workers/Mails.php
+++ b/src/Appwrite/Platform/Workers/Mails.php
@@ -62,17 +62,6 @@ class Mails extends Blocking
      */
     public function action(Message $message, Document $project, Registry $register, Log $log, Telemetry $telemetry): void
     {
-        $this->disableTcpHook();
-
-        try {
-            $this->process($message, $project, $register, $log, $telemetry);
-        } finally {
-            $this->restoreTcpHook();
-        }
-    }
-
-    private function process(Message $message, Document $project, Registry $register, Log $log, Telemetry $telemetry): void
-    {
         $payload = $message->getPayload();
 
         if (empty($payload)) {
@@ -224,7 +213,7 @@ class Mails extends Blocking
         $emailMessage->setOrigin(MESSAGE_SEND_TYPE_INTERNAL);
 
         try {
-            $result = $adapter->send($emailMessage);
+            $result = $this->send($adapter, $emailMessage);
 
             if (($result['deliveredTo'] ?? 0) === 0) {
                 $error = $result['results'][0]['error'] ?? ($result['error'] ?? 'Unknown error');

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -99,24 +99,6 @@ class Messaging extends Blocking
         UsagePublisher $publisherForUsage,
         Telemetry $telemetry
     ): void {
-        $this->disableTcpHook();
-
-        try {
-            $this->process($message, $project, $log, $dbForProject, $deviceForFiles, $publisherForUsage, $telemetry);
-        } finally {
-            $this->restoreTcpHook();
-        }
-    }
-
-    private function process(
-        Message $message,
-        Document $project,
-        Log $log,
-        Database $dbForProject,
-        Device $deviceForFiles,
-        UsagePublisher $publisherForUsage,
-        Telemetry $telemetry
-    ): void {
         $this->telemetry = $telemetry;
         $payload = $message->getPayload();
 
@@ -671,7 +653,7 @@ class Messaging extends Blocking
             // expired-device-token cleanup below is isolated in its own try so a DB hiccup there can never be
             // misattributed as a send failure.
             try {
-                $response = $adapter->send($data);
+                $response = $this->send($adapter, $data);
             } catch (\Throwable $e) {
                 if ($hasRetriesLeft && $this->isRetryableError($e->getMessage())) {
                     $retry = $pending;

--- a/src/Appwrite/Platform/Workers/Notifications.php
+++ b/src/Appwrite/Platform/Workers/Notifications.php
@@ -57,17 +57,6 @@ class Notifications extends Blocking
 
     public function action(Message $message, Document $project, Registry $register, Database $dbForPlatform, Log $log): void
     {
-        $this->disableTcpHook();
-
-        try {
-            $this->process($message, $project, $register, $dbForPlatform, $log);
-        } finally {
-            $this->restoreTcpHook();
-        }
-    }
-
-    private function process(Message $message, Document $project, Registry $register, Database $dbForPlatform, Log $log): void
-    {
         $payload = $message->getPayload();
 
         if (empty($payload)) {
@@ -353,7 +342,7 @@ class Notifications extends Blocking
         );
 
         try {
-            $adapter->send($emailMessage);
+            $this->send($adapter, $emailMessage);
         } catch (Throwable $error) {
             throw new Exception('Error sending notification: ' . $error->getMessage(), $type === 'smtp' ? 401 : 500);
         }


### PR DESCRIPTION
## What does this PR do?

Limits the process-wide `SWOOLE_HOOK_TCP` override to SMTP delivery instead of disabling TCP hooks for the entire mails, messaging, and notifications actions.

SMTP still needs the workaround: running STARTTLS with hooked TCP can crash the process ([swoole-src#4909](https://github.com/swoole/swoole-src/issues/4909)), and the crash remains reproducible with the current Swoole 6.2.2 development environment. However, SMS, push, webhook, console, database, and queue operations do not need that workaround.

The shared `Blocking::send()` method now:

- sends non-SMTP adapters without changing hook flags;
- disables TCP hooks immediately before `SMTP::send()`;
- restores the previous flags in `finally` immediately afterward;
- retains reference counting for safe overlapping calls.

This reduces the interval in which Redis receives and other TCP stream operations can block the combined worker. It follows #13277, which fixed leaked and stale hook flags.

## Tests

- `composer lint src/Appwrite/Platform/Workers/Blocking.php`
- `composer lint src/Appwrite/Platform/Workers/Mails.php`
- `composer lint src/Appwrite/Platform/Workers/Messaging.php`
- `composer lint src/Appwrite/Platform/Workers/Notifications.php`
- `php -l` on all four changed files
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G` on all four changed files
- `vendor/bin/phpunit --configuration phpunit.xml tests/unit/Platform/Workers/MailsTest.php tests/unit/Platform/Workers/NotificationsTest.php`
- `vendor/bin/phpunit --configuration phpunit.xml tests/unit/Messaging/MessagingFanoutTest.php`
- Manual hook-scope probe verifying a non-SMTP adapter leaves flags unchanged while SMTP runs without the TCP hook and restores the original flags afterward
