### PR TITLE
fix(specs): omit empty object examples

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -1143,7 +1143,7 @@ class OpenAPI3 extends Format
                 }
 
                 $propertyType = $rule['array'] ? 'array' : $type;
-                if (isset($rule['example']) && ($propertyType === 'string' || $rule['example'] !== '')) {
+                if (isset($rule['example']) && (\in_array($propertyType, ['string', 'array']) || $rule['example'] !== '')) {
                     $output['components']['schemas'][$model->getType()]['properties'][$name]['example'] = $this->normalizeExample($rule['example'], $propertyType);
                 }
                 if ($items) {

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -1104,7 +1104,7 @@ class OpenAPI3 extends Format
                         'description' => $rule['description'] ?? '',
                     ];
 
-                    if (isset($rule['example'])) {
+                    if (isset($rule['example']) && ($type === 'string' || $rule['example'] !== '')) {
                         $output['components']['schemas'][$model->getType()]['properties'][$name]['example'] = $this->normalizeExample($rule['example'], $type);
                     }
                     if ($readOnly) {
@@ -1142,8 +1142,8 @@ class OpenAPI3 extends Format
                     }
                 }
 
-                if (isset($rule['example'])) {
-                    $propertyType = $rule['array'] ? 'array' : $type;
+                $propertyType = $rule['array'] ? 'array' : $type;
+                if (isset($rule['example']) && ($propertyType === 'string' || $rule['example'] !== '')) {
                     $output['components']['schemas'][$model->getType()]['properties'][$name]['example'] = $this->normalizeExample($rule['example'], $propertyType);
                 }
                 if ($items) {

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -22,6 +22,7 @@ use Appwrite\Utopia\Response\Model\AlgoSha;
 use Appwrite\Utopia\Response\Model as ResponseModel;
 use Appwrite\Utopia\Response\Model\AttributeLine;
 use Appwrite\Utopia\Response\Model\Error as ErrorModel;
+use Appwrite\Utopia\Response\Model\ErrorDev;
 use Appwrite\Utopia\Response\Model\HealthStatus;
 use Appwrite\Utopia\Response\Model\Metric;
 use Appwrite\Utopia\Response\Model\Migration;
@@ -427,6 +428,34 @@ final class FormatTest extends TestCase
 
         $this->assertSame('object', $property['type']);
         $this->assertArrayNotHasKey('example', $property);
+    }
+
+    public function testExplicitEmptyArrayExampleIsPreserved(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route('GET', '/v1/tests/error'))
+            ->desc('Get error')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'getError',
+                description: 'Get error.',
+                auth: [],
+                responses: [
+                    new SDKResponse(
+                        code: 500,
+                        model: Response::MODEL_ERROR_DEV,
+                    ),
+                ],
+            ));
+
+        $openApi = (new OpenAPI3(new Container(), [], [$route], [new ErrorDev()], [], 0, 'console'))->parse();
+        $trace = $openApi['components']['schemas']['errorDev']['properties']['trace'];
+
+        $this->assertSame('array', $trace['type']);
+        $this->assertSame([], $trace['example']);
     }
 
     public function testOptionalPathParameterIsEmittedAsRequired(): void

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -19,6 +19,7 @@ use Appwrite\Utopia\Response\Model\AlgoPhpass;
 use Appwrite\Utopia\Response\Model\AlgoScrypt;
 use Appwrite\Utopia\Response\Model\AlgoScryptModified;
 use Appwrite\Utopia\Response\Model\AlgoSha;
+use Appwrite\Utopia\Response\Model as ResponseModel;
 use Appwrite\Utopia\Response\Model\AttributeLine;
 use Appwrite\Utopia\Response\Model\Error as ErrorModel;
 use Appwrite\Utopia\Response\Model\HealthStatus;
@@ -367,6 +368,67 @@ final class FormatTest extends TestCase
      * (`undefined: SessionId`) and a Python SDK that requested
      * `/account/sessions/None`.
      */
+    public function testObjectModelReferencesWithoutExamplesOmitExample(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $parent = new class () extends ResponseModel {
+            public function __construct()
+            {
+                $this->addRule('child', [
+                    'type' => 'childWithoutExample',
+                    'description' => 'Nested child.',
+                    'default' => null,
+                ]);
+            }
+
+            public function getName(): string
+            {
+                return 'Parent without example';
+            }
+
+            public function getType(): string
+            {
+                return 'parentWithoutExample';
+            }
+        };
+
+        $child = new class () extends ResponseModel {
+            public function getName(): string
+            {
+                return 'Child without example';
+            }
+
+            public function getType(): string
+            {
+                return 'childWithoutExample';
+            }
+        };
+
+        $route = (new Route('GET', '/v1/tests/parent'))
+            ->desc('Get parent')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'getParent',
+                description: 'Get parent.',
+                auth: [],
+                responses: [
+                    new SDKResponse(
+                        code: 200,
+                        model: 'parentWithoutExample',
+                    ),
+                ],
+            ));
+
+        $openApi = (new OpenAPI3(new Container(), [], [$route], [$parent, $child], [], 0, 'console'))->parse();
+        $property = $openApi['components']['schemas']['parentWithoutExample']['properties']['child'];
+
+        $this->assertSame('object', $property['type']);
+        $this->assertArrayNotHasKey('example', $property);
+    }
+
     public function testOptionalPathParameterIsEmittedAsRequired(): void
     {
         Method::$processed = [];


### PR DESCRIPTION
## What does this PR do?

Omits default empty-string examples from non-string OpenAPI component properties.

Response model rules default `example` to an empty string when no example is provided. After the typed-example migration, attempting to normalize that sentinel as an object throws `Object schema examples must be JSON objects`. This blocks Cloud spec generation on model references without explicit examples.

Explicit empty-string examples for string properties remain unchanged.

## Validation

- `vendor/bin/phpunit tests/unit/SDK/Specification/FormatTest.php` — 24 tests, 124 assertions
- Pint
- Rector

Regression coverage verifies that object model references without explicit examples omit `example`, while explicit empty array examples remain documented as `[]`.
