### PR TITLE
feat: VCS adapter capabilities and provider-agnostic source archives

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -135,7 +135,7 @@
         "league/csv": "9.14.*",
         "enshrined/svg-sanitize": "0.22.*",
         "utopia-php/client": "^0.3.0",
-        "open-runtimes/sdk-for-php": "0.10.*",
+        "open-runtimes/sdk-for-php": "0.11.*",
         "utopia-php/schedule": "^0.2.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -5068,16 +5068,16 @@
         },
         {
             "name": "utopia-php/vcs",
-            "version": "5.1.2",
+            "version": "5.2.0",
             "source": {
                 "type": "git",
-                "url": "git@github.com:utopia-php/vcs.git",
-                "reference": "abdb5763221d7e4900174c280244f83638e3133e"
+                "url": "https://github.com/utopia-php/vcs.git",
+                "reference": "780f3c84d270a14744a8cd61b1234310d9af59c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/vcs/zipball/abdb5763221d7e4900174c280244f83638e3133e",
-                "reference": "abdb5763221d7e4900174c280244f83638e3133e",
+                "url": "https://api.github.com/repos/utopia-php/vcs/zipball/780f3c84d270a14744a8cd61b1234310d9af59c4",
+                "reference": "780f3c84d270a14744a8cd61b1234310d9af59c4",
                 "shasum": ""
             },
             "require": {
@@ -5128,10 +5128,10 @@
                 "vcs"
             ],
             "support": {
-                "source": "https://github.com/utopia-php/vcs/tree/5.1.2",
+                "source": "https://github.com/utopia-php/vcs/tree/5.2.0",
                 "issues": "https://github.com/utopia-php/vcs/issues"
             },
-            "time": "2026-08-07T12:32:15+00:00"
+            "time": "2026-08-19T10:17:14+00:00"
         },
         {
             "name": "utopia-php/websocket",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "40231755d4dc80d8a23901402b42df4a",
+    "content-hash": "bc7793f803702df7c7726d103a13f599",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -1079,16 +1079,16 @@
         },
         {
             "name": "open-runtimes/sdk-for-php",
-            "version": "0.10.1",
+            "version": "0.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/open-runtimes/sdk-for-php.git",
-                "reference": "2a83df23a377d846a6a57e2146c485c4be706512"
+                "reference": "2db10da2fa7163d096bfd8343a44ae99a2852527"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/open-runtimes/sdk-for-php/zipball/2a83df23a377d846a6a57e2146c485c4be706512",
-                "reference": "2a83df23a377d846a6a57e2146c485c4be706512",
+                "url": "https://api.github.com/repos/open-runtimes/sdk-for-php/zipball/2db10da2fa7163d096bfd8343a44ae99a2852527",
+                "reference": "2db10da2fa7163d096bfd8343a44ae99a2852527",
                 "shasum": ""
             },
             "require": {
@@ -1113,12 +1113,12 @@
             "license": [
                 "MIT"
             ],
-            "description": "PHP SDK for the Open Runtimes orchestrator Jobs API.",
+            "description": "PHP SDK for the Open Runtimes orchestrator: jobs, deployments, sandboxes, and pools.",
             "support": {
                 "issues": "https://github.com/open-runtimes/sdk-for-php/issues",
-                "source": "https://github.com/open-runtimes/sdk-for-php/tree/0.10.1"
+                "source": "https://github.com/open-runtimes/sdk-for-php/tree/0.11.1"
             },
-            "time": "2026-07-31T13:09:22+00:00"
+            "time": "2026-08-19T12:49:14+00:00"
         },
         {
             "name": "open-telemetry/api",
@@ -5068,16 +5068,16 @@
         },
         {
             "name": "utopia-php/vcs",
-            "version": "5.2.0",
+            "version": "5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/vcs.git",
-                "reference": "780f3c84d270a14744a8cd61b1234310d9af59c4"
+                "reference": "ee3928969d6c654fad44fad7f38cc96383b031fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/vcs/zipball/780f3c84d270a14744a8cd61b1234310d9af59c4",
-                "reference": "780f3c84d270a14744a8cd61b1234310d9af59c4",
+                "url": "https://api.github.com/repos/utopia-php/vcs/zipball/ee3928969d6c654fad44fad7f38cc96383b031fa",
+                "reference": "ee3928969d6c654fad44fad7f38cc96383b031fa",
                 "shasum": ""
             },
             "require": {
@@ -5128,10 +5128,10 @@
                 "vcs"
             ],
             "support": {
-                "source": "https://github.com/utopia-php/vcs/tree/5.2.0",
+                "source": "https://github.com/utopia-php/vcs/tree/5.2.1",
                 "issues": "https://github.com/utopia-php/vcs/issues"
             },
-            "time": "2026-08-19T10:17:14+00:00"
+            "time": "2026-08-19T12:49:54+00:00"
         },
         {
             "name": "utopia-php/websocket",

--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -7,6 +7,7 @@ use Appwrite\Extend\Exception;
 use OpenRuntimes\Orchestrator\Enum\CallbackEvent;
 use OpenRuntimes\Orchestrator\Enum\ReadFormat;
 use OpenRuntimes\Orchestrator\Jobs;
+use OpenRuntimes\Orchestrator\Model\Artifact\CloneArtifact;
 use OpenRuntimes\Orchestrator\Model\Artifact\DownloadArtifact;
 use OpenRuntimes\Orchestrator\Model\Artifact\ReadArtifact;
 use OpenRuntimes\Orchestrator\Model\Artifact\StatArtifact;
@@ -21,6 +22,7 @@ use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
 use Utopia\Database\Query;
 use Utopia\System\System;
+use Utopia\VCS\Adapter\Git;
 
 /**
  * Owns a deployment's lifecycle: upload bookkeeping, creating it and
@@ -131,6 +133,41 @@ readonly class Deployments
         array $headers = [],
     ): Document {
         return $this->submit($resource, $deployment, ['url' => $url, 'subdir' => $rootDirectory, 'headers' => $headers]);
+    }
+
+    /**
+     * Same as createFromUpload(), but builds from a repository on a VCS
+     * provider: a presigned archive URL when the provider hands those out, or
+     * a git clone through the jobs-service's clone artifact when the provider
+     * serves content over the git protocol only (Origin).
+     *
+     * @param string $ref Branch, tag, or commit the deployment builds from
+     */
+    public function createFromVcs(
+        Document $resource,
+        Document $deployment,
+        Git $vcs,
+        string $owner,
+        string $repository,
+        string $ref,
+        string $rootDirectory = '',
+    ): Document {
+        if ($vcs->supportsRepositoryArchives()) {
+            return $this->createFromUrl(
+                $resource,
+                $deployment,
+                $vcs->getRepositoryPresignedUrl($owner, $repository, $ref),
+                $rootDirectory,
+                $vcs->getRepositoryPresignedUrlHeaders(),
+            );
+        }
+
+        return $this->submit($resource, $deployment, [
+            'clone' => $vcs->getRepositoryCloneUrl($owner, $repository),
+            'ref' => $ref,
+            'subdir' => $rootDirectory,
+            'headers' => $vcs->getRepositoryCloneHeaders(),
+        ]);
     }
 
     private function submit(Document $resource, Document $deployment, ?array $source): Document
@@ -317,15 +354,25 @@ readonly class Deployments
         $protocol = System::getEnv('_APP_OPTIONS_FORCE_HTTPS') === 'disabled' ? 'http' : 'https';
         $endpoint = System::getEnv('_APP_JOBS_ENDPOINT', "$protocol://{$platform['apiHostname']}");
 
-        // Source artifacts, both ending in /mnt/code/source:
-        //  - remote tarball ($source): templates (public codeload URL) and VCS
-        //    (a short-lived presigned URL). Git-forge archives wrap the tree in
-        //    a "{repo}-{ref}/" root the caller can't predict, so strip drops it
-        //    and subdir then extracts just the rootDirectory from the unwrapped
-        //    tree. Uploaded tarballs (the else branch) are flat — no strip.
+        // Source artifacts, all ending in /mnt/code/source:
+        //  - remote tarball ($source with url): templates (public codeload URL)
+        //    and VCS (a short-lived presigned URL). Git-forge archives wrap the
+        //    tree in a "{repo}-{ref}/" root the caller can't predict, so strip
+        //    drops it and subdir then extracts just the rootDirectory from the
+        //    unwrapped tree. Uploaded tarballs (the else branch) are flat — no
+        //    strip.
+        //  - git clone ($source with clone): a provider without archive
+        //    downloads; the sidecar clones over Git HTTPS and checks the tree
+        //    out directly, so there is no archive to unarchive — or to stat,
+        //    which is why this path reports no sourceSize.
         //  - otherwise: the deployment's uploaded tarball, fetched from Appwrite
         //    over a presigned GET (manual upload / duplicate).
-        if ($source !== null) {
+        if (isset($source['clone'])) {
+            $subdir = \trim($source['subdir'] ?? '', '/');
+            $sourceArtifacts = [
+                new CloneArtifact(id: 'source', in: $source['clone'], out: 'source', ref: $source['ref'] ?? '', subdir: $subdir, headers: $source['headers'] ?? []),
+            ];
+        } elseif ($source !== null) {
             $subdir = \trim($source['subdir'] ?? '', '/');
             $sourceArtifacts = [
                 new DownloadArtifact(id: 'source', in: $source['url'], out: 'source.tar.gz', headers: $source['headers'] ?? []),

--- a/src/Appwrite/Deployment/GitAction.php
+++ b/src/Appwrite/Deployment/GitAction.php
@@ -86,7 +86,7 @@ final class GitAction
             ]);
             $previewUrl = $isSite && !$rule->isEmpty() ? "{$protocol}://" . $rule->getAttribute('domain', '') : '';
 
-            $comment = new Comment($platform);
+            $comment = new Comment($platform, $vcs->supportsCommentImages());
             $comment->parseComment($vcs->getComment($owner, $repositoryName, $commentId));
             $comment->addBuild($project, $resource, $isSite ? 'site' : 'function', $status, $deployment->getId(), ['type' => 'logs'], $previewUrl);
             $vcs->updateComment($owner, $repositoryName, $commentId, $comment->generateComment());

--- a/src/Appwrite/Platform/Modules/Compute/Base.php
+++ b/src/Appwrite/Platform/Modules/Compute/Base.php
@@ -175,12 +175,14 @@ class Base extends Action
         // git write and then hands the build to the jobs-service itself.
         if ($template->isEmpty()) {
             $ref = $deployment->getAttribute('providerCommitHash') ?: $deployment->getAttribute('providerBranch');
-            $deployment = $deployments->createFromUrl(
+            $deployment = $deployments->createFromVcs(
                 $function,
                 $deployment,
-                $vcs->getRepositoryPresignedUrl($owner, $repositoryName, $ref),
+                $vcs,
+                $owner,
+                $repositoryName,
+                $ref,
                 $function->getAttribute('providerRootDirectory', ''),
-                $vcs->getRepositoryPresignedUrlHeaders(),
             );
         } else {
             $deployment = $dbForProject->createDocument('deployments', new Document([
@@ -400,12 +402,14 @@ class Base extends Action
         // pushes go through the Builds worker (same split as redeployVcsFunction).
         if ($template->isEmpty()) {
             $ref = $deployment->getAttribute('providerCommitHash') ?: $deployment->getAttribute('providerBranch');
-            $deployment = $deployments->createFromUrl(
+            $deployment = $deployments->createFromVcs(
                 $site,
                 $deployment,
-                $vcs->getRepositoryPresignedUrl($owner, $repositoryName, $ref),
+                $vcs,
+                $owner,
+                $repositoryName,
+                $ref,
                 $site->getAttribute('providerRootDirectory', ''),
-                $vcs->getRepositoryPresignedUrlHeaders(),
             );
         } else {
             $publisherForBuilds->enqueue(new BuildMessage(

--- a/src/Appwrite/Platform/Modules/Console/Http/Variables/Get.php
+++ b/src/Appwrite/Platform/Modules/Console/Http/Variables/Get.php
@@ -7,6 +7,7 @@ use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Appwrite\Vcs\Factory as VcsFactory;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Domains\Domain;
@@ -47,6 +48,7 @@ class Get extends Action
                 contentType: ContentType::JSON
             ))
             ->inject('vcsProviders')
+            ->inject('vcsFactory')
             ->inject('response')
             ->inject('platform')
             ->inject('dbForProject')
@@ -55,6 +57,7 @@ class Get extends Action
 
     public function action(
         callable $vcsProviders,
+        VcsFactory $vcsFactory,
         Response $response,
         array $platform,
         Database $dbForProject
@@ -71,7 +74,20 @@ class Get extends Action
 
         $isDomainEnabled = $isAAAAValid || $isAValid || $isCNAMEValid;
 
-        $isVcsEnabled = !empty($vcsProviders());
+        $providers = $vcsProviders();
+        $isVcsEnabled = !empty($providers);
+
+        $providersWithRepositoryCreation = [];
+        $providersWithPublicRepositories = [];
+        foreach ($providers as $provider) {
+            $adapter = $vcsFactory->fromProvider($provider);
+            if ($adapter->supportsRepositoryCreation()) {
+                $providersWithRepositoryCreation[] = $provider;
+            }
+            if ($adapter->supportsPublicRepositories()) {
+                $providersWithPublicRepositories[] = $provider;
+            }
+        }
 
         $isAssistantEnabled = !empty(System::getEnv('_APP_ASSISTANT_OPENAI_API_KEY', ''));
 
@@ -87,7 +103,9 @@ class Get extends Action
             '_APP_COMPUTE_SIZE_LIMIT' => +System::getEnv('_APP_COMPUTE_SIZE_LIMIT'),
             '_APP_USAGE_STATS' => System::getEnv('_APP_USAGE_STATS'),
             '_APP_VCS_ENABLED' => $isVcsEnabled,
-            '_APP_VCS_PROVIDERS' => $vcsProviders(),
+            '_APP_VCS_PROVIDERS' => $providers,
+            '_APP_VCS_PROVIDERS_WITH_REPOSITORY_CREATION' => $providersWithRepositoryCreation,
+            '_APP_VCS_PROVIDERS_WITH_PUBLIC_REPOSITORIES' => $providersWithPublicRepositories,
             '_APP_DOMAIN_ENABLED' => $isDomainEnabled,
             '_APP_ASSISTANT_ENABLED' => $isAssistantEnabled,
             '_APP_DOMAIN_SITES' => $platform['sitesDomain'],

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
@@ -157,12 +157,14 @@ class Create extends Action
             $github = $vcsFactory->fromInstallation($installation);
 
             $ref = $deployment->getAttribute('providerCommitHash') ?: $deployment->getAttribute('providerBranch');
-            $deployment = $deployments->createFromUrl(
+            $deployment = $deployments->createFromVcs(
                 $function,
                 $deployment,
-                $github->getRepositoryPresignedUrl($owner, $repository, $ref),
+                $github,
+                $owner,
+                $repository,
+                $ref,
                 $deployment->getAttribute('providerRootDirectory', ''),
-                $github->getRepositoryPresignedUrlHeaders(),
             );
         } else {
             // Public template repo: providerBranch holds the resolved ref,

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -401,12 +401,14 @@ class Builds extends Action
             // jobs-service like any other VCS commit, via the same Deployments
             // service the HTTP endpoints use.
             $ref = $deployment->getAttribute('providerCommitHash') ?: $branchName;
-            $deployments->createFromUrl(
+            $deployments->createFromVcs(
                 $resource,
                 $deployment,
-                $providerAdapter->getRepositoryPresignedUrl($cloneOwner, $cloneRepository, $ref),
+                $providerAdapter,
+                $cloneOwner,
+                $cloneRepository,
+                $ref,
                 $resource->getAttribute('providerRootDirectory', ''),
-                $providerAdapter->getRepositoryPresignedUrlHeaders(),
             );
 
             Console::execute('rm -rf ' . \escapeshellarg('/tmp/builds/' . $deploymentId), '', $stdout, $stderr);

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
@@ -182,12 +182,14 @@ class Create extends Action
             $vcs = $vcsFactory->fromInstallation($installation);
 
             $ref = $deployment->getAttribute('providerCommitHash') ?: $deployment->getAttribute('providerBranch');
-            $deployment = $deployments->createFromUrl(
+            $deployment = $deployments->createFromVcs(
                 $site,
                 $deployment,
-                $vcs->getRepositoryPresignedUrl($owner, $repository, $ref),
+                $vcs,
+                $owner,
+                $repository,
+                $ref,
                 $deployment->getAttribute('providerRootDirectory', ''),
-                $vcs->getRepositoryPresignedUrlHeaders(),
             );
         } else {
             // Public template repo: providerBranch holds the resolved ref,

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -395,12 +395,14 @@ trait Deployment
                 // The Deployments service is built per repository: a webhook fans out to
                 // many tenant projects, each with its own database.
                 $deployment = $authorization->skip(fn () => $deploymentsFactory($dbForProject, $project)
-                    ->createFromUrl(
+                    ->createFromVcs(
                         $resource,
                         $deployment,
-                        $vcs->getRepositoryPresignedUrl($providerRepositoryOwner, $providerRepositoryName, $providerCommitHash),
+                        $vcs,
+                        $providerRepositoryOwner,
+                        $providerRepositoryName,
+                        $providerCommitHash,
                         $resource->getAttribute('providerRootDirectory', ''),
-                        $vcs->getRepositoryPresignedUrlHeaders(),
                     ));
 
                 if ($resource->getCollection() === 'sites') {

--- a/src/Appwrite/Platform/Modules/VCS/Http/Installations/Repositories/Create.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/Installations/Repositories/Create.php
@@ -112,6 +112,11 @@ class Create extends Action
         } else {
             $providerInstallationId = $installation->getAttribute('providerInstallationId');
             $vcs = $vcsFactory->fromInstallation($installation);
+
+            if (!$vcs->supportsRepositoryCreation()) {
+                throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'VCS provider does not support repository creation: ' . $provider);
+            }
+
             $owner = !empty($providerNamespace) ? $providerNamespace : $vcs->getOwnerName($providerInstallationId);
 
             try {

--- a/src/Appwrite/Utopia/Response/Model/ConsoleVariables.php
+++ b/src/Appwrite/Utopia/Response/Model/ConsoleVariables.php
@@ -71,6 +71,20 @@ class ConsoleVariables extends Model
                 'example' => ['github'],
                 'array' => true,
             ])
+            ->addRule('_APP_VCS_PROVIDERS_WITH_REPOSITORY_CREATION', [
+                'type' => self::TYPE_STRING,
+                'description' => 'List of configured VCS providers that support repository creation.',
+                'default' => [],
+                'example' => ['github'],
+                'array' => true,
+            ])
+            ->addRule('_APP_VCS_PROVIDERS_WITH_PUBLIC_REPOSITORIES', [
+                'type' => self::TYPE_STRING,
+                'description' => 'List of configured VCS providers that can host public repositories.',
+                'default' => [],
+                'example' => ['github'],
+                'array' => true,
+            ])
             ->addRule('_APP_DOMAIN_ENABLED', [
                 'type' => self::TYPE_BOOLEAN,
                 'description' => 'Defines if main domain is configured. If so, custom domains can be created.',

--- a/src/Appwrite/Vcs/Comment.php
+++ b/src/Appwrite/Vcs/Comment.php
@@ -10,7 +10,8 @@ use Utopia\System\System;
 class Comment
 {
     public function __construct(
-        private array $platform
+        private array $platform,
+        private bool $withImages = true,
     ) {
     }
 
@@ -173,7 +174,9 @@ class Comment
                     $qrImagePathDark = '/images/vcs/qr-dark.svg';
 
                     $consoleUrl = $protocol . '://' . $hostname . '/v1/avatars/qr?text=' . \urlencode($site['previewUrl']);
-                    $qr = '[' . $this->generatImage($qrImagePathLight, $qrImagePathDark, 'QR Code', 28) . '](' . $consoleUrl . ')';
+                    $qr = $this->withImages
+                        ? '[' . $this->generatImage($qrImagePathLight, $qrImagePathDark, 'QR Code', 28) . '](' . $consoleUrl . ')'
+                        : '[QR Code](' . $consoleUrl . ')';
 
                     $preview = '[Preview URL](' . $site['previewUrl'] . ')';
 
@@ -248,6 +251,11 @@ class Comment
 
     public function generatImage(string $pathLight, string $pathDark, string $alt, int $width): string
     {
+        // Providers without comment image support get the textual cells only.
+        if (!$this->withImages) {
+            return '';
+        }
+
         $protocol = System::getEnv('_APP_OPTIONS_FORCE_HTTPS') === 'disabled' ? 'http' : 'https';
         $hostname = $this->platform['consoleHostname'] ?? '';
 


### PR DESCRIPTION
## What does this PR do?

Groundwork extracted from the Origin (Cursor) VCS integration branch so it can be reviewed on its own. Bumps `utopia-php/vcs` and makes Appwrite consult the adapter capability API instead of assuming every provider behaves like GitHub:

- **`Deployments::createFromVcs()`** — one place that owns where a VCS deployment's source comes from. Providers with archive downloads (all current ones) keep handing the build sidecar a presigned tarball URL, exactly as before. A provider without them (the upcoming Origin, which serves content over Git HTTPS only) is cloned by the sidecar itself, through the orchestrator's new `clone` artifact — credentials ride an `Authorization` header from the adapter's clone surface, never the URL. Every call site (webhook trait, redeploy, function/site duplication, builds worker) collapses to a single `createFromVcs()` call.
- **Text-only PR comments** — `Comment` asks `supportsCommentImages()` and drops the SVG status icons and QR image for providers that refuse hosted images, keeping the textual cells and links.
- **Console capability reporting** — `GET /v1/console/variables` gains `_APP_VCS_PROVIDERS_WITH_REPOSITORY_CREATION` and `_APP_VCS_PROVIDERS_WITH_PUBLIC_REPOSITORIES`, lists shaped like the existing `_APP_VCS_PROVIDERS`, so the console can hide flows a provider cannot serve.
- **Repository-creation guard** — the create-repository endpoint checks `supportsRepositoryCreation()` first and answers with a clear client error instead of an uncaught provider exception.

On current providers (GitHub, Gitea, GitLab, Bitbucket) every capability reports `true` and the presigned-URL path is byte-for-byte the old behavior; the clone path stays dormant until the Origin provider lands.

## Dependencies

All released and adopted by this PR:

- [open-runtimes/orchestrator v1.3.0](https://github.com/open-runtimes/orchestrator/releases/tag/v1.3.0) — the `clone` artifact (open-runtimes/orchestrator#70); a deployment-time requirement for the jobs-service, not a composer dependency
- [open-runtimes/sdk-for-php 0.11.1](https://github.com/open-runtimes/sdk-for-php/releases/tag/0.11.1) — `CloneArtifact` model (open-runtimes/sdk-for-php#12)
- [utopia-php/vcs 5.2.1](https://github.com/utopia-php/vcs/releases/tag/5.2.1) — `getRepositoryCloneUrl()` / `getRepositoryCloneHeaders()` (utopia-php/vcs#135)

## Test Plan

- `vendor/bin/pint --test` and PHPStan (level 4) pass on all changed files against the tagged releases.
- Existing VCS and console E2E suites cover the unchanged presigned-URL paths.
- The clone artifact itself is covered by unit tests in the orchestrator (branch, tag, commit-hash, subdir, auth-header, destination-merge, and symlink-confinement cases).

## Related PRs and Issues

- Origin (Cursor) VCS provider support: `feat-cursor-codebase-vcs-support` (depends on this PR)
- utopia-php/vcs#133, utopia-php/vcs#134

🤖 Generated with [Claude Code](https://claude.com/claude-code)