### PR TITLE
fix: emit Project.wafEnabled for SDK 27 migration client

### DIFF
--- a/src/Appwrite/Utopia/Response/Model/Project.php
+++ b/src/Appwrite/Utopia/Response/Model/Project.php
@@ -199,6 +199,12 @@ class Project extends Model
                 'default' => '',
                 'example' => self::TYPE_DATETIME_EXAMPLE,
             ])
+            ->addRule('wafEnabled', [
+                'type' => self::TYPE_BOOLEAN,
+                'description' => 'Whether WAF enforcement is enabled for the project.',
+                'default' => false,
+                'example' => false,
+            ])
         ;
     }
 
@@ -234,6 +240,7 @@ class Project extends Model
         $this->expandProtocols($document);
         $this->expandAuthMethods($document);
         $this->expandConsoleAccessedAt($document);
+        $document->setAttribute('wafEnabled', (bool) $document->getAttribute('wafEnabled', false));
 
         return $document;
     }


### PR DESCRIPTION
## Problem

`Tests / E2E / PostgreSQL (dedicated) / Migrations` is failing on `main`, and has been for several runs, with eight cases reporting:

```
{"code":500,"message":"Missing required field \"wafEnabled\" for Appwrite\\Models\\Project.","resourceName":"auth-methods",…}
```

`appwrite/appwrite` 27.1.0 declares the field as required and non-nullable:

```php
// vendor/appwrite/appwrite/src/Appwrite/Models/Project.php:89
public bool $wafEnabled,
```

The migration source adapter reads the source project through that SDK, so a project response without `wafEnabled` cannot be deserialised. The server's `Project` response model never emitted it.

## Fix

Declare the rule and coerce the attribute so the field is always present in the response.

## Why this isn't visible on main's own CI

Pushes to `main` run a reduced workflow — the three most recent runs had 1, 2 and 8 jobs, and **no `Migrations` job among them**. The full E2E matrix only runs on pull requests, so `main` can be broken here without anything going red.

## Attribution

This is not my change. It is cherry-picked from `2f152910c9` by @jakeb994 on `feat-query-lib`, where it is currently stranded behind #11649 — a large `utopia-php/database` query-lib migration that is itself `CONFLICTING` and unlikely to land soon.

Opening it standalone so the fix reaches `main` on its own. Close this in favour of #11649 if you would rather it went that way.

## Validation

- focused Pint and PHPStan pass
- confirmed against the pinned SDK that the field is required there (`Models/Project.php:89`) and absent from the server model on `main`
