### PR TITLE
fix(specs): keep open enums open in the generated spec

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -74,37 +74,6 @@ class OpenAPI3 extends Format
         return [$example];
     }
 
-    /**
-     * Whether a union of validators also accepts arbitrary strings.
-     *
-     * A param declared as `AnyOf([WhiteList(...), Text(...)])` is open at
-     * runtime: the whitelist names the values callers usually want, and the
-     * text branch keeps anything else valid. An enum on such a param
-     * therefore documents the known values instead of closing the set, and
-     * generators need to know the difference so they do not reject a name the
-     * endpoint would have accepted.
-     *
-     * @param  array<int, Validator>  $validators
-     */
-    private function acceptsAnyString(array $validators): bool
-    {
-        foreach ($validators as $validator) {
-            while ($validator instanceof ArrayList || $validator instanceof Nullable) {
-                $validator = $validator->getValidator();
-            }
-
-            if ($validator instanceof WhiteList) {
-                continue;
-            }
-
-            if ($validator->getType() === Validator::TYPE_STRING) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     private function normalizeObjectExample(mixed $example): object
     {
         if (\is_object($example)) {
@@ -570,7 +539,17 @@ class OpenAPI3 extends Format
                     $validators = $param['validator']->getValidators();
                     $validator = $validators[0];
                     $class = \get_class($validator);
-                    $openEnum = $this->acceptsAnyString($validators);
+
+                    foreach ($validators as $unionValidator) {
+                        while ($unionValidator instanceof ArrayList || $unionValidator instanceof Nullable) {
+                            $unionValidator = $unionValidator->getValidator();
+                        }
+
+                        if (!$unionValidator instanceof WhiteList && $unionValidator->getType() === Validator::TYPE_STRING) {
+                            $openEnum = true;
+                            break;
+                        }
+                    }
                 }
 
                 $array = false;

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -23,6 +23,7 @@ use Utopia\Validator;
 use Utopia\Validator\ArrayList;
 use Utopia\Validator\Nullable;
 use Utopia\Validator\Range;
+use Utopia\Validator\WhiteList;
 
 class OpenAPI3 extends Format
 {
@@ -71,6 +72,37 @@ class OpenAPI3 extends Format
         }
 
         return [$example];
+    }
+
+    /**
+     * Whether a union of validators also accepts arbitrary strings.
+     *
+     * A param declared as `AnyOf([WhiteList(...), Text(...)])` is open at
+     * runtime: the whitelist names the values callers usually want, and the
+     * text branch keeps anything else valid. An enum on such a param
+     * therefore documents the known values instead of closing the set, and
+     * generators need to know the difference so they do not reject a name the
+     * endpoint would have accepted.
+     *
+     * @param  array<int, Validator>  $validators
+     */
+    private function acceptsAnyString(array $validators): bool
+    {
+        foreach ($validators as $validator) {
+            while ($validator instanceof ArrayList || $validator instanceof Nullable) {
+                $validator = $validator->getValidator();
+            }
+
+            if ($validator instanceof WhiteList) {
+                continue;
+            }
+
+            if ($validator->getType() === Validator::TYPE_STRING) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function normalizeObjectExample(mixed $example): object
@@ -533,9 +565,12 @@ class OpenAPI3 extends Format
                     $class = Queries::class;
                 }
 
+                $openEnum = false;
                 if ($class === \Utopia\Validator\AnyOf::class) {
-                    $validator = $param['validator']->getValidators()[0];
+                    $validators = $param['validator']->getValidators();
+                    $validator = $validators[0];
                     $class = \get_class($validator);
+                    $openEnum = $this->acceptsAnyString($validators);
                 }
 
                 $array = false;
@@ -754,6 +789,15 @@ class OpenAPI3 extends Format
                                         $node['schema']['items']['x-enum-name'] = $enum->name;
                                     }
                                     $node['schema']['items']['x-enum-keys'] = $enumKeys;
+
+                                    if ($openEnum) {
+                                        $node['schema']['items'] = [
+                                            'anyOf' => [
+                                                $node['schema']['items'],
+                                                ['type' => Validator::TYPE_STRING],
+                                            ],
+                                        ];
+                                    }
                                 }
                             }
                             if ($validator->getType() === 'integer') {
@@ -791,6 +835,26 @@ class OpenAPI3 extends Format
                                         $node['schema']['x-enum-name'] = $enum->name;
                                     }
                                     $node['schema']['x-enum-keys'] = $enumKeys;
+
+                                    if ($openEnum) {
+                                        $enumBranch = ['type' => $node['schema']['type'], 'enum' => $enumValues];
+                                        if (!empty($enum->name)) {
+                                            $enumBranch['x-enum-name'] = $enum->name;
+                                        }
+                                        $enumBranch['x-enum-keys'] = $enumKeys;
+
+                                        unset(
+                                            $node['schema']['type'],
+                                            $node['schema']['enum'],
+                                            $node['schema']['x-enum-name'],
+                                            $node['schema']['x-enum-keys'],
+                                        );
+
+                                        $node['schema']['anyOf'] = [
+                                            $enumBranch,
+                                            ['type' => Validator::TYPE_STRING],
+                                        ];
+                                    }
                                 }
                             }
                             if ($validator->getType() === 'integer') {
@@ -935,6 +999,13 @@ class OpenAPI3 extends Format
 
                         if (isset($node['schema']['format'])) {
                             $body['content'][$consumes[0]]['schema']['properties'][$name]['format'] = $node['schema']['format'];
+                        }
+
+                        if (isset($node['schema']['anyOf'])) {
+                            // Open enum: the known values and the free-form branch
+                            // both live under anyOf, so copy the union wholesale.
+                            $body['content'][$consumes[0]]['schema']['properties'][$name]['anyOf'] = $node['schema']['anyOf'];
+                            unset($body['content'][$consumes[0]]['schema']['properties'][$name]['type']);
                         }
 
                         if (isset($node['schema']['enum'])) {

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -47,6 +47,8 @@ use Utopia\Database\Validator\Query\Offset;
 use Utopia\Database\Validator\Spatial;
 use Utopia\DI\Container;
 use Utopia\Http\Route;
+use Utopia\Platform\Enum;
+use Utopia\Validator\AnyOf;
 use Utopia\Validator\ArrayList;
 use Utopia\Validator\Assoc;
 use Utopia\Validator\Boolean as BooleanValidator;
@@ -54,6 +56,7 @@ use Utopia\Validator\JSON;
 use Utopia\Validator\Nullable;
 use Utopia\Validator\Range;
 use Utopia\Validator\Text;
+use Utopia\Validator\WhiteList;
 
 class TestFormat extends Format
 {
@@ -122,6 +125,68 @@ final class FormatTest extends TestCase
     public function testExistingResponseEnumMetadataRemainsUnchanged(): void
     {
         $this->assertSame('HealthCheckStatus', (new HealthStatus())->getRules()['status']['enumSDKName']);
+    }
+
+    private function parseEnumParamSchema(\Utopia\Validator $validator): array
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route('GET', '/v1/tests'))
+            ->desc('List tests')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'listTests',
+                description: 'List tests.',
+                auth: [],
+                responses: [],
+            ))
+            ->param('metrics', [], $validator, 'Metric names.', false, enum: new Enum(name: 'TestMetric'));
+
+        $spec = (new OpenAPI3(new Container(), [], [$route], [], [], 0, 'console'))->parse();
+
+        return $spec['paths']['/tests']['get']['parameters'][0]['schema'];
+    }
+
+    public function testUnionWithAFreeStringBranchEmitsAnyOf(): void
+    {
+        $schema = $this->parseEnumParamSchema(new AnyOf([
+            new ArrayList(new WhiteList(['alpha', 'beta'], true), 10),
+            new ArrayList(new Text(255), 10),
+        ]));
+
+        // Standard OpenAPI: the known values are one branch of a union whose
+        // other branch is any string, mirroring the AnyOf validator exactly.
+        $this->assertCount(2, $schema['items']['anyOf']);
+        $this->assertSame(
+            ['type' => 'string', 'enum' => ['alpha', 'beta'], 'x-enum-name' => 'TestMetric', 'x-enum-keys' => ['alpha', 'beta']],
+            $schema['items']['anyOf'][0],
+        );
+        $this->assertSame(['type' => 'string'], $schema['items']['anyOf'][1]);
+        $this->assertArrayNotHasKey('enum', $schema['items']);
+    }
+
+    public function testWhitelistOnlyParamEmitsAPlainEnum(): void
+    {
+        $schema = $this->parseEnumParamSchema(
+            new ArrayList(new WhiteList(['alpha', 'beta'], true), 10)
+        );
+
+        $this->assertSame(['alpha', 'beta'], $schema['items']['enum']);
+        $this->assertSame('TestMetric', $schema['items']['x-enum-name']);
+        $this->assertArrayNotHasKey('anyOf', $schema['items']);
+    }
+
+    public function testUnionOfClosedBranchesEmitsAPlainEnum(): void
+    {
+        $schema = $this->parseEnumParamSchema(new AnyOf([
+            new ArrayList(new WhiteList(['alpha', 'beta'], true), 10),
+            new ArrayList(new WhiteList(['gamma'], true), 10),
+        ]));
+
+        $this->assertSame(['alpha', 'beta'], $schema['items']['enum']);
+        $this->assertArrayNotHasKey('anyOf', $schema['items']);
     }
 
     public function testOpenApiCustomIdBodyFieldIncludesIdGeneratorMetadata(): void

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -127,7 +127,7 @@ final class FormatTest extends TestCase
         $this->assertSame('HealthCheckStatus', (new HealthStatus())->getRules()['status']['enumSDKName']);
     }
 
-    private function parseEnumParamSchema(\Utopia\Validator $validator): array
+    public function testUnionWithAFreeStringBranchEmitsAnyOf(): void
     {
         Method::$processed = [];
         Method::$errors = [];
@@ -142,48 +142,19 @@ final class FormatTest extends TestCase
                 auth: [],
                 responses: [],
             ))
-            ->param('metrics', [], $validator, 'Metric names.', false, enum: new Enum(name: 'TestMetric'));
+            ->param('metrics', [], new AnyOf([
+                new ArrayList(new WhiteList(['alpha', 'beta'], true), 10),
+                new ArrayList(new Text(255), 10),
+            ]), 'Metric names.', false, enum: new Enum(name: 'TestMetric'));
 
         $spec = (new OpenAPI3(new Container(), [], [$route], [], [], 0, 'console'))->parse();
 
-        return $spec['paths']['/tests']['get']['parameters'][0]['schema'];
-    }
-
-    public function testUnionWithAFreeStringBranchEmitsAnyOf(): void
-    {
-        $schema = $this->parseEnumParamSchema(new AnyOf([
-            new ArrayList(new WhiteList(['alpha', 'beta'], true), 10),
-            new ArrayList(new Text(255), 10),
-        ]));
-
-        // Standard OpenAPI: the known values are one branch of a union whose
-        // other branch is any string, mirroring the AnyOf validator exactly.
-        $this->assertCount(2, $schema['items']['anyOf']);
-        $this->assertSame(
-            ['type' => 'string', 'enum' => ['alpha', 'beta'], 'x-enum-name' => 'TestMetric', 'x-enum-keys' => ['alpha', 'beta']],
-            $schema['items']['anyOf'][0],
-        );
-        $this->assertSame(['type' => 'string'], $schema['items']['anyOf'][1]);
-        $this->assertArrayNotHasKey('enum', $schema['items']);
-    }
-
-    public function testClosedEnumsRemainPlain(): void
-    {
-        $schema = $this->parseEnumParamSchema(
-            new ArrayList(new WhiteList(['alpha', 'beta'], true), 10)
-        );
-
-        $this->assertSame(['alpha', 'beta'], $schema['items']['enum']);
-        $this->assertSame('TestMetric', $schema['items']['x-enum-name']);
-        $this->assertArrayNotHasKey('anyOf', $schema['items']);
-
-        $schema = $this->parseEnumParamSchema(new AnyOf([
-            new ArrayList(new WhiteList(['alpha', 'beta'], true), 10),
-            new ArrayList(new WhiteList(['gamma'], true), 10),
-        ]));
-
-        $this->assertSame(['alpha', 'beta'], $schema['items']['enum']);
-        $this->assertArrayNotHasKey('anyOf', $schema['items']);
+        $this->assertSame([
+            'anyOf' => [
+                ['type' => 'string', 'enum' => ['alpha', 'beta'], 'x-enum-name' => 'TestMetric', 'x-enum-keys' => ['alpha', 'beta']],
+                ['type' => 'string'],
+            ],
+        ], $spec['paths']['/tests']['get']['parameters'][0]['schema']['items']);
     }
 
     public function testOpenApiCustomIdBodyFieldIncludesIdGeneratorMetadata(): void

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -167,7 +167,7 @@ final class FormatTest extends TestCase
         $this->assertArrayNotHasKey('enum', $schema['items']);
     }
 
-    public function testWhitelistOnlyParamEmitsAPlainEnum(): void
+    public function testClosedEnumsRemainPlain(): void
     {
         $schema = $this->parseEnumParamSchema(
             new ArrayList(new WhiteList(['alpha', 'beta'], true), 10)
@@ -176,10 +176,7 @@ final class FormatTest extends TestCase
         $this->assertSame(['alpha', 'beta'], $schema['items']['enum']);
         $this->assertSame('TestMetric', $schema['items']['x-enum-name']);
         $this->assertArrayNotHasKey('anyOf', $schema['items']);
-    }
 
-    public function testUnionOfClosedBranchesEmitsAPlainEnum(): void
-    {
         $schema = $this->parseEnumParamSchema(new AnyOf([
             new ArrayList(new WhiteList(['alpha', 'beta'], true), 10),
             new ArrayList(new WhiteList(['gamma'], true), 10),


### PR DESCRIPTION
## What

A parameter declared as `AnyOf([WhiteList(...), Text(...)])` accepts any string at runtime. The whitelist names the values callers usually want; the text branch keeps everything else valid. `OpenAPI3` resolved such a union by taking the first branch and discarding the rest:

```php
if ($class === \Utopia\Validator\AnyOf::class) {
    $validator = $param['validator']->getValidators()[0];
    $class = \get_class($validator);
}
```

The text branch never reached the spec. Combined with an `enum:` declaration, the spec then advertises a closed set for a parameter that is deliberately open, and generated SDKs reject values the endpoint would have accepted.

This surfaced in the Cloud usage events endpoint, whose `metrics` param is `AnyOf([ArrayList(WhiteList(known)), ArrayList(Text(255))])` with `enum: new Enum(name: 'UsageEventMetric')`. The generated TypeScript enum is nominal, so a caller holding a metric name as a plain string cannot pass it — even a name the server accepts. Consumers work around it with a local module augmentation that re-widens the parameter. The cast silences the checker without validating anything.

## How

Emit the union the way OpenAPI already expresses it:

```json
"schema": {
  "type": "array",
  "items": {
    "anyOf": [
      {
        "type": "string",
        "enum": ["network.requests", "network.inbound"],
        "x-enum-name": "UsageEventMetric",
        "x-enum-keys": ["NetworkRequests", "NetworkInbound"]
      },
      { "type": "string" }
    ]
  }
}
```

This is plain OpenAPI 3.0 — no new vendor extension. The enum branch carries the same `x-enum-name` / `x-enum-keys` it does today, so a generator that already reads those keeps working on the branch, and the second branch tells it the parameter is open. For TypeScript that means a type like `Enum | (string & {})`, which accepts any string while keeping the known values in completions.

Both the array-item and scalar paths are covered, and body parameters carry the union across.

Openness is derived from the validator rather than declared separately on `Utopia\Platform\Enum`. A second declaration could contradict the validator, and that drift is exactly what produced the wrong spec here.

## Compatibility

No committed spec changes. The union is only emitted when an open union *also* declares an enum, and no parameter in this repository does both — there are three `AnyOf` parameters and none of them declares `enum:`. Their existing first-branch behaviour is untouched; generalising that is a separate discussion.

`anyOf` currently appears only in *response* schemas (polymorphic models via `$ref`), never in a parameter schema. `appwrite/sdk-generator` therefore needs to handle `anyOf` in parameter position before any SDK is regenerated against a spec that uses it.

## Test plan

- `testUnionWithAFreeStringBranchEmitsAnyOf` — asserts the complete array-item schema, including the enum metadata and free-string branch

Verified failing before the change and passing after. `FormatTest` is green at 25 tests / 125 assertions, `composer lint` passes repo-wide, and PHPStan reports no errors on the changed file.

## Follow-up (not in this PR)

`Gauges/XList.php` has the opposite bug: `aggregate` is a strict `WhiteList(['last', 'max'])` with no `enum:` at all, so it degrades to bare `string`. That file is not on `main`, so the fix belongs with the usage branch.



