### PR TITLE
test(specs): parse the generated document with a real OpenAPI parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -150,7 +150,8 @@
         "czproject/git-php": "4.*",
         "laravel/pint": "1.*",
         "rector/rector": "^2.4",
-        "shipmonk/dead-code-detector": "^0.13"
+        "shipmonk/dead-code-detector": "^0.13",
+        "utopia-php/openapi": "0.1.*"
     },
     "provide": {
         "ext-phpiredis": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4fd078c5f4c652e6b07c639e275b520c",
+    "content-hash": "b027d7fb901fc35cc5410d8df498b27a",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -8443,16 +8443,16 @@
         },
         {
             "name": "utopia-php/openapi",
-            "version": "0.1.0",
+            "version": "0.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/openapi.git",
-                "reference": "5962baf44f339ae0919ec751bcbf1a96828f0038"
+                "reference": "cb7367ee701dbfdc74b64c6906c55c5d37ba6392"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/5962baf44f339ae0919ec751bcbf1a96828f0038",
-                "reference": "5962baf44f339ae0919ec751bcbf1a96828f0038",
+                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/cb7367ee701dbfdc74b64c6906c55c5d37ba6392",
+                "reference": "cb7367ee701dbfdc74b64c6906c55c5d37ba6392",
                 "shasum": ""
             },
             "require": {
@@ -8477,9 +8477,9 @@
             "description": "Framework-independent OpenAPI 2.0, 3.0, and 3.1 parser with an immutable canonical model",
             "support": {
                 "issues": "https://github.com/utopia-php/openapi/issues",
-                "source": "https://github.com/utopia-php/openapi/tree/0.1.0"
+                "source": "https://github.com/utopia-php/openapi/tree/0.1.1"
             },
-            "time": "2026-08-14T07:11:54+00:00"
+            "time": "2026-08-19T07:16:25+00:00"
         }
     ],
     "aliases": [],

--- a/tests/unit/SDK/Specification/OpenAPI3ValidityTest.php
+++ b/tests/unit/SDK/Specification/OpenAPI3ValidityTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\Unit\SDK\Specification;
+
+use Appwrite\SDK\Method;
+use Appwrite\SDK\Response as SDKResponse;
+use Appwrite\SDK\Specification\Format\OpenAPI3;
+use Appwrite\Utopia\Response;
+use Appwrite\Utopia\Response\Model\Preferences;
+use Appwrite\Utopia\Response\Model\Team;
+use PHPUnit\Framework\TestCase;
+use Utopia\DI\Container;
+use Utopia\Http\Route;
+use Utopia\OpenAPI\Model\ArraySchema;
+use Utopia\OpenAPI\Model\ObjectSchema;
+use Utopia\OpenAPI\Parser;
+use Utopia\OpenAPI\Version;
+use Utopia\Platform\Enum;
+use Utopia\Validator\ArrayList;
+use Utopia\Validator\Boolean as BooleanValidator;
+use Utopia\Validator\Integer as IntegerValidator;
+use Utopia\Validator\Nullable;
+use Utopia\Validator\Text;
+use Utopia\Validator\WhiteList;
+
+/**
+ * The generated specs are build artifacts, so nothing checks them until an SDK
+ * is generated and something downstream breaks. Parse the formatter's output
+ * with a real OpenAPI parser instead, so a formatter change that produces an
+ * invalid document fails here rather than in a consumer.
+ */
+class OpenAPI3ValidityTest extends TestCase
+{
+    /**
+     * @param  array<string, mixed>  $spec
+     */
+    private function parseSpec(array $spec): \Utopia\OpenAPI\Specification
+    {
+        return Parser::parse($spec, Version::V3_0);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildSpec(): array
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $list = (new Route('GET', '/v1/tests'))
+            ->desc('List tests')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'listTests',
+                description: 'List tests.',
+                auth: [],
+                responses: [new SDKResponse(code: Response::STATUS_CODE_OK, model: Response::MODEL_TEAM)],
+            ))
+            ->param('search', '', new Text(256), 'Search term.', true)
+            ->param('limit', 25, new IntegerValidator(), 'Result limit.', true)
+            ->param('verbose', false, new BooleanValidator(), 'Verbose output.', true)
+            ->param('cursor', null, new Nullable(new Text(256)), 'Cursor.', true)
+            ->param('order', 'asc', new WhiteList(['asc', 'desc']), 'Sort order.', true, enum: new Enum(name: 'TestOrder'))
+            ->param('fields', [], new ArrayList(new WhiteList(['id', 'name'], true), 10), 'Fields.', true, enum: new Enum(name: 'TestField'));
+
+        $create = (new Route('POST', '/v1/tests'))
+            ->desc('Create test')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'createTest',
+                description: 'Create test.',
+                auth: [],
+                responses: [new SDKResponse(code: Response::STATUS_CODE_CREATED, model: Response::MODEL_TEAM)],
+            ))
+            ->param('name', '', new Text(128), 'Name.')
+            ->param('kind', 'basic', new WhiteList(['basic', 'advanced']), 'Kind.', true, enum: new Enum(name: 'TestKind'));
+
+        $models = [new Team(), new Preferences()];
+
+        return (new OpenAPI3(new Container(), [], [$list, $create], $models, [], 0, 'console'))->parse();
+    }
+
+    public function testGeneratedDocumentParsesAsOpenApi30(): void
+    {
+        $spec = $this->parseSpec($this->buildSpec());
+
+        $this->assertSame(Version::V3_0, $spec->version);
+        $this->assertArrayHasKey('/tests', $spec->paths);
+        $this->assertArrayHasKey('get', $spec->paths['/tests']->operations);
+        $this->assertArrayHasKey('post', $spec->paths['/tests']->operations);
+    }
+
+    public function testEnumParametersSurviveThroughTheParser(): void
+    {
+        $spec = $this->parseSpec($this->buildSpec());
+        $operation = $spec->paths['/tests']->operations['get'];
+
+        $byName = [];
+        foreach ($operation->parameters as $parameter) {
+            $byName[$parameter->name] = $parameter;
+        }
+
+        $this->assertSame(['asc', 'desc'], $byName['order']->schema->enum);
+        $this->assertSame('TestOrder', $byName['order']->schema->extensions['x-enum-name']);
+
+        $fields = $byName['fields']->schema;
+        $this->assertInstanceOf(ArraySchema::class, $fields);
+        $this->assertSame(['id', 'name'], $fields->items->enum);
+        $this->assertSame('TestField', $fields->items->extensions['x-enum-name']);
+    }
+
+    public function testAppwriteExtensionsSurviveThroughTheParser(): void
+    {
+        $spec = $this->parseSpec($this->buildSpec());
+        $operation = $spec->paths['/tests']->operations['get'];
+
+        // Codegen depends on these, so a formatter change that drops them
+        // should fail here and not three repositories downstream.
+        $this->assertArrayHasKey('x-appwrite', $operation->extensions);
+        $this->assertArrayHasKey('rate-limit', $operation->extensions['x-appwrite']);
+        $this->assertArrayHasKey('scope', $operation->extensions['x-appwrite']);
+        $this->assertSame('testListTests', $operation->id);
+    }
+
+    public function testResponseModelsBecomeComponentSchemas(): void
+    {
+        $spec = $this->parseSpec($this->buildSpec());
+
+        $this->assertArrayHasKey('team', $spec->schemas);
+        $this->assertInstanceOf(ObjectSchema::class, $spec->schemas['team']);
+        $this->assertArrayHasKey('$id', $spec->schemas['team']->properties);
+    }
+}


### PR DESCRIPTION
## What

`app/config/specs/` is gitignored — the specs are build artifacts. So nothing in CI checks whether the formatter emits a valid OpenAPI document; the first signal is an SDK being generated and something downstream misbehaving.

`utopia-php/openapi` is already in the tree as a transitive dependency of `appwrite/sdk-generator`, and it is a parser with an immutable canonical model. This points it at the formatter's own output and lets it decide whether the document is valid.

## How

The test builds a spec covering the shapes that carry codegen weight — scalar, nullable, array and enum parameters, plus a response model that becomes a component schema — then parses it with `Parser::parse($spec, Version::V3_0)` and asserts the parts codegen relies on survive:

- the document parses as 3.0 and both operations are present
- scalar and array enum parameters keep their values and their `x-enum-name`
- the `x-appwrite` block survives, including `rate-limit` and `scope`
- the operation id survives
- the response model lands in `components/schemas` as an object schema with its properties

A formatter change that produces an invalid document, or that quietly drops metadata codegen depends on, now fails here rather than three repositories away.

`utopia-php/openapi` moves into `require-dev` because the tests import it directly; relying on it transitively would break the moment the generator's own dependencies change. The lockfile update that comes with declaring it also picks up `0.1.0 -> 0.1.1`, a patch release inside the existing `0.1.*` constraint.

## Test plan

- `tests/unit/SDK/Specification/OpenAPI3ValidityTest.php` — 4 tests, 16 assertions, all passing
- the whole `tests/unit/SDK/Specification/` directory is green at 28 tests / 140 assertions
- `composer validate` passes, `composer lint` (Pint) passes repo-wide, PHPStan reports no errors on the new file
- verified against `utopia-php/openapi` 0.1.1 as installed from the updated lockfile, not just the previously vendored 0.1.0

## Context

First step of moving spec handling onto the shared canonical model. It changes no behaviour and no generated output, so it stands alone — but it also becomes the gate for later work, in particular emitting OpenAPI 3.1 and replacing the `x-enum-name` / `x-enum-keys` extensions with `components` refs and `oneOf`/`const`/`title`.
