### PR TITLE
fix: mark successful function and site deployments as active

### DIFF
--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -83,10 +83,10 @@ readonly class Deployments
     /**
      * Finalizes the deployment document (see upload() for what `$deployment`
      * should carry) and dispatches it for building from its own uploaded
-     * source. Marks it queued, writes its buildPath and deactivates any other
-     * active deployment for $resource. A deployment canceled before it is
-     * queued is left canceled and never dispatched. Returns the persisted,
-     * updated deployment.
+     * source. Marks it queued and writes its buildPath. A deployment canceled
+     * before it is queued is left canceled and never dispatched. Returns the
+     * persisted, updated deployment. Activation of a successful build is
+     * decided later by the Jobs worker (see shouldGoLive()).
      */
     public function createFromUpload(Document $resource, Document $deployment): Document
     {
@@ -189,25 +189,9 @@ readonly class Deployments
 
         $deployment = $this->dbForProject->getDocument('deployments', $deployment->getId());
 
-        // Canceled before it could be queued: leave it canceled, submit nothing,
-        // and leave the currently active deployment alone.
-        if ($queued === 0) {
+        // Canceled before it could be queued: leave it canceled, submit nothing.
+        if ($queued === 0 || $deployment->getAttribute('status') === 'canceled') {
             return $deployment;
-        }
-
-        // Claiming activation takes it away from the other pending deployments,
-        // so a cancel landing while we do it would leave nothing able to go
-        // live. Hand the claim back to exactly the deployments it was taken
-        // from, and stop before submitting a job for a canceled deployment.
-        $deactivated = $this->deactivateOthers($resource, $deployment);
-        if ($deactivated !== [] && $this->status($deployment->getId()) === 'canceled') {
-            foreach ($deactivated as $other) {
-                $this->dbForProject->updateDocument('deployments', $other, new Document([
-                    'activate' => true,
-                ]));
-            }
-
-            return $this->dbForProject->getDocument('deployments', $deployment->getId());
         }
 
         try {
@@ -241,39 +225,27 @@ readonly class Deployments
     }
 
     /**
-     * Deactivates any other active deployment for $resource before this one
-     * goes live, called once the deployment is queued for building.
+     * Whether a finished deployment should become the resource's live
+     * deployment. $current is the document currently pointed at by the
+     * resource's deploymentId, or empty if nothing is live yet.
      *
-     * @return array<string> The ids it deactivated, so the caller can hand the
-     *                       claim back if this deployment never gets to build.
+     * Overlapping builds keep their own `activate` request: an older success
+     * still goes live if nothing newer already has, and a newer success
+     * replaces an older live one. Clearing `activate` on other deployments at
+     * submit time is racy — concurrent submits steal the flag from each other
+     * and a later failure leaves a successful build with nobody live.
      */
-    protected function deactivateOthers(Document $resource, Document $deployment): array
+    public static function shouldGoLive(Document $candidate, Document $current): bool
     {
-        if (!$deployment->getAttribute('activate', false)) {
-            return [];
+        if (!\filter_var($candidate->getAttribute('activate', false), FILTER_VALIDATE_BOOLEAN)) {
+            return false;
         }
 
-        $others = $this->dbForProject->find('deployments', [
-            Query::equal('activate', [true]),
-            Query::equal('resourceId', [$resource->getId()]),
-            Query::equal('resourceType', [$resource->getCollection()]),
-            Query::notEqual('$id', $deployment->getId()),
-        ]);
-
-        $deactivated = [];
-        foreach ($others as $other) {
-            $this->dbForProject->updateDocument('deployments', $other->getId(), new Document([
-                'activate' => false,
-            ]));
-            $deactivated[] = $other->getId();
+        if ($current->isEmpty() || $current->getId() === $candidate->getId()) {
+            return true;
         }
 
-        return $deactivated;
-    }
-
-    private function status(string $deploymentId): string
-    {
-        return $this->dbForProject->getDocument('deployments', $deploymentId)->getAttribute('status', '');
+        return $current->getCreatedAt() < $candidate->getCreatedAt();
     }
 
     /**

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
@@ -141,8 +141,7 @@ class Create extends Action
             'buildSize' => null,
             'buildPath' => '',
             'buildLogs' => '',
-            // Not inherited: a redeploy always goes live, and the source's own
-            // flag is unset by deactivateOthers() once anything newer builds.
+            // Not inherited: a redeploy always goes live when its build succeeds.
             'activate' => true,
         ]);
 

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -3,6 +3,7 @@
 namespace Appwrite\Platform\Modules\Functions\Workers;
 
 use Appwrite\Bus\Events\RuleUpdated;
+use Appwrite\Deployment\Deployments;
 use Appwrite\Deployment\Detection;
 use Appwrite\Deployment\GitAction;
 use Appwrite\Event\Event;
@@ -38,8 +39,9 @@ use Utopia\System\System;
  * processing for a deployment is serialized under a per-deployment lock — that
  * keeps its buildLogs a clean, monotonic append while letting different
  * deployments build in parallel. Callbacks are at-least-once, so events are
- * de-duplicated on the CloudEvent id (inside the lock, so dedup + apply is
- * atomic and a lock timeout retries cleanly).
+ * de-duplicated on the CloudEvent id (inside the lock). The dedupe key is
+ * written after a successful apply so a callback that reached 'ready' then
+ * failed while activating is retried instead of being dropped.
  *
  * Handlers are protected extension points: downstream workers (e.g. cloud)
  * override finalize() and wrap parent:: — before it for work that must
@@ -115,11 +117,13 @@ class Jobs extends Action
                 if ($cache->load($key, self::DEDUPE_TTL) !== false) {
                     return; // already processed
                 }
-                $cache->save($key, true);
             }
 
             $deployment = $dbForProject->getDocument('deployments', $deploymentId);
             if ($deployment->isEmpty() || $deployment->getAttribute('status') === 'canceled') {
+                if ($event->id !== '') {
+                    $cache->save('jobs-event-' . $event->id, true);
+                }
                 return;
             }
 
@@ -150,6 +154,13 @@ class Jobs extends Action
             // (success), so key off the status change rather than the event.
             if ($statusBefore !== $deployment->getAttribute('status') && \in_array($deployment->getAttribute('status'), ['ready', 'failed'], true)) {
                 $this->dispatchUpdate($queueForEvents, $queueForWebhooks, $publisherForFunctions, $project, $deployment);
+            }
+
+            // Mark processed only after apply succeeds. Saving first dropped
+            // retries of a callback that wrote 'ready' then failed while
+            // pointing the resource at the deployment.
+            if ($event->id !== '') {
+                $cache->save('jobs-event-' . $event->id, true);
             }
         }, self::LOCK_TIMEOUT);
     }
@@ -311,8 +322,23 @@ class Jobs extends Action
         array $plan,
         Bus $bus,
     ): Document {
-        if (\in_array($deployment->getAttribute('status'), ['ready', 'failed'], true)) {
+        if ($deployment->getAttribute('status') === 'failed') {
             return $deployment; // already finalized
+        }
+
+        // A previous callback may have written 'ready' then failed before
+        // pointing the resource at this deployment. Later events (or a retry)
+        // still try to activate, then refresh the cron schedule so it sees
+        // the new deploymentId.
+        if ($deployment->getAttribute('status') === 'ready') {
+            $collection = $deployment->getAttribute('resourceType', 'functions');
+            $resource = $dbForProject->getDocument($collection, $deployment->getAttribute('resourceId'));
+            if (! $resource->isEmpty()) {
+                $this->activate($dbForProject, $dbForPlatform, $project, $resource, $deployment, $bus);
+                $this->schedule($dbForProject, $dbForPlatform, $resource);
+            }
+
+            return $deployment;
         }
 
         $deploymentId = $deployment->getId();
@@ -434,7 +460,7 @@ class Jobs extends Action
         ]);
         $deployment = $dbForProject->getDocument('deployments', $deployment->getId());
 
-        if ($applied > 0 && $success && $deployment->getAttribute('activate') === true && ! $resource->isEmpty()) {
+        if ($applied > 0 && $success && ! $resource->isEmpty()) {
             $this->activate($dbForProject, $dbForPlatform, $project, $resource, $deployment, $bus);
         }
 
@@ -529,11 +555,26 @@ class Jobs extends Action
     }
 
     /**
-     * Point the resource at this deployment (auto-activate). Mirrors the
-     * essential activation from the Builds worker.
+     * Point the resource at this deployment when it requested auto-activate
+     * and is newer than whatever is already live. Re-reads the resource so an
+     * older in-flight build cannot overwrite a newer one that finished first.
      */
     protected function activate(Database $dbForProject, Database $dbForPlatform, Document $project, Document $resource, Document $deployment, Bus $bus): void
     {
+        $resource = $dbForProject->getDocument($resource->getCollection(), $resource->getId());
+        if ($resource->isEmpty()) {
+            return;
+        }
+
+        $currentId = $resource->getAttribute('deploymentId', '');
+        $current = empty($currentId)
+            ? new Document()
+            : $dbForProject->getDocument('deployments', $currentId);
+
+        if (!Deployments::shouldGoLive($deployment, $current)) {
+            return;
+        }
+
         $resource = $dbForProject->updateDocument($resource->getCollection(), $resource->getId(), new Document([
             'live' => true,
             'deploymentId' => $deployment->getId(),

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
@@ -166,8 +166,7 @@ class Create extends Action
             'buildPath' => '',
             'buildLogs' => '',
             'type' => $request->getHeaderLine('x-sdk-language') === 'cli' ? 'cli' : 'manual',
-            // Not inherited: a redeploy always goes live, and the source's own
-            // flag is unset by deactivateOthers() once anything newer builds.
+            // Not inherited: a redeploy always goes live when its build succeeds.
             'activate' => true,
         ]);
 

--- a/tests/unit/Deployment/DeploymentsTest.php
+++ b/tests/unit/Deployment/DeploymentsTest.php
@@ -126,4 +126,78 @@ final class DeploymentsTest extends TestCase
 
         $this->assertSame(['users.read'], Deployments::scopes($site));
     }
+
+    public function testShouldGoLiveRejectsWhenActivateIsFalse(): void
+    {
+        $candidate = new Document([
+            '$id' => 'new',
+            '$createdAt' => '2026-08-20T12:00:00.000+00:00',
+            'activate' => false,
+        ]);
+
+        $this->assertFalse(Deployments::shouldGoLive($candidate, new Document()));
+    }
+
+    public function testShouldGoLiveActivatesWhenNothingIsLive(): void
+    {
+        $candidate = new Document([
+            '$id' => 'new',
+            '$createdAt' => '2026-08-20T12:00:00.000+00:00',
+            'activate' => true,
+        ]);
+
+        $this->assertTrue(Deployments::shouldGoLive($candidate, new Document()));
+    }
+
+    public function testShouldGoLiveReplacesAnOlderLiveDeployment(): void
+    {
+        $candidate = new Document([
+            '$id' => 'new',
+            '$createdAt' => '2026-08-20T13:00:00.000+00:00',
+            'activate' => true,
+        ]);
+        $current = new Document([
+            '$id' => 'old',
+            '$createdAt' => '2026-08-20T12:00:00.000+00:00',
+        ]);
+
+        $this->assertTrue(Deployments::shouldGoLive($candidate, $current));
+    }
+
+    public function testShouldGoLiveSkipsWhenTheLiveDeploymentIsNewer(): void
+    {
+        $candidate = new Document([
+            '$id' => 'old',
+            '$createdAt' => '2026-08-20T12:00:00.000+00:00',
+            'activate' => true,
+        ]);
+        $current = new Document([
+            '$id' => 'new',
+            '$createdAt' => '2026-08-20T13:00:00.000+00:00',
+        ]);
+
+        $this->assertFalse(Deployments::shouldGoLive($candidate, $current));
+    }
+
+    public function testShouldGoLiveIsIdempotentForTheLiveDeployment(): void
+    {
+        $deployment = new Document([
+            '$id' => 'live',
+            '$createdAt' => '2026-08-20T12:00:00.000+00:00',
+            'activate' => true,
+        ]);
+
+        $this->assertTrue(Deployments::shouldGoLive($deployment, $deployment));
+    }
+
+    public function testShouldGoLiveTreatsIntegerOneAsRequested(): void
+    {
+        $candidate = new Document([
+            '$id' => 'new',
+            '$createdAt' => '2026-08-20T12:00:00.000+00:00',
+            'activate' => 1,
+        ]);
+
+        $this->assertTrue(Deployments::shouldGoLive($candidate, new Document()));
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Successful function and site deployments were sometimes never marked as the live deployment. It looked random because it was a race around the `activate` flag.

When a deployment was submitted with `activate: true`, `deactivateOthers()` cleared `activate` on every other deployment for that resource — including ones still building. Two overlapping submits could steal the flag from each other, so both finished `ready` and neither went live. A newer build that then failed left the older successful one with `activate: false` as well.

That flag-stealing was added when builds moved onto the jobs-service. The executor Builds worker never did it: it kept each deployment’s `activate` request and, on success, compared `$createdAt` against the resource’s current live deployment.

This restores that model:

- Stop clearing other deployments’ `activate` flags at submit time.
- When a build succeeds, go live if nothing is live yet, or if this deployment is newer than the current one.
- If a callback writes `ready` and then fails before pointing the resource at the deployment, a later callback or retry still tries to activate (dedupe is recorded after a successful apply).

## Test Plan

- Unit: `tests/unit/Deployment/DeploymentsTest.php` covers `shouldGoLive()` (activate false, nothing live, older vs newer live, idempotent same id, integer `1`).
- Existing Functions and Sites e2e still cover single-deployment activate true/false and switching the live deployment.
- Manual: deploy a function/site with `activate: true` while another build for the same resource is in flight (or fire two VCS pushes quickly). The successful build should become live; a later successful newer build should replace it; a failed newer build should not prevent an older success from going live.

## Related PRs and Issues

- Regression from centralizing `deactivateOthers()` on every jobs-service submit (after the executor Builds worker’s createdAt check was removed).

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30fe2154-8edc-410e-ae69-0b74bf765f79?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30fe2154-8edc-410e-ae69-0b74bf765f79&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

