### PR TITLE
feat: add POST createQuery for TablesDB, Databases, and DocumentsDB

### DIFF
--- a/docs/references/databases/create-query.md
+++ b/docs/references/databases/create-query.md
@@ -1,0 +1,1 @@
+Get a list of all the user's documents in a given collection using a POST request. This behaves identically to the list documents endpoint but accepts the queries in the request body, allowing much larger `queries` arrays than can fit in a URL query string.

--- a/docs/references/documentsdb/create-query.md
+++ b/docs/references/documentsdb/create-query.md
@@ -1,0 +1,1 @@
+Get a list of all the user's documents in a given collection using a POST request. This behaves identically to the list documents endpoint but accepts the queries in the request body, allowing much larger `queries` arrays than can fit in a URL query string.

--- a/docs/references/tablesdb/create-query.md
+++ b/docs/references/tablesdb/create-query.md
@@ -1,0 +1,1 @@
+Get a list of all the user's rows in a given table using a POST request. This behaves identically to the list rows endpoint but accepts the queries in the request body, allowing much larger `queries` arrays than can fit in a URL query string.

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Queries/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Queries/Create.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Appwrite\Platform\Modules\Databases\Http\Databases\Collections\Documents\Queries;
+
+use Appwrite\Platform\Modules\Databases\Http\Databases\Collections\Documents\XList;
+use Appwrite\SDK\AuthType;
+use Appwrite\SDK\ContentType;
+use Appwrite\SDK\Deprecated;
+use Appwrite\SDK\Method;
+use Appwrite\SDK\Response as SDKResponse;
+use Utopia\Database\Database;
+use Utopia\Database\Validator\UID;
+use Utopia\Http\Adapter\Swoole\Response as SwooleResponse;
+use Utopia\Validator\ArrayList;
+use Utopia\Validator\Boolean;
+use Utopia\Validator\Nullable;
+use Utopia\Validator\Range;
+use Utopia\Validator\Text;
+
+class Create extends XList
+{
+    public static function getName(): string
+    {
+        return 'createDocumentsQuery';
+    }
+
+    public function __construct()
+    {
+        $this
+            ->setHttpMethod(self::HTTP_REQUEST_METHOD_POST)
+            ->setHttpPath('/v1/databases/:databaseId/collections/:collectionId/documents/query')
+            ->desc('Create query')
+            ->groups(['api', 'database'])
+            ->label('scope', 'documents.read')
+            ->label('resourceType', RESOURCE_TYPE_DATABASES)
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}/documents')
+            ->label('sdk', new Method(
+                namespace: $this->getSDKNamespace(),
+                group: $this->getSDKGroup(),
+                name: 'createQuery',
+                description: '/docs/references/databases/create-query.md',
+                auth: [AuthType::ADMIN, AuthType::SESSION, AuthType::KEY, AuthType::JWT],
+                responses: [
+                    new SDKResponse(
+                        code: SwooleResponse::STATUS_CODE_OK,
+                        model: $this->getResponseModel(),
+                    )
+                ],
+                contentType: ContentType::JSON,
+                deprecated: new Deprecated(
+                    since: '1.8.0',
+                    replaceWith: 'tablesDB.createQuery',
+                ),
+            ))
+            ->param('databaseId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Database ID.', false, ['dbForProject'])
+            ->param('collectionId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Collection ID. You can create a new collection using the Database service [server integration](https://appwrite.io/docs/server/databases#databasesCreateCollection).', false, ['dbForProject'])
+            ->param('queries', [], new ArrayList(new Text(APP_LIMIT_ARRAY_ELEMENT_SIZE), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' queries are allowed, each ' . APP_LIMIT_ARRAY_ELEMENT_SIZE . ' characters long.', true)
+            ->param('transactionId', null, fn (Database $dbForProject) => new Nullable(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'Transaction ID to read uncommitted changes within the transaction.', true, ['dbForProject'])
+            ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
+            ->param('ttl', 0, new Range(min: 0, max: 86400), 'TTL (seconds) for caching list responses. Responses are stored in an in-memory key-value cache, keyed per project, collection, schema version (attributes and indexes), caller authorization roles, and the exact query — so users with different permissions never share cached entries. Schema changes invalidate cached entries automatically; document writes do not, so choose a TTL you are comfortable serving as stale data. Set to 0 to disable caching. Must be between 0 and 86400 (24 hours).', true)
+            ->inject('response')
+            ->inject('dbForProject')
+            ->inject('user')
+            ->inject('getDatabasesDB')
+            ->inject('usage')
+            ->inject('transactionState')
+            ->inject('authorization')
+            ->inject('utopia')
+            ->callback($this->action(...));
+    }
+}

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Queries/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Queries/Create.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Appwrite\Platform\Modules\Databases\Http\DocumentsDB\Collections\Documents\Queries;
+
+use Appwrite\Platform\Modules\Databases\Http\DocumentsDB\Collections\Documents\XList;
+use Appwrite\SDK\AuthType;
+use Appwrite\SDK\ContentType;
+use Appwrite\SDK\Method;
+use Appwrite\SDK\Response as SDKResponse;
+use Utopia\Database\Validator\UID;
+use Utopia\Http\Adapter\Swoole\Response as SwooleResponse;
+use Utopia\Validator\ArrayList;
+use Utopia\Validator\Boolean;
+use Utopia\Validator\Range;
+use Utopia\Validator\Text;
+
+class Create extends XList
+{
+    public static function getName(): string
+    {
+        return 'createDocumentsDBDocumentsQuery';
+    }
+
+    public function __construct()
+    {
+        $this
+            ->setHttpMethod(self::HTTP_REQUEST_METHOD_POST)
+            ->setHttpPath('/v1/documentsdb/:databaseId/collections/:collectionId/documents/query')
+            ->desc('Create query')
+            ->groups(['api', 'database'])
+            ->label('scope', 'documents.read')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('resourceType', RESOURCE_TYPE_DATABASES)
+            ->label('sdk', new Method(
+                namespace: 'documentsDB',
+                group: $this->getSdkGroup(),
+                name: 'createQuery',
+                description: '/docs/references/documentsdb/create-query.md',
+                auth: [AuthType::ADMIN, AuthType::SESSION, AuthType::KEY, AuthType::JWT],
+                responses: [
+                    new SDKResponse(
+                        code: SwooleResponse::STATUS_CODE_OK,
+                        model: $this->getResponseModel(),
+                    )
+                ],
+                contentType: ContentType::JSON
+            ))
+            ->param('databaseId', '', new UID(), 'Database ID.')
+            ->param('collectionId', '', new UID(), 'Collection ID. You can create a new collection using the Database service [server integration](https://appwrite.io/docs/server/databases#databasesCreateCollection).')
+            ->param('queries', [], new ArrayList(new Text(APP_LIMIT_ARRAY_ELEMENT_SIZE), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' queries are allowed, each ' . APP_LIMIT_ARRAY_ELEMENT_SIZE . ' characters long.', true)
+            ->param('transactionId', null, new UID(), 'Transaction ID to read uncommitted changes within the transaction.', true)
+            ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
+            ->param('ttl', 0, new Range(min: 0, max: 86400), 'TTL (seconds) for cached responses when caching is enabled for select queries. Must be between 0 and 86400 (24 hours).', true)
+            ->inject('response')
+            ->inject('dbForProject')
+            ->inject('user')
+            ->inject('getDatabasesDB')
+            ->inject('usage')
+            ->inject('transactionState')
+            ->inject('authorization')
+            ->inject('utopia')
+            ->callback($this->action(...));
+    }
+}

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Queries/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Queries/Create.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Appwrite\Platform\Modules\Databases\Http\TablesDB\Tables\Rows\Queries;
+
+use Appwrite\Platform\Modules\Databases\Http\TablesDB\Tables\Rows\XList;
+use Appwrite\SDK\AuthType;
+use Appwrite\SDK\ContentType;
+use Appwrite\SDK\Method;
+use Appwrite\SDK\Response as SDKResponse;
+use Utopia\Database\Database;
+use Utopia\Database\Validator\UID;
+use Utopia\Http\Adapter\Swoole\Response as SwooleResponse;
+use Utopia\Validator\ArrayList;
+use Utopia\Validator\Boolean;
+use Utopia\Validator\Nullable;
+use Utopia\Validator\Range;
+use Utopia\Validator\Text;
+
+class Create extends XList
+{
+    public static function getName(): string
+    {
+        return 'createRowsQuery';
+    }
+
+    public function __construct()
+    {
+        $this
+            ->setHttpMethod(self::HTTP_REQUEST_METHOD_POST)
+            ->setHttpPath('/v1/tablesdb/:databaseId/tables/:tableId/rows/query')
+            ->desc('Create query')
+            ->groups(['api', 'database'])
+            ->label('scope', ['rows.read', 'documents.read'])
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('resourceType', RESOURCE_TYPE_DATABASES)
+            ->label('sdk', new Method(
+                namespace: $this->getSDKNamespace(),
+                group: $this->getSDKGroup(),
+                name: 'createQuery',
+                description: '/docs/references/tablesdb/create-query.md',
+                auth: [AuthType::ADMIN, AuthType::SESSION, AuthType::KEY, AuthType::JWT],
+                responses: [
+                    new SDKResponse(
+                        code: SwooleResponse::STATUS_CODE_OK,
+                        model: $this->getResponseModel(),
+                    )
+                ],
+                contentType: ContentType::JSON
+            ))
+            ->param('databaseId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Database ID.', false, ['dbForProject'])
+            ->param('tableId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Table ID. You can create a new table using the TablesDB service [server integration](https://appwrite.io/docs/products/databases/tables#create-table).', false, ['dbForProject'])
+            ->param('queries', [], new ArrayList(new Text(APP_LIMIT_ARRAY_ELEMENT_SIZE), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' queries are allowed, each ' . APP_LIMIT_ARRAY_ELEMENT_SIZE . ' characters long.', true)
+            ->param('transactionId', null, fn (Database $dbForProject) => new Nullable(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'Transaction ID to read uncommitted changes within the transaction.', true, ['dbForProject'])
+            ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
+            ->param('ttl', 0, new Range(min: 0, max: 86400), 'TTL (seconds) for caching list responses. Responses are stored in an in-memory key-value cache, keyed per project, table, schema version (columns and indexes), caller authorization roles, and the exact query — so users with different permissions never share cached entries. Schema changes invalidate cached entries automatically; row writes do not, so choose a TTL you are comfortable serving as stale data. Set to 0 to disable caching. Must be between 0 and 86400 (24 hours).', true)
+            ->inject('response')
+            ->inject('dbForProject')
+            ->inject('user')
+            ->inject('getDatabasesDB')
+            ->inject('usage')
+            ->inject('transactionState')
+            ->inject('authorization')
+            ->inject('utopia')
+            ->callback($this->action(...));
+    }
+}

--- a/src/Appwrite/Platform/Modules/Databases/Services/Registry/DocumentsDB.php
+++ b/src/Appwrite/Platform/Modules/Databases/Services/Registry/DocumentsDB.php
@@ -12,6 +12,7 @@ use Appwrite\Platform\Modules\Databases\Http\DocumentsDB\Collections\Documents\B
 use Appwrite\Platform\Modules\Databases\Http\DocumentsDB\Collections\Documents\Create as CreateRow;
 use Appwrite\Platform\Modules\Databases\Http\DocumentsDB\Collections\Documents\Delete as DeleteRow;
 use Appwrite\Platform\Modules\Databases\Http\DocumentsDB\Collections\Documents\Get as GetRow;
+use Appwrite\Platform\Modules\Databases\Http\DocumentsDB\Collections\Documents\Queries\Create as CreateDocumentsQuery;
 use Appwrite\Platform\Modules\Databases\Http\DocumentsDB\Collections\Documents\Update as UpdateRow;
 use Appwrite\Platform\Modules\Databases\Http\DocumentsDB\Collections\Documents\Upsert as UpsertRow;
 use Appwrite\Platform\Modules\Databases\Http\DocumentsDB\Collections\Documents\XList as ListRows;
@@ -83,6 +84,7 @@ class DocumentsDB extends Base
         $service->addAction(DeleteRow::getName(), new DeleteRow());
         $service->addAction(DeleteRows::getName(), new DeleteRows());
         $service->addAction(ListRows::getName(), new ListRows());
+        $service->addAction(CreateDocumentsQuery::getName(), new CreateDocumentsQuery());
         $service->addAction(IncrementRowColumn::getName(), new IncrementRowColumn());
         $service->addAction(DecrementRowColumn::getName(), new DecrementRowColumn());
     }

--- a/src/Appwrite/Platform/Modules/Databases/Services/Registry/Legacy.php
+++ b/src/Appwrite/Platform/Modules/Databases/Services/Registry/Legacy.php
@@ -51,6 +51,7 @@ use Appwrite\Platform\Modules\Databases\Http\Databases\Collections\Documents\Bul
 use Appwrite\Platform\Modules\Databases\Http\Databases\Collections\Documents\Create as CreateDocument;
 use Appwrite\Platform\Modules\Databases\Http\Databases\Collections\Documents\Delete as DeleteDocument;
 use Appwrite\Platform\Modules\Databases\Http\Databases\Collections\Documents\Get as GetDocument;
+use Appwrite\Platform\Modules\Databases\Http\Databases\Collections\Documents\Queries\Create as CreateDocumentsQuery;
 use Appwrite\Platform\Modules\Databases\Http\Databases\Collections\Documents\Update as UpdateDocument;
 use Appwrite\Platform\Modules\Databases\Http\Databases\Collections\Documents\Upsert as UpsertDocument;
 use Appwrite\Platform\Modules\Databases\Http\Databases\Collections\Documents\XList as ListDocuments;
@@ -125,6 +126,7 @@ class Legacy extends Base
         $service->addAction(DeleteDocument::getName(), new DeleteDocument());
         $service->addAction(DeleteDocuments::getName(), new DeleteDocuments());
         $service->addAction(ListDocuments::getName(), new ListDocuments());
+        $service->addAction(CreateDocumentsQuery::getName(), new CreateDocumentsQuery());
         $service->addAction(IncrementDocumentAttribute::getName(), new IncrementDocumentAttribute());
         $service->addAction(DecrementDocumentAttribute::getName(), new DecrementDocumentAttribute());
 

--- a/src/Appwrite/Platform/Modules/Databases/Services/Registry/TablesDB.php
+++ b/src/Appwrite/Platform/Modules/Databases/Services/Registry/TablesDB.php
@@ -59,6 +59,7 @@ use Appwrite\Platform\Modules\Databases\Http\TablesDB\Tables\Rows\Column\Increme
 use Appwrite\Platform\Modules\Databases\Http\TablesDB\Tables\Rows\Create as CreateRow;
 use Appwrite\Platform\Modules\Databases\Http\TablesDB\Tables\Rows\Delete as DeleteRow;
 use Appwrite\Platform\Modules\Databases\Http\TablesDB\Tables\Rows\Get as GetRow;
+use Appwrite\Platform\Modules\Databases\Http\TablesDB\Tables\Rows\Queries\Create as CreateRowsQuery;
 use Appwrite\Platform\Modules\Databases\Http\TablesDB\Tables\Rows\Update as UpdateRow;
 use Appwrite\Platform\Modules\Databases\Http\TablesDB\Tables\Rows\Upsert as UpsertRow;
 use Appwrite\Platform\Modules\Databases\Http\TablesDB\Tables\Rows\XList as ListRows;
@@ -212,6 +213,7 @@ class TablesDB extends Base
         $service->addAction(DeleteRow::getName(), new DeleteRow());
         $service->addAction(DeleteRows::getName(), new DeleteRows());
         $service->addAction(ListRows::getName(), new ListRows());
+        $service->addAction(CreateRowsQuery::getName(), new CreateRowsQuery());
         $service->addAction(IncrementRowColumn::getName(), new IncrementRowColumn());
         $service->addAction(DecrementRowColumn::getName(), new DecrementRowColumn());
     }

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -3804,6 +3804,60 @@ trait DatabasesBase
         ], $this->getHeaders()));
     }
 
+    public function testCreateQuery(): void
+    {
+        $data = $this->setupDocuments();
+        $databaseId = $data['databaseId'];
+        $documentIds = $data['documentIds'];
+        $url = $this->getRecordUrl($databaseId, $data['moviesId']);
+        $headers = array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders());
+        $queries = [
+            Query::equal('$id', $documentIds)->toString(),
+            Query::limit(10)->toString(),
+        ];
+
+        $list = $this->client->call(Client::METHOD_GET, $url, $headers, [
+            'queries' => $queries,
+        ]);
+
+        $this->assertSame(200, $list['headers']['status-code']);
+
+        $created = $this->client->call(Client::METHOD_POST, $url . '/query', $headers, [
+            'queries' => $queries,
+        ]);
+
+        $this->assertSame(200, $created['headers']['status-code']);
+        $this->assertSame($list['body']['total'], $created['body']['total']);
+
+        $resource = $this->getRecordResource();
+        $this->assertSame(
+            array_column($list['body'][$resource], '$id'),
+            array_column($created['body'][$resource], '$id'),
+        );
+
+        $values = $documentIds;
+        for ($index = 0; $index < 80; $index++) {
+            $values[] = ID::unique();
+        }
+
+        $large = $this->client->call(Client::METHOD_POST, $url . '/query', $headers, [
+            'queries' => [
+                Query::equal('$id', $values)->toString(),
+                Query::limit(10)->toString(),
+            ],
+        ]);
+
+        $this->assertSame(200, $large['headers']['status-code']);
+        $this->assertSame($list['body']['total'], $large['body']['total']);
+        $this->assertSame(
+            array_column($list['body'][$resource], '$id'),
+            array_column($large['body'][$resource], '$id'),
+        );
+    }
+
     public function testListDocumentsWithCache(): void
     {
         if (!$this->getSupportForAttributes()) {


### PR DESCRIPTION
## Summary

Adds `POST .../query` (`createQuery`) for TablesDB, legacy Databases, and DocumentsDB so large `queries` arrays can be sent in the request body instead of the URL query string.

VectorsDB already has this endpoint (`POST /v1/vectorsdb/:databaseId/collections/:collectionId/documents/query`). GET list is capped by typical URL length (~4096). This stacks on `feat-query-lib` and reuses each API's existing GET list `action()` via subclassed `Create` actions.

### Endpoints

| API | Method | Path | Action name | SDK |
|---|---|---|---|---|
| Databases (legacy) | POST | `/v1/databases/:databaseId/collections/:collectionId/documents/query` | `createDocumentsQuery` | `databases.createQuery` (deprecated since 1.8.0, replace with `tablesDB.createQuery`) |
| TablesDB | POST | `/v1/tablesdb/:databaseId/tables/:tableId/rows/query` | `createRowsQuery` | `tablesDB.createQuery` |
| DocumentsDB | POST | `/v1/documentsdb/:databaseId/collections/:collectionId/documents/query` | `createDocumentsDBDocumentsQuery` | `documentsDB.createQuery` |

Each `Create` clones its parent `XList` constructor and only changes HTTP method, path, description, SDK method name (`createQuery`), and docs path. Inherited `action()` is unchanged.

## How verified

- Pint/PSR-12: `composer format` + `composer lint` on the changed PHP files
- `php -l` on the three new `Create.php` files
- Confirmed `feat-query-lib` was not modified (this branch is one commit on top)

## Not verified

- Full e2e matrix (Docker stack was not running locally)
- Spec/SDK generation
- PHPStan over the whole project

New e2e coverage is `Tests\E2E\Services\Databases\DatabasesBase::testCreateQuery` (shared by Legacy, TablesDB, and DocumentsDB via URL helpers): GET list vs POST `/query` for the same `Query::equal`/`limit`, plus a large in-list body query.

## Stacked PR

Targets **`feat-query-lib`** (https://github.com/appwrite/appwrite/pull/11649), not `main`. Do not merge `feat-query-lib` into this.