### PR TITLE
chore: autologin local Adminer at postgres.localhost

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -601,36 +601,7 @@ configs:
         }
       ]
   adminer-index.php:
-    content: |
-      <?php
-        $$postgres = explode(':', $$_SERVER['HTTP_HOST'] ?? '')[0] === 'postgres.localhost';
-        if ($$postgres && isset($$_GET['username']) && !isset($$_GET['ns'])) {
-          $$_GET['ns'] = $$_ENV['ADMINER_DEFAULT_DB'] ?: 'appwrite';
-          header('Location: ?' . http_build_query($$_GET));
-          exit;
-        }
-
-        function adminer_object() {
-          return new class extends Adminer\Adminer {
-            function loginForm() {
-              parent::loginForm();
-              if (isset($$_GET['username']) || !empty($$_POST['auth'])) {
-                return;
-              }
-              $$postgres = explode(':', $$_SERVER['HTTP_HOST'] ?? '')[0] === 'postgres.localhost';
-              $$auth = json_encode([
-                'server' => $$_ENV['ADMINER_DEFAULT_SERVER'],
-                'driver' => ($$postgres || $$_ENV['ADMINER_DEFAULT_DRIVER'] === 'postgresql') ? 'pgsql' : 'server',
-                'username' => $$_ENV['ADMINER_DEFAULT_USERNAME'],
-                'password' => $$_ENV['ADMINER_DEFAULT_PASSWORD'],
-                'db' => $$_ENV['ADMINER_DEFAULT_DB'],
-              ], JSON_THROW_ON_ERROR);
-              echo Adminer\script('document.addEventListener("DOMContentLoaded",()=>{const a=' . $$auth . ';const f=document.querySelector("#content form");if(!f||!f["auth[driver]"])return;f["auth[driver]"].value=a.driver;f["auth[server]"].value=a.server;f["auth[username]"].value=a.username;f["auth[password]"].value=a.password;f["auth[db]"].value=a.db;f.submit();});');
-            }
-          };
-        }
-
-        include './adminer.php';
+    file: ./tests/resources/docker/adminer/index.php
 networks:
   appwrite:
     ipam:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -603,7 +603,7 @@ configs:
   adminer-index.php:
     content: |
       <?php
-        $$postgres = str_contains($$_SERVER['HTTP_HOST'] ?? '', 'postgres.localhost');
+        $$postgres = explode(':', $$_SERVER['HTTP_HOST'] ?? '')[0] === 'postgres.localhost';
         if ($$postgres && isset($$_GET['username']) && !isset($$_GET['ns'])) {
           $$_GET['ns'] = $$_ENV['ADMINER_DEFAULT_DB'] ?: 'appwrite';
           header('Location: ?' . http_build_query($$_GET));
@@ -617,9 +617,9 @@ configs:
               if (isset($$_GET['username']) || !empty($$_POST['auth'])) {
                 return;
               }
-              $$postgres = str_contains($$_SERVER['HTTP_HOST'] ?? '', 'postgres.localhost');
+              $$postgres = explode(':', $$_SERVER['HTTP_HOST'] ?? '')[0] === 'postgres.localhost';
               $$auth = json_encode([
-                'server' => $$postgres ? 'postgresql' : $$_ENV['ADMINER_DEFAULT_SERVER'],
+                'server' => $$_ENV['ADMINER_DEFAULT_SERVER'],
                 'driver' => ($$postgres || $$_ENV['ADMINER_DEFAULT_DRIVER'] === 'postgresql') ? 'pgsql' : 'server',
                 'username' => $$_ENV['ADMINER_DEFAULT_USERNAME'],
                 'password' => $$_ENV['ADMINER_DEFAULT_PASSWORD'],

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -454,10 +454,10 @@ services:
       - traefik.docker.network=gateway
       - traefik.http.services.appwrite_adminer.loadbalancer.server.port=8080
       - traefik.http.routers.appwrite_adminer_http.entrypoints=appwrite_web
-      - traefik.http.routers.appwrite_adminer_http.rule=Host(`mysql.localhost`)
+      - traefik.http.routers.appwrite_adminer_http.rule=Host(`mysql.localhost`) || Host(`postgres.localhost`)
       - traefik.http.routers.appwrite_adminer_http.service=appwrite_adminer
       - traefik.http.routers.appwrite_adminer_https.entrypoints=appwrite_websecure
-      - traefik.http.routers.appwrite_adminer_https.rule=Host(`mysql.localhost`)
+      - traefik.http.routers.appwrite_adminer_https.rule=Host(`mysql.localhost`) || Host(`postgres.localhost`)
       - traefik.http.routers.appwrite_adminer_https.service=appwrite_adminer
       - traefik.http.routers.appwrite_adminer_https.tls=true
   redis-insight:
@@ -603,16 +603,33 @@ configs:
   adminer-index.php:
     content: |
       <?php
-        if(!count($$_GET)) {
-          $$_POST['auth'] = [
-            'server' => $$_ENV['ADMINER_DEFAULT_SERVER'],
-            /* Adminer calls the MySQL/MariaDB driver "server". */
-            'driver' => $$_ENV['ADMINER_DEFAULT_DRIVER'] === 'postgresql' ? 'pgsql' : 'server',
-            'username' => $$_ENV['ADMINER_DEFAULT_USERNAME'],
-            'password' => $$_ENV['ADMINER_DEFAULT_PASSWORD'],
-            'db' => $$_ENV['ADMINER_DEFAULT_DB'],
-          ];
+        $$postgres = str_contains($$_SERVER['HTTP_HOST'] ?? '', 'postgres.localhost');
+        if ($$postgres && isset($$_GET['username']) && !isset($$_GET['ns'])) {
+          $$_GET['ns'] = $$_ENV['ADMINER_DEFAULT_DB'] ?: 'appwrite';
+          header('Location: ?' . http_build_query($$_GET));
+          exit;
         }
+
+        function adminer_object() {
+          return new class extends Adminer\Adminer {
+            function loginForm() {
+              parent::loginForm();
+              if (isset($$_GET['username']) || !empty($$_POST['auth'])) {
+                return;
+              }
+              $$postgres = str_contains($$_SERVER['HTTP_HOST'] ?? '', 'postgres.localhost');
+              $$auth = json_encode([
+                'server' => $$postgres ? 'postgresql' : $$_ENV['ADMINER_DEFAULT_SERVER'],
+                'driver' => ($$postgres || $$_ENV['ADMINER_DEFAULT_DRIVER'] === 'postgresql') ? 'pgsql' : 'server',
+                'username' => $$_ENV['ADMINER_DEFAULT_USERNAME'],
+                'password' => $$_ENV['ADMINER_DEFAULT_PASSWORD'],
+                'db' => $$_ENV['ADMINER_DEFAULT_DB'],
+              ], JSON_THROW_ON_ERROR);
+              echo Adminer\script('document.addEventListener("DOMContentLoaded",()=>{const a=' . $$auth . ';const f=document.querySelector("#content form");if(!f||!f["auth[driver]"])return;f["auth[driver]"].value=a.driver;f["auth[server]"].value=a.server;f["auth[username]"].value=a.username;f["auth[password]"].value=a.password;f["auth[db]"].value=a.db;f.submit();});');
+            }
+          };
+        }
+
         include './adminer.php';
 networks:
   appwrite:

--- a/tests/resources/docker/adminer/index.php
+++ b/tests/resources/docker/adminer/index.php
@@ -1,15 +1,10 @@
 <?php
-// Dev-only Adminer entrypoint for docker-compose.override.yml.
-//
-// postgres.localhost targets the PostgreSQL container; every other host
-// (mysql.localhost) keeps the ADMINER_DEFAULT_* connection values.
 
 function onPostgresHost(): bool
 {
     return explode(':', $_SERVER['HTTP_HOST'] ?? '')[0] === 'postgres.localhost';
 }
 
-// Credentials the login form is prefilled with.
 function defaultAuth(): array
 {
     return [
@@ -21,24 +16,21 @@ function defaultAuth(): array
     ];
 }
 
-// Adminer opens the public schema unless ?ns= names another one,
-// so add it once right after login.
+// Adminer opens the public schema unless ?ns= names another one.
 if (onPostgresHost() && isset($_GET['username']) && !isset($_GET['ns'])) {
     $_GET['ns'] = $_ENV['ADMINER_DEFAULT_DB'] ?: 'appwrite';
     header('Location: ?' . http_build_query($_GET));
     exit;
 }
 
-// Adminer 6 ignores server-side POST autologin, so fill and submit
-// the login form in the browser instead.
+// Adminer 6 ignores server-side POST autologin.
 function adminer_object()
 {
     return new class extends Adminer\Adminer {
         function loginForm()
         {
             parent::loginForm();
-            // Skip while a login is in flight or just failed, otherwise
-            // wrong credentials would resubmit forever.
+            // A login is already in flight or just failed; resubmitting would loop forever.
             if (isset($_GET['username']) || !empty($_POST['auth'])) {
                 return;
             }

--- a/tests/resources/docker/adminer/index.php
+++ b/tests/resources/docker/adminer/index.php
@@ -1,0 +1,62 @@
+<?php
+// Dev-only Adminer entrypoint for docker-compose.override.yml.
+//
+// postgres.localhost targets the PostgreSQL container; every other host
+// (mysql.localhost) keeps the ADMINER_DEFAULT_* connection values.
+
+function onPostgresHost(): bool
+{
+    return explode(':', $_SERVER['HTTP_HOST'] ?? '')[0] === 'postgres.localhost';
+}
+
+// Credentials the login form is prefilled with.
+function defaultAuth(): array
+{
+    return [
+        'server' => $_ENV['ADMINER_DEFAULT_SERVER'],
+        'driver' => (onPostgresHost() || $_ENV['ADMINER_DEFAULT_DRIVER'] === 'postgresql') ? 'pgsql' : 'server',
+        'username' => $_ENV['ADMINER_DEFAULT_USERNAME'],
+        'password' => $_ENV['ADMINER_DEFAULT_PASSWORD'],
+        'db' => $_ENV['ADMINER_DEFAULT_DB'],
+    ];
+}
+
+// Adminer opens the public schema unless ?ns= names another one,
+// so add it once right after login.
+if (onPostgresHost() && isset($_GET['username']) && !isset($_GET['ns'])) {
+    $_GET['ns'] = $_ENV['ADMINER_DEFAULT_DB'] ?: 'appwrite';
+    header('Location: ?' . http_build_query($_GET));
+    exit;
+}
+
+// Adminer 6 ignores server-side POST autologin, so fill and submit
+// the login form in the browser instead.
+function adminer_object()
+{
+    return new class extends Adminer\Adminer {
+        function loginForm()
+        {
+            parent::loginForm();
+            // Skip while a login is in flight or just failed, otherwise
+            // wrong credentials would resubmit forever.
+            if (isset($_GET['username']) || !empty($_POST['auth'])) {
+                return;
+            }
+            $auth = json_encode(defaultAuth(), JSON_THROW_ON_ERROR);
+            echo Adminer\script(
+                'document.addEventListener("DOMContentLoaded",()=>{'
+                . 'const a=' . $auth . ';'
+                . 'const f=document.querySelector("#content form");'
+                . 'if(!f||!f["auth[driver]"])return;'
+                . 'f["auth[driver]"].value=a.driver;'
+                . 'f["auth[server]"].value=a.server;'
+                . 'f["auth[username]"].value=a.username;'
+                . 'f["auth[password]"].value=a.password;'
+                . 'f["auth[db]"].value=a.db;'
+                . 'f.submit();});'
+            );
+        }
+    };
+}
+
+include './adminer.php';

--- a/tests/resources/docker/adminer/index.php
+++ b/tests/resources/docker/adminer/index.php
@@ -26,8 +26,8 @@ if (onPostgresHost() && isset($_GET['username']) && !isset($_GET['ns'])) {
 // Adminer 6 ignores server-side POST autologin.
 function adminer_object()
 {
-    return new class extends Adminer\Adminer {
-        function loginForm()
+    return new class () extends Adminer\Adminer {
+        public function loginForm()
         {
             parent::loginForm();
             // A login is already in flight or just failed; resubmitting would loop forever.


### PR DESCRIPTION
## Summary

- Adds `http://postgres.localhost:9520/` as a Traefik host for the local Adminer container.
- Autologin uses the local Postgres credentials and opens database `appwrite` / schema `appwrite` (not `public`).
- Adminer 6 dropped the old `$_POST['auth']` autologin, so the form is filled and submitted instead.

`mysql.localhost` still works and keeps env-based defaults.

## Test plan

- [x] Recreate `adminer` and open `http://postgres.localhost:9520/`
- [x] Lands logged in on schema `appwrite` (tables like `_1_buckets`, not `public.spatial_ref_sys`)
- [ ] `mysql.localhost` still loads Adminer