### PR TITLE
chore: remove redundant discriminator property names

### DIFF
--- a/src/Appwrite/SDK/Specification/Format.php
+++ b/src/Appwrite/SDK/Specification/Format.php
@@ -422,7 +422,6 @@ abstract class Format
         return \array_filter([
             'propertyName' => $primaryKey,
             'mapping' => !empty($primaryMapping) ? $primaryMapping : null,
-            'x-propertyNames' => $allKeys,
             'x-mapping' => $compoundMapping,
         ]);
     }

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -20,7 +20,10 @@ use Appwrite\Utopia\Response\Model\AlgoScrypt;
 use Appwrite\Utopia\Response\Model\AlgoScryptModified;
 use Appwrite\Utopia\Response\Model\AlgoSha;
 use Appwrite\Utopia\Response\Model as ResponseModel;
+use Appwrite\Utopia\Response\Model\AttributeEmail;
+use Appwrite\Utopia\Response\Model\AttributeEnum;
 use Appwrite\Utopia\Response\Model\AttributeLine;
+use Appwrite\Utopia\Response\Model\AttributeString;
 use Appwrite\Utopia\Response\Model\Error as ErrorModel;
 use Appwrite\Utopia\Response\Model\ErrorDev;
 use Appwrite\Utopia\Response\Model\HealthStatus;
@@ -1009,6 +1012,38 @@ final class FormatTest extends TestCase
 
         $this->assertTrue($openApiOptions['additionalProperties']);
         $this->assertArrayNotHasKey('nullable', $openApiOptions);
+    }
+
+    public function testCompoundDiscriminatorDoesNotEmitRedundantPropertyNames(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $email = new AttributeEmail();
+        $enum = new AttributeEnum();
+        $string = new AttributeString();
+        $route = (new Route('GET', '/v1/tests/attribute'))
+            ->desc('Get test attribute')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'getTestAttribute',
+                description: 'Get test attribute.',
+                auth: [],
+                responses: [
+                    new SDKResponse(
+                        code: 200,
+                        model: [$email->getType(), $enum->getType(), $string->getType()],
+                    ),
+                ],
+            ));
+
+        $openApi = (new OpenAPI3(new Container(), [], [$route], [$email, $enum, $string], [], 0, 'console'))->parse();
+        $discriminator = $openApi['paths']['/tests/attribute']['get']['responses']['200']
+            ['content']['application/json']['schema']['discriminator'];
+
+        $this->assertArrayHasKey('x-mapping', $discriminator);
+        $this->assertArrayNotHasKey('x-propertyNames', $discriminator);
     }
 
     public function testQueriesSubclassesEmitArrayOfStrings(): void

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -20,10 +20,7 @@ use Appwrite\Utopia\Response\Model\AlgoScrypt;
 use Appwrite\Utopia\Response\Model\AlgoScryptModified;
 use Appwrite\Utopia\Response\Model\AlgoSha;
 use Appwrite\Utopia\Response\Model as ResponseModel;
-use Appwrite\Utopia\Response\Model\AttributeEmail;
-use Appwrite\Utopia\Response\Model\AttributeEnum;
 use Appwrite\Utopia\Response\Model\AttributeLine;
-use Appwrite\Utopia\Response\Model\AttributeString;
 use Appwrite\Utopia\Response\Model\Error as ErrorModel;
 use Appwrite\Utopia\Response\Model\ErrorDev;
 use Appwrite\Utopia\Response\Model\HealthStatus;
@@ -1012,38 +1009,6 @@ final class FormatTest extends TestCase
 
         $this->assertTrue($openApiOptions['additionalProperties']);
         $this->assertArrayNotHasKey('nullable', $openApiOptions);
-    }
-
-    public function testCompoundDiscriminatorDoesNotEmitRedundantPropertyNames(): void
-    {
-        Method::$processed = [];
-        Method::$errors = [];
-
-        $email = new AttributeEmail();
-        $enum = new AttributeEnum();
-        $string = new AttributeString();
-        $route = (new Route('GET', '/v1/tests/attribute'))
-            ->desc('Get test attribute')
-            ->label('sdk', new Method(
-                namespace: 'test',
-                group: null,
-                name: 'getTestAttribute',
-                description: 'Get test attribute.',
-                auth: [],
-                responses: [
-                    new SDKResponse(
-                        code: 200,
-                        model: [$email->getType(), $enum->getType(), $string->getType()],
-                    ),
-                ],
-            ));
-
-        $openApi = (new OpenAPI3(new Container(), [], [$route], [$email, $enum, $string], [], 0, 'console'))->parse();
-        $discriminator = $openApi['paths']['/tests/attribute']['get']['responses']['200']
-            ['content']['application/json']['schema']['discriminator'];
-
-        $this->assertArrayHasKey('x-mapping', $discriminator);
-        $this->assertArrayNotHasKey('x-propertyNames', $discriminator);
     }
 
     public function testQueriesSubclassesEmitArrayOfStrings(): void


### PR DESCRIPTION
## Summary

- stop emitting `x-propertyNames` for compound discriminators
- keep `x-mapping` unchanged for existing SDK discriminator behavior

`x-propertyNames` duplicated the condition keys already present in every `x-mapping` entry and had no consumers.

## Tests

- `vendor/bin/phpunit tests/unit/SDK/Specification/FormatTest.php`
- `composer lint src/Appwrite/SDK/Specification/Format.php`
- `composer refactor:check`
- `git diff --check`