### PR TITLE
chore: remove upload ID extension

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -647,9 +647,6 @@ class OpenAPI3 extends Format
                         $node['schema']['example'] = ($param['example'] ?? '') ?: false;
                         break;
                     case \Appwrite\Utopia\Database\Validator\CustomId::class:
-                        if ($sdk->getType() === MethodType::UPLOAD) {
-                            $node['schema']['x-upload-id'] = true;
-                        }
                         $node['schema']['type'] = $validator->getType();
                         $node['schema']['x-appwrite'] = [
                             'idGenerator' => 'ID.unique',
@@ -1029,10 +1026,6 @@ class OpenAPI3 extends Format
                                     $body['content'][$consumes[0]]['schema']['properties'][$name][$key] = $node['schema'][$key];
                                 }
                             }
-                        }
-
-                        if ($node['schema']['x-upload-id'] ?? false) {
-                            $body['content'][$consumes[0]]['schema']['properties'][$name]['x-upload-id'] = $node['schema']['x-upload-id'];
                         }
 
                         if (isset($node['schema']['x-appwrite'])) {


### PR DESCRIPTION
## Summary

Remove the custom `x-upload-id` extension from generated OpenAPI 3 specifications.

SDK Generator 4.3.0 no longer reads this extension. It infers resumable upload IDs from the standard multipart request schema by pairing a single binary property with its sibling `<name>Id` string property.

For example:

```json
{
  "type": "object",
  "properties": {
    "fileId": {
      "type": "string"
    },
    "file": {
      "type": "string",
      "format": "binary"
    }
  }
}
```

is interpreted as:

```text
file (binary) + fileId (string) -> fileId is the resumable upload ID
```

A deployment request containing `code` without a `codeId` does not infer a caller-provided upload ID.

## Changes

- stop annotating upload `CustomId` parameters with `x-upload-id`
- stop copying `x-upload-id` into multipart request-body properties
- preserve the existing standard schema and `x-appwrite.idGenerator` metadata

## Compatibility

Support for extension-free upload schemas was released in [SDK Generator 4.3.0](https://github.com/appwrite/sdk-generator/releases/tag/4.3.0) through [appwrite/sdk-generator#1821](https://github.com/appwrite/sdk-generator/pull/1821).

## Validation

- `FormatTest.php`: 28 tests, 141 assertions
- PHP syntax check
- Pint formatting check
- `git diff --check`
- confirmed no remaining `x-upload-id` occurrences under `src/` or `tests/`

## Follow-up

Regenerate the latest and maintained-version specifications so `x-upload-id` is removed from the published JSON files.
