### PR TITLE
feat(jobs): let the ready transition be deferred

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -42,11 +42,25 @@ use Utopia\System\System;
  * atomic and a lock timeout retries cleanly).
  *
  * Handlers are protected extension points: downstream workers (e.g. cloud)
- * override finalize() and wrap parent:: — before it for work that must
- * precede 'ready' (edge distribution), after it for post-activation work.
+ * override finalize() and wrap parent:: for post-activation work.
+ *
+ * A build that has to exist somewhere other than the region that produced it
+ * joins on that too, through three seams a downstream worker overrides:
+ * dispatchDistribution() starts the copies once the build is known good,
+ * recordEdgeReady() notes each target that answers, and distributed() decides
+ * when enough have. Waiting happens between callbacks rather than inside one,
+ * so nothing holds jobs-deployment:<id> while a copy is in flight.
  */
 class Jobs extends Action
 {
+    /**
+     * An edge reporting that it can serve a deployment's build. Not an
+     * orchestrator callback: downstream deployments that distribute a build
+     * beyond the region that built it publish this themselves as each target
+     * reports in.
+     */
+    public const string EVENT_EDGE_READY = 'appwrite.deployment.edge-ready';
+
     private const DEDUPE_TTL = 3600;
     private const LOCK_TTL = 30;
     private const LOCK_TIMEOUT = 10.0;
@@ -130,6 +144,7 @@ class Jobs extends Action
                 'orchestrator.job.artifact' => $this->onArtifact($dbForProject, $dbForPlatform, $project, $deployment, $event->data, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
                 'orchestrator.job.exit' => $this->onExit($dbForProject, $dbForPlatform, $project, $deployment, (int) ($event->data['exitCode'] ?? 0), $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
                 'orchestrator.job.complete' => $this->onComplete($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
+                self::EVENT_EDGE_READY => $this->onEdgeReady($dbForProject, $dbForPlatform, $project, $deployment, $event->data, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
                 default => $deployment,
             };
 
@@ -187,6 +202,68 @@ class Jobs extends Action
         }
 
         return $deployment;
+    }
+
+    /**
+     * Apply one edge's readiness report, then retry the success join.
+     *
+     * The report is recorded by recordEdgeReady(), which is where a downstream
+     * worker tracks which targets have answered; distributed() is the gate that
+     * decides whether enough of them have. Neither does anything here, because a
+     * self-hosted build is servable in the only place it exists.
+     */
+    protected function onEdgeReady(
+        Database $dbForProject,
+        Database $dbForPlatform,
+        Document $project,
+        Document $deployment,
+        array $data,
+        UsageContext $usage,
+        UsagePublisher $publisherForUsage,
+        ScreenshotPublisher $publisherForScreenshots,
+        Device $deviceForBuilds,
+        VcsFactory $vcsFactory,
+        Cache $cache,
+        array $platform,
+        array $plan,
+        Bus $bus,
+    ): Document {
+        $this->recordEdgeReady($deployment, $data, $cache);
+
+        return $this->ready($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus);
+    }
+
+    /**
+     * Note that one edge can serve this deployment. A no-op here; overridden
+     * where builds are distributed beyond the region that produced them.
+     *
+     * @param array<string, mixed> $data
+     */
+    protected function recordEdgeReady(Document $deployment, array $data, Cache $cache): void
+    {
+    }
+
+    /**
+     * Start copying the build everywhere it has to be. A no-op here; overridden
+     * where builds are distributed beyond the region that produced them.
+     *
+     * Called every time the join is retried, so an override must be idempotent.
+     */
+    protected function dispatchDistribution(Database $dbForProject, Document $project, Document $deployment, Cache $cache): void
+    {
+    }
+
+    /**
+     * Whether the build has reached everywhere it has to be before the
+     * deployment may be called ready.
+     *
+     * Always true here: a self-hosted build is servable in the only place it
+     * exists. Overridden where a build is copied out to other regions, so that
+     * 'ready' never advertises a deployment some of those regions cannot serve.
+     */
+    protected function distributed(Document $deployment, Cache $cache): bool
+    {
+        return true;
     }
 
     /**
@@ -348,6 +425,16 @@ class Jobs extends Action
             $deviceForBuilds->delete($path);
 
             return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, 'Build size should be less than ' . \number_format($limit / (1000 * 1000), 2) . ' MBs.', $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
+        }
+
+        // Only now is the build known good, so this is the first point it is worth
+        // copying anywhere. Idempotent: every edge report re-enters here.
+        $this->dispatchDistribution($dbForProject, $project, $deployment, $cache);
+
+        // Joined on the build itself, still waiting on the copies of it. Each
+        // report re-enters through onEdgeReady() and retries this.
+        if (! $this->distributed($deployment, $cache)) {
+            return $deployment;
         }
 
         return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, true, '', $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus, $size);

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -44,14 +44,14 @@ use Utopia\System\System;
  * Handlers are protected extension points: downstream workers (e.g. cloud)
  * override finalize() and wrap parent:: for post-activation work.
  *
- * A build that has to exist somewhere other than where it was produced joins on
- * that too, through two seams a downstream worker overrides:
- * dispatchDistribution() starts the copies once the build is known good, and
- * distributed() decides when enough of them have arrived. Both are no-ops here,
- * where a build is servable in the only place it exists. How a copy reports back
- * is that worker's business — it puts its own callback on this queue and handles
- * it in onCallback(), so the waiting happens between callbacks rather than inside
- * one and nothing holds jobs-deployment:<id> while a copy is in flight.
+ * The ready transition can be deferred. Once a build has passed every check this
+ * worker makes, onVerified() runs and deferred() is asked whether the deployment
+ * may be called ready yet; a subclass with work of its own to finish first starts
+ * it in the former and answers true from the latter until it is done. Both are
+ * no-ops here, where a verified build has nothing left to wait for. Whatever the
+ * subclass is waiting on reports back as its own callback on this queue, handled
+ * in onCallback(), so the waiting happens between callbacks rather than inside one
+ * and nothing holds jobs-deployment:<id> while it is outstanding.
  */
 class Jobs extends Action
 {
@@ -231,26 +231,28 @@ class Jobs extends Action
     }
 
     /**
-     * Start copying the build everywhere it has to be. A no-op here; overridden
-     * where builds are distributed beyond the region that produced them.
+     * The build has passed every check and the deployment could be called ready.
      *
-     * Called every time the join is retried, so an override must be idempotent.
+     * A no-op here. A subclass with work that must finish before that happens
+     * starts it here and defers the transition through deferred(). Called on
+     * every attempt at the transition, not only the first, so an override must be
+     * idempotent.
      */
-    protected function dispatchDistribution(Database $dbForProject, Document $project, Document $deployment, Cache $cache): void
+    protected function onVerified(Database $dbForProject, Document $project, Document $deployment, Cache $cache): void
     {
     }
 
     /**
-     * Whether the build has reached everywhere it has to be before the
-     * deployment may be called ready.
+     * Whether the ready transition has to wait for something.
      *
-     * Always true here: a self-hosted build is servable in the only place it
-     * exists. Overridden where a build is copied out to other regions, so that
-     * 'ready' never advertises a deployment some of those regions cannot serve.
+     * Never here: a verified build has nothing left outstanding. A subclass
+     * answers true while its own work is unfinished, so that 'ready' is not
+     * published before the deployment can actually be served, and false once it
+     * is done or has given up waiting.
      */
-    protected function distributed(Document $deployment, Cache $cache): bool
+    protected function deferred(Document $deployment, Cache $cache): bool
     {
-        return true;
+        return false;
     }
 
     /**
@@ -414,13 +416,13 @@ class Jobs extends Action
             return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, 'Build size should be less than ' . \number_format($limit / (1000 * 1000), 2) . ' MBs.', $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
         }
 
-        // Only now is the build known good, so this is the first point it is worth
-        // copying anywhere. Idempotent: every report re-enters here.
-        $this->dispatchDistribution($dbForProject, $project, $deployment, $cache);
+        // Every check this worker makes has passed, so the deployment is publishable
+        // as far as it is concerned. Idempotent: each retry of the join arrives here.
+        $this->onVerified($dbForProject, $project, $deployment, $cache);
 
-        // Joined on the build itself, still waiting on the copies of it. Whatever
-        // reports a copy arriving re-enters through onCallback() and retries this.
-        if (! $this->distributed($deployment, $cache)) {
+        // Something else is not finished. Whatever it is reports back as its own
+        // callback, which re-enters through onCallback() and retries this.
+        if ($this->deferred($deployment, $cache)) {
             return $deployment;
         }
 

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -44,23 +44,17 @@ use Utopia\System\System;
  * Handlers are protected extension points: downstream workers (e.g. cloud)
  * override finalize() and wrap parent:: for post-activation work.
  *
- * A build that has to exist somewhere other than the region that produced it
- * joins on that too, through three seams a downstream worker overrides:
- * dispatchDistribution() starts the copies once the build is known good,
- * recordEdgeReady() notes each target that answers, and distributed() decides
- * when enough have. Waiting happens between callbacks rather than inside one,
- * so nothing holds jobs-deployment:<id> while a copy is in flight.
+ * A build that has to exist somewhere other than where it was produced joins on
+ * that too, through two seams a downstream worker overrides:
+ * dispatchDistribution() starts the copies once the build is known good, and
+ * distributed() decides when enough of them have arrived. Both are no-ops here,
+ * where a build is servable in the only place it exists. How a copy reports back
+ * is that worker's business — it puts its own callback on this queue and handles
+ * it in onCallback(), so the waiting happens between callbacks rather than inside
+ * one and nothing holds jobs-deployment:<id> while a copy is in flight.
  */
 class Jobs extends Action
 {
-    /**
-     * An edge reporting that it can serve a deployment's build. Not an
-     * orchestrator callback: downstream deployments that distribute a build
-     * beyond the region that built it publish this themselves as each target
-     * reports in.
-     */
-    public const string EVENT_EDGE_READY = 'appwrite.deployment.edge-ready';
-
     private const DEDUPE_TTL = 3600;
     private const LOCK_TTL = 30;
     private const LOCK_TIMEOUT = 10.0;
@@ -144,8 +138,7 @@ class Jobs extends Action
                 'orchestrator.job.artifact' => $this->onArtifact($dbForProject, $dbForPlatform, $project, $deployment, $event->data, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
                 'orchestrator.job.exit' => $this->onExit($dbForProject, $dbForPlatform, $project, $deployment, (int) ($event->data['exitCode'] ?? 0), $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
                 'orchestrator.job.complete' => $this->onComplete($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
-                self::EVENT_EDGE_READY => $this->onEdgeReady($dbForProject, $dbForPlatform, $project, $deployment, $event->data, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
-                default => $deployment,
+                default => $this->onCallback($event->event, $dbForProject, $dbForPlatform, $project, $deployment, $event->data, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
             };
 
             // Console realtime on every callback (log stream + status).
@@ -205,14 +198,20 @@ class Jobs extends Action
     }
 
     /**
-     * Apply one edge's readiness report, then retry the success join.
+     * A callback this worker does not handle.
      *
-     * The report is recorded by recordEdgeReady(), which is where a downstream
-     * worker tracks which targets have answered; distributed() is the gate that
-     * decides whether enough of them have. Neither does anything here, because a
-     * self-hosted build is servable in the only place it exists.
+     * Everything the jobs-service sends is matched above. A subclass that puts
+     * its own events on this queue handles them here, with the deployment already
+     * read and the lock already held, and returns the deployment as it left it —
+     * which is why the outcome of one is published like any other callback's.
+     *
+     * Returns the deployment untouched here: an unrecognised callback is not an
+     * error, it belongs to something this class does not know about.
+     *
+     * @param array<string, mixed> $data
      */
-    protected function onEdgeReady(
+    protected function onCallback(
+        string $event,
         Database $dbForProject,
         Database $dbForPlatform,
         Document $project,
@@ -228,19 +227,7 @@ class Jobs extends Action
         array $plan,
         Bus $bus,
     ): Document {
-        $this->recordEdgeReady($deployment, $data, $cache);
-
-        return $this->ready($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus);
-    }
-
-    /**
-     * Note that one edge can serve this deployment. A no-op here; overridden
-     * where builds are distributed beyond the region that produced them.
-     *
-     * @param array<string, mixed> $data
-     */
-    protected function recordEdgeReady(Document $deployment, array $data, Cache $cache): void
-    {
+        return $deployment;
     }
 
     /**
@@ -428,11 +415,11 @@ class Jobs extends Action
         }
 
         // Only now is the build known good, so this is the first point it is worth
-        // copying anywhere. Idempotent: every edge report re-enters here.
+        // copying anywhere. Idempotent: every report re-enters here.
         $this->dispatchDistribution($dbForProject, $project, $deployment, $cache);
 
-        // Joined on the build itself, still waiting on the copies of it. Each
-        // report re-enters through onEdgeReady() and retries this.
+        // Joined on the build itself, still waiting on the copies of it. Whatever
+        // reports a copy arriving re-enters through onCallback() and retries this.
         if (! $this->distributed($deployment, $cache)) {
             return $deployment;
         }


### PR DESCRIPTION
> Rewritten twice after review. The first version named an `EVENT_EDGE_READY` constant and an `onEdgeReady()` handler here; the second still framed the seams as *distribution*. An edge is a Cloud concept and so is copying a build to several places — a self-hosted build is built and served in one place. This version has vocabulary for neither.

## Problem

`finalize()` runs under `jobs-deployment:<id>`, and a downstream worker with work to do before a deployment may be published did it there. Appwrite Cloud copies a site build out and waits for the result, bounded only by its own 60s timeout.

| constant | value |
|---|---|
| cloud's wait | **60** |
| `Jobs::LOCK_TTL` | **30** |
| `Jobs::LOCK_TIMEOUT` | **10** |

**Starvation.** Other callbacks for that deployment get 10s to acquire. Across a 60s hold none can win — destroyed, not delayed, including the sibling half of the success join.

**Lost mutual exclusion.** A 60s wait structurally outlives a 30s lease, so the key expires and another coroutine can enter the critical section.

Observed in one 12-minute production window as **successful** (`level=info`) spans, so the time was spent holding the lock, not waiting for it: **82.11s**, 35.21s, 34.31s, and four in the 11–13s range. The median callback is ~150ms.

## Change

Waiting belongs *between* callbacks, not inside one.

**Two seams**, both no-ops here because a verified build has nothing left outstanding:

```php
protected function onVerified(Database $dbForProject, Document $project, Document $deployment, Cache $cache): void {}

protected function deferred(Document $deployment, Cache $cache): bool
{
    return false;
}
```

- `onVerified()` runs once the build has passed every check this worker makes, so a subclass starts its work at the first point the deployment is publishable and not before. Called on every attempt at the transition, so an override must be idempotent.
- `deferred()` holds the transition while that work is unfinished, so `ready` is never published before the deployment can be served.

**Neither names what the subclass is waiting for.** Whatever it is reports back as its own callback on this queue — the default `match` arm is now `onCallback()`, where a subclass handles events this class does not define, with the deployment read and the lock held. An unrecognised callback returns the deployment untouched rather than erroring; it belongs to something this class does not know about.

`grep -in "edge\|distribut"` over this file returns nothing. The only matches for `copy` are pre-existing `getArrayCopy()` calls.

## Review notes

- **The seams sit after validation, not before.** A subclass starts work only once the build has passed detection, artifact existence and the size limit — otherwise it would act on builds that were going to fail anyway.
- **Failure paths are untouched.** They still finalize inside the same callback; they are fast and have nothing to wait for.
- **`onArtifact` also completes the join.** `ready()` is reachable from `exit`, `complete` *and* the `manifest` artifact, so all three pass through the same seams. Missing one would leave builds whose last marker is the manifest waiting forever.

## Testing

Unit suite: 997 tests. The 3 failures (`ExtensionsTest::testMaxminddb`, `Auth\KeyTest::testDecode`, `Vcs\FactoryTest::testRegistryEntries`) reproduce identically on a clean tree — verified by stashing, not assumed. PHPStan and Pint clean.

No unit coverage of `action()`'s locking structure — it needs 17 injections and a real lock — so this is guarded by the Sites E2E deployment-to-`ready` path. Stating that rather than leaving it implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)