### PR TITLE
feat(usage): add team billing dimensions to CE Usage Context

### DIFF
--- a/src/Appwrite/Platform/Workers/StatsUsage.php
+++ b/src/Appwrite/Platform/Workers/StatsUsage.php
@@ -97,6 +97,8 @@ class StatsUsage extends Action
                     'resourceType' => $resourceType === '' ? 'project' : $resourceType,
                     'resourceId' => $resourceId !== '' ? $resourceId : ($projectScoped ? $projectId : ''),
                     'resourceInternalId' => $resourceInternalId !== '' ? $resourceInternalId : ($projectScoped ? $tenant : ''),
+                    'teamId' => $metric['teamId'] ?? '',
+                    'teamInternalId' => $metric['teamInternalId'] ?? '',
                     'country' => $metric['country'] ?? '',
                     'hostname' => $metric['hostname'] ?? '',
                     'ip' => $metric['ip'] ?? '',

--- a/src/Appwrite/Usage/Context.php
+++ b/src/Appwrite/Usage/Context.php
@@ -16,6 +16,8 @@ class Context
     protected string $resourceId = '';
     protected string $resourceInternalId = '';
     protected string $resourcePath = '';
+    protected string $teamId = '';
+    protected string $teamInternalId = '';
     protected string $country = '';
     protected string $region = '';
     protected string $hostname = '';
@@ -90,6 +92,18 @@ class Context
     public function getResourcePath(): string
     {
         return $this->resourcePath;
+    }
+
+    public function setTeamId(string $teamId): static
+    {
+        $this->teamId = $teamId;
+        return $this;
+    }
+
+    public function setTeamInternalId(string $teamInternalId): static
+    {
+        $this->teamInternalId = $teamInternalId;
+        return $this;
     }
 
     /**
@@ -183,6 +197,8 @@ class Context
             'resourceId' => $this->resourceId,
             'resourceInternalId' => $this->resourceInternalId,
             'resourcePath' => $this->resourcePath,
+            'teamId' => $this->teamId,
+            'teamInternalId' => $this->teamInternalId,
             'country' => $this->country,
             'region' => $this->region,
             'hostname' => $this->hostname,
@@ -251,6 +267,8 @@ class Context
         $this->resourceId = '';
         $this->resourceInternalId = '';
         $this->resourcePath = '';
+        $this->teamId = '';
+        $this->teamInternalId = '';
         $this->country = '';
         $this->region = '';
         $this->hostname = '';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Lifts `teamId` and `teamInternalId` onto `Appwrite\Usage\Context` so Cloud can set team billing dimensions without patching `addMetric`.

CE has no teams-as-billing today. Both fields default to `''`, are included on every `addMetric` envelope, and `reset()` clears them. Cloud can call `setTeamId()` / `setTeamInternalId()` on the existing subclass instead of stamping the last metric after `parent::addMetric()`.

The stats-usage worker already maps an explicit ClickHouse tag list. This PR adds the two team tags the same way as other optional dimensions (`sdk`, `sdkVersion`, …). Empty values are still filtered out before insert.

**ClickHouse schema change: not needed.** `utopia-php/usage` (`^0.14.0`) already defines `teamId` / `teamInternalId` as `Nullable(String)` on events, gauges, and the daily rollup (`Metric::EVENT_COLUMNS` / `GAUGE_COLUMNS`). Inserting a populated tag writes the existing column; a blank CE default is omitted and stored as null.

API response models and `/v1/usage/events` dimension/filter allow-lists are unchanged. Team remains a write-path billing dimension, not a self-hosted query surface.

Does not touch Cloud or rewrite #13286.

## Test Plan

- Inspected `src/Appwrite/Usage/Context.php` after #13286: dimensional envelope now includes `teamId` / `teamInternalId` default `''`.
- Inspected `utopia-php/usage` at `baeef33` (`ClickHouse.php` + `Metric.php`): team columns already exist; no CE migration or `ALTER TABLE` required.
- Writer maps an explicit tag list, so team fields were added there rather than dumping the full metric array into ClickHouse.
- No CE unit test currently snapshots the `addMetric` envelope keys (`tests/unit/Usage` from the #13286 description is not in the merged tree). Did not add a new test file per that constraint.
- No API model / spec change.

## Related PRs and Issues

- Follow-up to #13286 (self-hosted usage service). Cloud adoption can drop its `addMetric` post-stamp once this lands.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? (N/A — no API metadata change)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d29f5eb1-2218-4b1f-92fc-64e40369a289?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d29f5eb1-2218-4b1f-92fc-64e40369a289&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

