### PR TITLE
feat(usage): pin Context resource and wrap prebuilt Usage

### DIFF
--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -59,7 +59,6 @@ use Utopia\Storage\DeviceType;
 use Utopia\System\System;
 use Utopia\Telemetry\Adapter as Telemetry;
 use Utopia\Telemetry\Adapter\None as NoTelemetry;
-use Utopia\Usage\Usage;
 
 global $register;
 global $container;
@@ -193,8 +192,6 @@ $container->set('usageConnection', function () {
         retention: (int) System::getEnv('_APP_MAINTENANCE_RETENTION_USAGE_TTL', 180),
     );
 }, []);
-
-$container->set('dbForUsage', fn (UsageConnection $usageConnection): Usage => $usageConnection->getUsage(), ['usageConnection']);
 
 $container->set('publisherForBuilds', fn (Publisher $publisher) => new BuildPublisher(
     $publisher,

--- a/src/Appwrite/Usage/Connection.php
+++ b/src/Appwrite/Usage/Connection.php
@@ -10,6 +10,11 @@ use Utopia\Usage\Usage;
 
 /**
  * Lifecycle-local connection to the shared OSS usage namespace.
+ *
+ * Self-hosted constructs this from enabled / DSN / HTTP client and lazily
+ * builds Usage. To attach an already-pooled Usage (one client, schema out
+ * of band), use Connection::fromUsage(). Callers that need the raw Utopia
+ * Usage object use getUsage(); do not register a second usage resource.
  */
 class Connection
 {
@@ -18,13 +23,28 @@ class Connection
     private ?Usage $usage = null;
     private bool $ready = false;
     private float $checkedAt = 0.0;
+    private bool $wrapped = false;
 
     public function __construct(
         private readonly bool $enabled,
         private readonly string $dsn,
-        private readonly ClientInterface $client,
+        private readonly ?ClientInterface $client = null,
         private readonly int $retention = 180,
     ) {
+    }
+
+    /**
+     * Wrap an already-built Usage instance. isEnabled and isReady are true;
+     * setup() does not run DDL.
+     */
+    public static function fromUsage(Usage $usage): self
+    {
+        $connection = new self(enabled: true, dsn: '');
+        $connection->usage = $usage;
+        $connection->wrapped = true;
+        $connection->ready = true;
+
+        return $connection;
     }
 
     public function isEnabled(): bool
@@ -44,6 +64,10 @@ class Connection
 
         if ($this->dsn === '') {
             throw new \RuntimeException('Usage database connection not configured (_APP_CONNECTIONS_DB_USAGE)');
+        }
+
+        if ($this->client === null) {
+            throw new \RuntimeException('Usage HTTP client is not configured');
         }
 
         try {
@@ -100,6 +124,10 @@ class Connection
 
     public function isReady(): bool
     {
+        if ($this->wrapped) {
+            return true;
+        }
+
         if (
             $this->ready
             && (microtime(true) - $this->checkedAt) < self::READY_TTL_SECONDS
@@ -115,6 +143,10 @@ class Connection
 
     public function setup(): void
     {
+        if ($this->wrapped) {
+            return;
+        }
+
         if ($this->enabled) {
             $this->ready = false;
             $this->checkedAt = 0.0;

--- a/src/Appwrite/Usage/Context.php
+++ b/src/Appwrite/Usage/Context.php
@@ -240,6 +240,10 @@ class Context
 
     public function fillMissingResource(string $resourceType, string $resourceId, string $resourceInternalId): static
     {
+        $this->setResourceType($resourceType);
+        $this->setResourceId($resourceId);
+        $this->setResourceInternalId($resourceInternalId);
+
         foreach ($this->metrics as $index => $metric) {
             if (($metric['resourceType'] ?? '') === '') {
                 $this->metrics[$index]['resourceType'] = $resourceType;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Three CE usage lifts so Cloud can drop its remaining Usage subclasses and keep a single ClickHouse client.

### 1. `fillMissingResource` pins the resource on the context

CE used to backfill empty `resourceType` / `resourceId` / `resourceInternalId` on already-buffered metric rows only. Later `addMetric` calls still snapshot empty resource fields.

This pins the resource with the existing setters first, then keeps the metric-row backfill. Matches Cloud's `Appwrite\Cloud\Usage\Context` overlay. Return type stays `static`.

### 2. `Connection::fromUsage()` wraps a prebuilt Usage

Self-hosted construction is unchanged: `new Connection($enabled, $dsn, $client, $retention)` lazily builds Usage.

Cloud can attach its pooled Usage without a second HTTP client or DDL:

```php
$usageConnection = Connection::fromUsage($dbForUsage);
```

In that mode: `isEnabled()` is true, `getUsage()` returns the injected instance, `isReady()` is true (schema is out of band), and `setup()` is a no-op so stats-resources does not run DDL.

### 3. One usage handle

CE already injected `usageConnection` for stats-resources / setup / health. It also registered an unused `dbForUsage` alias of `usageConnection->getUsage()` — nothing in CE injected it, and it did not build a second client. That alias is removed.

`usageConnection` is the single inject. Callers that need the raw `Utopia\Usage\Usage` object use `$connection->getUsage()`.

**Cloud migration:** register `usageConnection = Connection::fromUsage($pooledUsage)` and delete `Appwrite\Cloud\Usage\Connection.php`. If Cloud still injects `dbForUsage`, alias it as `usageConnection->getUsage()` so there is one client.

Does not touch the Cloud repo or rewrite #13286 / #13316.

## Test Plan

- Inspected `Context::fillMissingResource` on current `main`: it only looped `$this->metrics`. Setters now pin context fields before that loop; `addMetric` snapshots those fields at emit time.
- Inspected CE resource graph: `usageConnection` is the only injected usage handle. `dbForUsage` was registered as `usageConnection->getUsage()` and had zero inject sites; it is removed.
- Existing `new Connection(enabled:, dsn:, client:, retention:)` call site in `app/init/resources.php` is unchanged.
- No CE unit test currently snapshots `fillMissingResource` or `Connection` (`tests/unit/Usage` is not in the tree). Did not add a new test file per that constraint.
- No API model / spec change.

## Related PRs and Issues

- Follow-up to #13286 (self-hosted usage service) and #13316 (team billing dimensions).
- Cloud can drop `Appwrite\Cloud\Usage\Context` (`fillMissingResource`) and `Appwrite\Cloud\Usage\Connection` (`fromUsage`).

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? (N/A — no API metadata change)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3400029c-7d8f-479d-85d8-73bbfad923ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3400029c-7d8f-479d-85d8-73bbfad923ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

