### PR TITLE
fix(usage): lower the stats-resources interval floor to 1 second

### DIFF
--- a/src/Appwrite/Platform/Tasks/StatsResources.php
+++ b/src/Appwrite/Platform/Tasks/StatsResources.php
@@ -42,7 +42,9 @@ class StatsResources extends Action
         }
 
         $this->disableSubqueries();
-        $interval = max(60, (int) System::getEnv('_APP_STATS_RESOURCES_INTERVAL', 3600));
+        // Floor of 1 guards against a zero/negative interval spinning the loop;
+        // test stacks legitimately run short intervals (Cloud CI uses 2s).
+        $interval = max(1, (int) System::getEnv('_APP_STATS_RESOURCES_INTERVAL', 3600));
 
         Console::loop(function () use ($dbForPlatform, $publisherForStatsResources, $usageConnection): void {
             if (!$usageConnection->isReady()) {


### PR DESCRIPTION
## Problem

The stats-resources task clamps its loop interval with `max(60, ...)`. Test stacks legitimately configure `_APP_STATS_RESOURCES_INTERVAL=2` (Cloud CI and `.env.tests`) so resource gauges converge within seconds; the 60s floor silently overrides that, gauges recompute only once a minute, and Cloud's `AppsUsageTest` — whose `assertEventually` timeout is exactly 60s — fails on every run since the upstream usage adoption (appwrite-labs/cloud#5378 replaced the Cloud scheduler, which honored the configured interval, with this task).

## Fix

Floor the interval at 1 instead of 60. The floor exists to keep a zero or negative value from spinning the loop, and 1 still does that; production keeps its 3600 default.

## Testing

There is no unit seam around `Console::loop`'s interval, so no unit test covers this line; the regression coverage is Cloud's `tests/e2e/Services/Apps/AppsUsageTest` (red on main today at the 60s floor, green at the configured 2s interval once Cloud relocks onto this fix).