### PR TITLE
refactor(functions): fetch variables fresh for scheduled executions

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Variables/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Variables/Create.php
@@ -11,11 +11,9 @@ use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response;
 use Utopia\Database\Database;
-use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
 use Utopia\Database\Helpers\ID;
-use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\UID;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
@@ -67,9 +65,7 @@ class Create extends Base
             ->inject('response')
             ->inject('queueForEvents')
             ->inject('dbForProject')
-            ->inject('dbForPlatform')
             ->inject('project')
-            ->inject('authorization')
             ->callback($this->action(...));
     }
 
@@ -82,9 +78,7 @@ class Create extends Base
         Response $response,
         QueueEvent $queueForEvents,
         Database $dbForProject,
-        Database $dbForPlatform,
-        Document $project,
-        Authorization $authorization
+        Document $project
     ) {
         $function = $dbForProject->getDocument('functions', $functionId);
 
@@ -115,18 +109,6 @@ class Create extends Base
 
         $function->setAttribute('live', false);
         $dbForProject->updateDocument('functions', $function->getId(), new Document(['live' => false]));
-
-        // Inform scheduler to pull the latest changes
-        $schedule = $dbForPlatform->getDocument('schedules', $function->getAttribute('scheduleId'));
-        $schedule
-            ->setAttribute('resourceUpdatedAt', DateTime::now())
-            ->setAttribute('schedule', $function->getAttribute('schedule'))
-            ->setAttribute('active', !empty($function->getAttribute('schedule')) && !empty($function->getAttribute('deploymentId')));
-        $authorization->skip(fn () => $dbForPlatform->updateDocument('schedules', $schedule->getId(), new Document([
-            'resourceUpdatedAt' => $schedule->getAttribute('resourceUpdatedAt'),
-            'schedule' => $schedule->getAttribute('schedule'),
-            'active' => $schedule->getAttribute('active'),
-        ])));
 
         $queueForEvents->setParam('variableId', $variable->getId());
 

--- a/src/Appwrite/Platform/Modules/Functions/Http/Variables/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Variables/Delete.php
@@ -11,9 +11,7 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
 use Utopia\Database\Database;
-use Utopia\Database\DateTime;
 use Utopia\Database\Document;
-use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\UID;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
@@ -61,8 +59,6 @@ class Delete extends Base
             ->inject('response')
             ->inject('queueForEvents')
             ->inject('dbForProject')
-            ->inject('dbForPlatform')
-            ->inject('authorization')
             ->callback($this->action(...));
     }
 
@@ -71,9 +67,7 @@ class Delete extends Base
         string $variableId,
         Response $response,
         QueueEvent $queueForEvents,
-        Database $dbForProject,
-        Database $dbForPlatform,
-        Authorization $authorization
+        Database $dbForProject
     ) {
         $function = $dbForProject->getDocument('functions', $functionId);
 
@@ -90,18 +84,6 @@ class Delete extends Base
 
         $function->setAttribute('live', false);
         $dbForProject->updateDocument('functions', $function->getId(), new Document(['live' => false]));
-
-        // Inform scheduler to pull the latest changes
-        $schedule = $dbForPlatform->getDocument('schedules', $function->getAttribute('scheduleId'));
-        $schedule
-            ->setAttribute('resourceUpdatedAt', DateTime::now())
-            ->setAttribute('schedule', $function->getAttribute('schedule'))
-            ->setAttribute('active', !empty($function->getAttribute('schedule')) && !empty($function->getAttribute('deploymentId')));
-        $authorization->skip(fn () => $dbForPlatform->updateDocument('schedules', $schedule->getId(), new Document([
-            'resourceUpdatedAt' => $schedule->getAttribute('resourceUpdatedAt'),
-            'schedule' => $schedule->getAttribute('schedule'),
-            'active' => $schedule->getAttribute('active'),
-        ])));
 
         $queueForEvents->setParam('variableId', $variable->getId());
 

--- a/src/Appwrite/Platform/Modules/Functions/Http/Variables/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Variables/Update.php
@@ -10,10 +10,8 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
 use Utopia\Database\Database;
-use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
-use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\UID;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
@@ -66,8 +64,6 @@ class Update extends Base
             ->inject('response')
             ->inject('queueForEvents')
             ->inject('dbForProject')
-            ->inject('dbForPlatform')
-            ->inject('authorization')
             ->callback($this->action(...));
     }
 
@@ -79,9 +75,7 @@ class Update extends Base
         ?bool $secret,
         Response $response,
         QueueEvent $queueForEvents,
-        Database $dbForProject,
-        Database $dbForPlatform,
-        Authorization $authorization
+        Database $dbForProject
     ) {
         $function = $dbForProject->getDocument('functions', $functionId);
 
@@ -125,18 +119,6 @@ class Update extends Base
 
         $function->setAttribute('live', false);
         $dbForProject->updateDocument('functions', $function->getId(), new Document(['live' => false]));
-
-        // Inform scheduler to pull the latest changes
-        $schedule = $dbForPlatform->getDocument('schedules', $function->getAttribute('scheduleId'));
-        $schedule
-            ->setAttribute('resourceUpdatedAt', DateTime::now())
-            ->setAttribute('schedule', $function->getAttribute('schedule'))
-            ->setAttribute('active', !empty($function->getAttribute('schedule')) && !empty($function->getAttribute('deploymentId')));
-        $authorization->skip(fn () => $dbForPlatform->updateDocument('schedules', $schedule->getId(), new Document([
-            'resourceUpdatedAt' => $schedule->getAttribute('resourceUpdatedAt'),
-            'schedule' => $schedule->getAttribute('schedule'),
-            'active' => $schedule->getAttribute('active'),
-        ])));
 
         $queueForEvents->setParam('variableId', $variable->getId());
 

--- a/src/Appwrite/Platform/Workers/Functions.php
+++ b/src/Appwrite/Platform/Workers/Functions.php
@@ -268,6 +268,16 @@ class Functions extends Action
                 break;
             case 'schedule':
                 $execution = new Document($payload['execution'] ?? []);
+
+                // The scheduler dispatches a snapshot without variables; a
+                // fresh read pulls them along with any other changes made
+                // since the snapshot was taken.
+                $function = $dbForProject->getDocument('functions', $function->getId());
+                if ($function->isEmpty()) {
+                    Console::log('Function not found, skipping scheduled execution.');
+                    break;
+                }
+
                 $this->execute(
                     log: $log,
                     dbForProject: $dbForProject,

--- a/src/Appwrite/Schedule/Source/Functions.php
+++ b/src/Appwrite/Schedule/Source/Functions.php
@@ -36,6 +36,17 @@ final class Functions extends Database
     }
 
     #[\Override]
+    protected function resource(\Utopia\Database\Database $projectDB, array $schedule): Document
+    {
+        // The functions worker reads variables fresh at execution time, so the
+        // snapshot must not carry them: they would go stale in memory.
+        return $projectDB->skipFilters(
+            fn () => $projectDB->getDocument($this->collection(), $schedule['resourceId']),
+            ['subQueryVariables', 'subQueryProjectVariables']
+        );
+    }
+
+    #[\Override]
     protected function trigger(array $schedule): Trigger
     {
         $window = ($this->spread)($schedule);


### PR DESCRIPTION
## What does this PR do?

Stops the scheduler from caching function variables and stops variable APIs from updating the schedule document.

**Before:** the `schedule-functions` scheduler snapshotted the entire function document — `vars` and `varsProject` included — into memory, and the functions worker executed scheduled runs directly from that snapshot. This meant:

- Every variable Create/Update/Delete had to bump `resourceUpdatedAt` on the schedule document just to invalidate the scheduler's cache.
- Project-level variable changes never bumped it, so scheduled executions ran with stale `varsProject` values indefinitely.
- Decrypted variable values (including secrets) sat in the scheduler's process memory and in every dispatched queue payload.

**After:**

- `Schedule\Source\Functions::resource()` skips the `subQueryVariables` / `subQueryProjectVariables` filters, so the snapshot physically cannot carry variable values.
- The functions worker re-fetches the function from the project DB when handling a `schedule` dispatch, so variables (and any other function changes, e.g. a new deployment) are read fresh at execution time. A function deleted between dispatch and execution is now skipped instead of executed from a stale snapshot.
- The variable endpoints (`Functions/Http/Variables/{Create,Update,Delete}.php`) drop the schedule-document update and their now-unused `dbForPlatform` / `authorization` injections.

Cron/deployment changes still propagate to the scheduler as before via the `resourceUpdatedAt` bumps in `Functions/Update.php` and `Deployment/Update.php` — those own the `schedule` / `active` attributes.

## Test Plan

- `composer lint` and PHPStan pass on all changed files.
- No existing e2e/unit tests asserted the removed schedule write.
- Manual: function on a cron schedule → update a function variable and a project variable → next scheduled execution receives the new values without any schedule-document write.

## Related PRs and Issues

None.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

🤖 Generated with [Claude Code](https://claude.com/claude-code)