### PR TITLE
fix: bound screenshot cache resource

### DIFF
--- a/src/Appwrite/Platform/Modules/Avatars/Http/Screenshots/Get.php
+++ b/src/Appwrite/Platform/Modules/Avatars/Http/Screenshots/Get.php
@@ -48,8 +48,7 @@ class Get extends Action
             ->label('usage.metric', METRIC_AVATARS_SCREENSHOTS_GENERATED)
             ->label('abuse-limit', 60)
             ->label('cache', true)
-            ->label('cache.resourceType', 'avatar/screenshot')
-            ->label('cache.resource', 'screenshot/{request.url}/{request.width}/{request.height}/{request.scale}/{request.theme}/{request.userAgent}/{request.fullpage}/{request.locale}/{request.timezone}/{request.latitude}/{request.longitude}/{request.accuracy}/{request.touch}/{request.permissions}/{request.sleep}/{request.quality}/{request.output}')
+            ->label('cache.resource', 'avatar/screenshot')
             ->label('sdk', new Method(
                 namespace: 'avatars',
                 group: null,

--- a/tests/e2e/Services/Avatars/AvatarsBase.php
+++ b/tests/e2e/Services/Avatars/AvatarsBase.php
@@ -600,6 +600,7 @@ trait AvatarsBase
             'url' => 'https://appwrite.io?x=' . time() . rand(1000, 9999),
             'width' => 800,
             'height' => 600,
+            'userAgent' => str_repeat('a', 512),
             'headers' => [
                 'User-Agent' => 'Mozilla/5.0 (compatible; AppwriteBot/1.0)',
                 'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'


### PR DESCRIPTION
## What does this PR do?

Uses a bounded, static cache resource for webpage screenshots and adds regression coverage for requests with long, valid parameters.

The screenshot endpoint previously rendered request-controlled values into `cache.resource`:

```php
screenshot/{request.url}/{request.width}/{request.height}/{request.scale}/{request.theme}/{request.userAgent}/...
```

That value is persisted in the project `cache` collection after the screenshot response is generated. The collection defines `resource` as a string with a maximum length of 255 characters. However, valid screenshot parameters can be much longer; `userAgent` alone accepts up to 512 characters, and the URL and remaining parameters add more data.

### Before

A valid request such as:

```http
GET /v1/avatars/screenshots
    ?url=https://appwrite.io
    &userAgent=aaaaaaaa...aaaaaaaa
```

where `userAgent` contains 512 characters passes request validation and the browser service successfully generates the screenshot. During the API shutdown hook, Appwrite then attempts to persist cache metadata similar to:

```text
screenshot/https://appwrite.io/0/0/1/light/aaaaaaaa...aaaaaaaa/0/.../png
```

This value is longer than 255 characters, so `createDocument('cache', ...)` throws:

```text
Invalid document structure: Attribute "resource" has invalid type.
Value must be a valid string and no longer than 255 chars
```

The failure happens after the expensive screenshot generation work and prevents the cache entry from being recorded. Subsequent identical requests repeat both the screenshot generation and the failure.

### After

The cache metadata now uses the bounded value:

```text
avatar/screenshot
```

The same request completes successfully and its cache record can be persisted. Request-specific cache identity is unchanged because cache lookup and storage use `Request::cacheIdentifier()`, not `cache.resource`. Different URLs, dimensions, user agents, headers, and other request parameters therefore continue to produce distinct cache keys.

### Why this fix

`cache.resource` is invalidation metadata rather than the cache identity. Screenshot results do not correspond to a mutable Appwrite resource that needs per-URL invalidation, so embedding every request parameter in this field provides no benefit. A static resource:

- stays within the database schema limit;
- preserves request-specific caching through `Request::cacheIdentifier()`;
- avoids storing request-controlled URL and user-agent data as invalidation metadata;
- matches the existing avatar cache labels such as `avatar/browser` and `avatar/image`;
- avoids a cache collection schema expansion or migration for data that does not need to be unbounded.

The regression test uses the maximum accepted 512-character `userAgent`, which would exceed the old `resource` limit but succeeds with the bounded label.

Sentry: [CLOUD-3NZG](https://appwrite.sentry.io/issues/7605040002/)

## Test Plan

- `composer lint src/Appwrite/Platform/Modules/Avatars/Http/Screenshots/Get.php`
- `composer lint tests/e2e/Services/Avatars/AvatarsBase.php`
- `git diff --check`
- Full screenshot E2E not run locally because the Docker stack is not running.

## Related PRs and Issues

- Sentry issue CLOUD-3NZG

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] API specs and example docs are not affected; this only changes internal cache metadata.
