### PR TITLE
fix(usage): contain per-cycle failures in the stats-resources loop

### DIFF
--- a/src/Appwrite/Platform/Tasks/StatsResources.php
+++ b/src/Appwrite/Platform/Tasks/StatsResources.php
@@ -47,19 +47,41 @@ class StatsResources extends Action
         $interval = max(1, (int) System::getEnv('_APP_STATS_RESOURCES_INTERVAL', 3600));
 
         Console::loop(function () use ($dbForPlatform, $publisherForStatsResources, $usageConnection): void {
-            if (!$usageConnection->isReady()) {
-                throw new \RuntimeException('Usage schema is not ready');
-            }
-            $this->concurrency->sample($usageConnection->getUsage());
+            // Nothing here may end the loop. An exception escaping this closure
+            // ends Console::loop, and the process then stays alive and idle: it
+            // never exits, so restartPolicy never fires, and with no liveness
+            // probe nothing observes that scheduling has stopped. A single
+            // transient ClickHouse timeout on one tick silently ended gauge
+            // collection for a whole region, and the task went on reporting
+            // Ready for weeks while queueing nothing.
+            try {
+                if (!$usageConnection->isReady()) {
+                    Console::error('stats resources: usage schema is not ready, skipping cycle');
+                    return;
+                }
 
-            $last24Hours = (new \DateTime())->sub(new \DateInterval('P1D'));
-            $this->foreachDocument($dbForPlatform, 'projects', [
-                Query::greaterThanEqual('accessedAt', DateTime::format($last24Hours)),
-                Query::equal('region', [System::getEnv('_APP_REGION', 'default')]),
-                Query::orderAsc('$sequence'), // accessedAt Can be updated during iteration
-            ], function ($project) use ($publisherForStatsResources): void {
-                $publisherForStatsResources->enqueue(new StatsResourcesMessage(project: $project));
-            });
+                // Concurrency sampling reads the usage store; project scheduling
+                // reads the platform DB. They share no data, so a failure in the
+                // first must not cost the second -- that coupling is what turned
+                // one bad read into no scheduling at all.
+                try {
+                    $this->concurrency->sample($usageConnection->getUsage());
+                } catch (\Throwable $th) {
+                    Console::error('stats resources: concurrency sample failed, continuing: ' . $th->getMessage());
+                }
+
+                $last24Hours = (new \DateTime())->sub(new \DateInterval('P1D'));
+                $this->foreachDocument($dbForPlatform, 'projects', [
+                    Query::greaterThanEqual('accessedAt', DateTime::format($last24Hours)),
+                    Query::equal('region', [System::getEnv('_APP_REGION', 'default')]),
+                    Query::orderAsc('$sequence'), // accessedAt Can be updated during iteration
+                ], function ($project) use ($publisherForStatsResources): void {
+                    $publisherForStatsResources->enqueue(new StatsResourcesMessage(project: $project));
+                });
+            } catch (\Throwable $th) {
+                // Cost a cycle, not the process: the next tick retries in full.
+                Console::error('stats resources: cycle failed, retrying next interval: ' . $th->getMessage());
+            }
         }, $interval);
     }
 }


### PR DESCRIPTION
An exception thrown inside the `Console::loop` closure in `StatsResources` ends the loop — and the process then sits alive and idle, so nothing recovers it.

## Why that's worse than a crash

```php
Console::loop(function () use (...) {
    if (!$usageConnection->isReady()) { throw new \RuntimeException(...); }
    $this->concurrency->sample($usageConnection->getUsage());   // ← throws here

    $last24Hours = ...;
    $this->foreachDocument($dbForPlatform, 'projects', [...],   // ← never reached
        fn($project) => $publisherForStatsResources->enqueue(...));
}, $interval);
```

When the closure throws, the loop ends but the process **does not exit**. A container restart policy only fires on exit, so it never fires. Without a liveness probe, the scheduler keeps reporting healthy while queueing nothing.

We hit this in production: one transient timeout on the usage-store read at the top of the closure ended gauge collection for an entire region. The task stayed `Ready` and idle — **22 log lines total, none after the failure** — until the numbers were noticed to have stopped moving in the console. Gauges are only produced by this scheduler, so nothing downstream fills the gap.

## Changes

**Wrap the cycle body.** Any failure costs one interval, not the process; the next tick retries in full.

**Stop letting concurrency sampling gate project scheduling.** `concurrency->sample()` reads the usage store; the scheduling scan reads the platform DB. They share no data, so a failure in the first shouldn't prevent the second — that coupling is what turned one bad read into no scheduling at all. It's now caught separately and the scan proceeds.

An unready usage schema also becomes a skipped cycle with a logged error rather than a `RuntimeException` out of the loop, which had the same terminal effect as any other throw.

## Verification

Drove the closure directly against both revisions:

| scenario | `main` | this branch |
|---|---|---|
| healthy | queued 5 | queued 5 |
| `sample()` throws | **escaped, queued 0** | contained, logged, **queued 5** |
| usage schema not ready | **escaped, queued 0** | contained, logged, queued 0 |

The middle row is the production failure.

## Not in scope

A liveness probe on the task deployment. Even with this change a wedged process should be detectable from outside, and today nothing distinguishes "looping happily" from "alive and doing nothing" — worth addressing separately in the deployment config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)