### PR TITLE
fix(realtime): send connected handshake before channel subscribe

### DIFF
--- a/app/realtime.php
+++ b/app/realtime.php
@@ -1035,12 +1035,17 @@ $server->onOpen(function (int $connection, SwooleRequest $request) use ($server,
                 ]
             ]);
 
+            // Send `connected` before subscribe()/updateStats(). Those steps put the
+            // connection in the in-memory delivery tree and then hit the platform DB
+            // / usage queue (coroutine yields). A pub/sub event delivered in that
+            // window would otherwise become the client's first websocket frame.
+            $server->send([$connection], $connectedPayloadJson);
+            $outboundBytes += \strlen($connectedPayloadJson);
+
             $realtime->subscribe($project->getId(), $connection, '', $roles, [], [], $targetUser->getId());
             $realtime->connections[$connection]['authorization'] = $authorization;
             $realtime->connections[$connection]['impersonatedUserId'] = $impersonatorUser->isEmpty() ? null : $targetUser->getId();
             $updateStats($project->getId(), $project->getAttribute('teamId'));
-            $server->send([$connection], $connectedPayloadJson);
-            $outboundBytes += \strlen($connectedPayloadJson);
             triggerStats([
                 METRIC_REALTIME_OUTBOUND => \strlen($connectedPayloadJson),
             ], $project->getId());
@@ -1064,29 +1069,11 @@ $server->onOpen(function (int $connection, SwooleRequest $request) use ($server,
         $sanitizedUser = empty($targetUser->getId()) ? null : $response->output($targetUser, Response::MODEL_ACCOUNT);
 
         $mapping = [];
+        $prepared = [];
         foreach ($subscriptions as $index => $subscription) {
             $subscriptionId = ID::unique();
-
-            $realtime->subscribe(
-                $project->getId(),
-                $connection,
-                $subscriptionId,
-                $roles,
-                $subscription['channels'],
-                $subscription['queries'],
-                $targetUser->getId()
-            );
-
             $mapping[$index] = $subscriptionId;
-        }
-
-        $realtime->connections[$connection]['authorization'] = $authorization;
-        $realtime->connections[$connection]['impersonatedUserId'] = $impersonatorUser->isEmpty() ? null : $targetUser->getId();
-        $updateStats($project->getId(), $project->getAttribute('teamId'));
-
-        $subscriptionCount = \count($subscriptions);
-        if (!empty($subscriptions)) {
-            $register->get('telemetry.workerSubscriptionCounter')->add(\count($subscriptions), $register->get('telemetry.workerAttributes'));
+            $prepared[] = [$subscriptionId, $subscription];
         }
 
         $connectedPayloadJson = json_encode([
@@ -1098,8 +1085,34 @@ $server->onOpen(function (int $connection, SwooleRequest $request) use ($server,
             ]
         ]);
 
+        // Handshake first: URL channels subscribe the connection into the delivery
+        // tree before `connected` is sent, and updateStats() yields on DB/queue I/O.
+        // Concurrent events (especially on the shared console `presences` channel)
+        // can then race ahead of the handshake frame.
         $server->send([$connection], $connectedPayloadJson);
         $outboundBytes += \strlen($connectedPayloadJson);
+
+        foreach ($prepared as [$subscriptionId, $subscription]) {
+            $realtime->subscribe(
+                $project->getId(),
+                $connection,
+                $subscriptionId,
+                $roles,
+                $subscription['channels'],
+                $subscription['queries'],
+                $targetUser->getId()
+            );
+        }
+
+        $realtime->connections[$connection]['authorization'] = $authorization;
+        $realtime->connections[$connection]['impersonatedUserId'] = $impersonatorUser->isEmpty() ? null : $targetUser->getId();
+        $updateStats($project->getId(), $project->getAttribute('teamId'));
+
+        $subscriptionCount = \count($subscriptions);
+        if (!empty($subscriptions)) {
+            $register->get('telemetry.workerSubscriptionCounter')->add(\count($subscriptions), $register->get('telemetry.workerAttributes'));
+        }
+
         triggerStats([
             METRIC_REALTIME_OUTBOUND => \strlen($connectedPayloadJson),
         ], $project->getId());

--- a/tests/e2e/Services/Presences/PresenceConsoleClientTest.php
+++ b/tests/e2e/Services/Presences/PresenceConsoleClientTest.php
@@ -119,8 +119,6 @@ final class PresenceConsoleClientTest extends Scope
     public function testExpiredConsolePresenceDeletedByMaintenance(): void
     {
         $presenceId = ID::unique();
-        // Set a near-future expiry to satisfy validation, then wait until it is in the past.
-        $expiresAt = DateTime::format((new \DateTime())->modify('+2 seconds'));
 
         $upsert = $this->client->call(
             Client::METHOD_PUT,
@@ -141,6 +139,9 @@ final class PresenceConsoleClientTest extends Scope
         );
         $this->assertSame(200, $upsert['headers']['status-code']);
 
+        // Compute expiry immediately before PATCH. The API requires a future
+        // datetime; stamping it before upsert can already be in the past under load.
+        $expiresAt = DateTime::format((new \DateTime())->modify('+2 seconds'));
         $expire = $this->client->call(
             Client::METHOD_PATCH,
             '/presences/' . $presenceId,

--- a/tests/e2e/Services/Presences/PresenceConsoleClientTest.php
+++ b/tests/e2e/Services/Presences/PresenceConsoleClientTest.php
@@ -199,10 +199,41 @@ final class PresenceConsoleClientTest extends Scope
             ]
         );
 
-        $connected = \json_decode($client->receive(), true);
-        $this->assertSame('connected', $connected['type'] ?? null);
+        $this->receiveConnected($client);
 
         return $client;
+    }
+
+    private function receiveConnected(WebSocketClient $client, int $timeoutMs = 3000): void
+    {
+        $deadline = \microtime(true) + ($timeoutMs / 1000);
+        $lastFrame = [];
+
+        while (\microtime(true) < $deadline) {
+            try {
+                $raw = $client->receive();
+            } catch (TimeoutException) {
+                continue;
+            }
+
+            $frame = \json_decode($raw, true);
+            if (!\is_array($frame)) {
+                continue;
+            }
+
+            $lastFrame = $frame;
+            if (($frame['type'] ?? null) === 'error') {
+                $this->fail('Realtime handshake returned error: ' . \json_encode($frame));
+            }
+            if (($frame['type'] ?? null) === 'connected') {
+                return;
+            }
+        }
+
+        $this->fail(
+            'Timed out waiting for connected websocket frame on console. Last frame: '
+            . \json_encode($lastFrame)
+        );
     }
 
     private function receivePresenceFrame(

--- a/tests/e2e/Services/Presences/PresenceConsoleClientTest.php
+++ b/tests/e2e/Services/Presences/PresenceConsoleClientTest.php
@@ -208,7 +208,6 @@ final class PresenceConsoleClientTest extends Scope
     private function receiveConnected(WebSocketClient $client, int $timeoutMs = 3000): void
     {
         $deadline = \microtime(true) + ($timeoutMs / 1000);
-        $lastFrame = [];
 
         while (\microtime(true) < $deadline) {
             try {
@@ -222,19 +221,15 @@ final class PresenceConsoleClientTest extends Scope
                 continue;
             }
 
-            $lastFrame = $frame;
-            if (($frame['type'] ?? null) === 'error') {
-                $this->fail('Realtime handshake returned error: ' . \json_encode($frame));
-            }
-            if (($frame['type'] ?? null) === 'connected') {
-                return;
-            }
+            $this->assertSame(
+                'connected',
+                $frame['type'] ?? null,
+                'First realtime frame must be the handshake, got: ' . \json_encode($frame)
+            );
+            return;
         }
 
-        $this->fail(
-            'Timed out waiting for connected websocket frame on console. Last frame: '
-            . \json_encode($lastFrame)
-        );
+        $this->fail('Timed out waiting for connected websocket frame on console.');
     }
 
     private function receivePresenceFrame(

--- a/tests/e2e/Services/Presences/PresenceExpiryTest.php
+++ b/tests/e2e/Services/Presences/PresenceExpiryTest.php
@@ -80,23 +80,30 @@ final class PresenceExpiryTest extends Scope
             (new \DateTime($expireServer['body']['expiresAt']))->getTimestamp()
         );
 
-        \sleep(3);
+        $headers = [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+            'x-appwrite-key' => $this->getPresenceApiKey(),
+        ];
+
+        // Wait until expiresAt is in the past, then run maintenance and observe cleanup.
+        $this->assertEventually(function () use ($expiresAt) {
+            $this->assertGreaterThan(
+                (new \DateTime($expiresAt))->getTimestamp(),
+                (new \DateTime())->getTimestamp()
+            );
+        }, 30000, 50);
 
         $stdout = '';
         $stderr = '';
         $code = Console::execute('docker exec appwrite maintenance --type=trigger', '', $stdout, $stderr);
         $this->assertSame(0, $code, "Maintenance command failed with code $code: $stderr ($stdout)");
 
-        // Maintenance + delete workers are asynchronous; give extra time to observe cleanup.
-        $this->assertEventually(function () use ($presenceIdServer, $projectId) {
+        $this->assertEventually(function () use ($presenceIdServer, $headers) {
             $getServer = $this->client->call(
                 Client::METHOD_GET,
                 '/presences/' . $presenceIdServer,
-                [
-                    'content-type' => 'application/json',
-                    'x-appwrite-project' => $projectId,
-                    'x-appwrite-key' => $this->getPresenceApiKey(),
-                ]
+                $headers
             );
 
             $this->assertEquals(404, $getServer['headers']['status-code']);

--- a/tests/e2e/Services/Presences/PresenceExpiryTest.php
+++ b/tests/e2e/Services/Presences/PresenceExpiryTest.php
@@ -39,8 +39,6 @@ final class PresenceExpiryTest extends Scope
     {
         $projectId = $this->getProject()['$id'];
         $userId = $this->getUser()['$id'];
-        // Set a near-future expiry to satisfy validation, then wait until it is in the past.
-        $expiresAt = DateTime::format((new \DateTime())->modify('+2 seconds'));
 
         $createServer = $this->client->call(
             Client::METHOD_PUT,
@@ -60,6 +58,9 @@ final class PresenceExpiryTest extends Scope
         $this->assertEquals(200, $createServer['headers']['status-code']);
         $presenceIdServer = $createServer['body']['$id'];
 
+        // Compute expiry immediately before PATCH. The API requires a future
+        // datetime; stamping it before create can already be in the past under load.
+        $expiresAt = DateTime::format((new \DateTime())->modify('+2 seconds'));
         $expireServer = $this->client->call(
             Client::METHOD_PATCH,
             '/presences/' . $presenceIdServer,

--- a/tests/e2e/Services/Presences/PresenceRealtimeClientTest.php
+++ b/tests/e2e/Services/Presences/PresenceRealtimeClientTest.php
@@ -81,12 +81,7 @@ final class PresenceRealtimeClientTest extends Scope
             ]
         );
 
-        $connected = $this->receiveUntil(
-            $client,
-            fn (array $message): bool => ($message['type'] ?? null) === 'connected',
-            timeoutMs: \max(800, $timeout * 1000)
-        );
-        $this->assertSame('connected', $connected['type'] ?? null);
+        $this->receiveConnected($client, \max(800, $timeout * 1000));
 
         if (empty($channels)) {
             return $client;
@@ -106,6 +101,32 @@ final class PresenceRealtimeClientTest extends Scope
         $this->assertNotEmpty($subscribeResponse['data']['subscriptions'] ?? []);
 
         return $client;
+    }
+
+    private function receiveConnected(WebSocketClient $client, int $timeoutMs = 800): void
+    {
+        $deadline = \microtime(true) + ($timeoutMs / 1000);
+
+        while (\microtime(true) < $deadline) {
+            try {
+                $message = \json_decode($client->receive(), true);
+            } catch (TimeoutException) {
+                continue;
+            }
+
+            if (!\is_array($message)) {
+                continue;
+            }
+
+            $this->assertSame(
+                'connected',
+                $message['type'] ?? null,
+                'First realtime frame must be the handshake, got: ' . \json_encode($message)
+            );
+            return;
+        }
+
+        $this->fail('Timed out waiting for connected websocket handshake.');
     }
 
     private function receiveUntil(

--- a/tests/e2e/Services/Presences/PresenceRealtimeClientTest.php
+++ b/tests/e2e/Services/Presences/PresenceRealtimeClientTest.php
@@ -81,7 +81,11 @@ final class PresenceRealtimeClientTest extends Scope
             ]
         );
 
-        $connected = \json_decode($client->receive(), true);
+        $connected = $this->receiveUntil(
+            $client,
+            fn (array $message): bool => ($message['type'] ?? null) === 'connected',
+            timeoutMs: \max(800, $timeout * 1000)
+        );
         $this->assertSame('connected', $connected['type'] ?? null);
 
         if (empty($channels)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes a flaky Presences E2E job (`Tests / E2E / PostgreSQL (dedicated) / Presences`) caused by a realtime handshake race, not by broken main.

Failed example: [run 32718699783](https://github.com/appwrite/appwrite/actions/runs/32718699783) on `2772486a` — the same SHA later passed on other CI events.

### Root cause

The failing assertion was:

```
PresenceConsoleClientTest::testConsolePresenceUpsertAndUpdateBroadcastRealtime
Failed asserting that two strings are identical.
-'connected'
+'event'
PresenceConsoleClientTest.php:203
```

That test opens a websocket **with URL channels already set** (`presences` + `presences.{id}`) on the **shared console project**. Paratest runs 4 processes against the same console presence stream.

`onOpen` used to:

1. `subscribe()` the connection into the in-memory delivery tree
2. Call `updateStats()` / `triggerStats()` (platform DB read + usage queue — **coroutine yield** under `SWOOLE_HOOK_ALL`)
3. Only then send the `connected` frame

While that coroutine is yielded, the pub/sub worker can deliver a concurrent `presences` event from another test. The client’s first `receive()` then sees `event` instead of `connected`. Isolated-project realtime tests do not hit this because they do not share the console firehose.

This is why it only fails sometimes, and more often under concurrent CI load.

The hypothesized HTTP DELETE + websocket close duplicate-event race is a false synchronization comment, but it did not fail this run: `onClose` only emits delete events for IDs actually removed by `deleteDocuments`, so an already-deleted HTTP row does not re-fire.

Benchmark `CreateArtifact` JSON errors are a separate infra issue and are not addressed here.

### Fix

- Send `connected` **before** registering subscriptions and before `updateStats()`. Generate subscription IDs first so the handshake payload is unchanged.
- Presence handshake tests assert the **first JSON frame is `connected`** (the original flake). Timeout / non-JSON frames are ignored; an `event` first fails the test.
- Expiry tests stamp `expiresAt` immediately before PATCH (the API requires a future datetime; computing it before upsert can already be past under load), then wait until it is in the past before running maintenance (no fixed `sleep(3)`).

## Test Plan

- [x] Root-cause confirmed from job logs (first frame `event` vs `connected` on console handshake).
- [x] CI on `28644e200d`: all 46 checks passed, including `Tests / E2E / PostgreSQL (dedicated) / Presences` ([job 97676970149](https://github.com/appwrite/appwrite/actions/runs/32806212979/job/97676970149)).
- [x] VM E2E (this environment), CI-equivalent command:

```
docker compose exec -T appwrite vendor/bin/paratest --processes "$(nproc)" --functional \
  /usr/src/code/tests/e2e/Services/Presences \
  --exclude-group abuseEnabled --exclude-group screenshots --exclude-group antivirus
```

`nproc` = 4. PostgreSQL dedicated, development/testing image, Appwrite + Executor up.

| Batch | What | Result |
| --- | --- | --- |
| 1 | 12 full suites | 12/12 pass |
| 2 | 20 `PresenceConsoleClientTest.php` (18 tests, 4 processes) | 20/20 pass |
| 3 | 8 full suites with original first-frame `assertSame('connected', …)` | 8/8 pass; `'connected'` vs `'event'` did not fire |
| 4 | 20 console-file first-frame runs | 19/20 pass; 0 handshake failures. One PATCH 400 from past `expiresAt` |
| 5 | Stamp `expiresAt` immediately before PATCH (`dcdda5fb65`), 8 more full suites | 8/8 pass |
| 6 | Restore first-frame handshake assertion (`b8c1ed1226`); 8 full suites after recreating PHP services | **8/8 pass**; original `'event'`-first assertion did not fire |

A degraded-Postgres stretch immediately after push (HY000 server closed the connection; project create 500s) is not the handshake race. After recreate, the committed first-frame tests were green for 8 consecutive full suites.

Divergences from GitHub Actions: local `appwrite-dev` build (not ECR cache); Docker `vfs` storage (nested overlay); session-only `bridge-nf-call-iptables=0`; later runs used `nofile=65536`. Test command, 4 processes, PostgreSQL dedicated, and `--functional` match CI.

## Related PRs and Issues

- Flaky main push: https://github.com/appwrite/appwrite/actions/runs/32718699783

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55882be4-04fa-465d-825f-d818c1dc68c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55882be4-04fa-465d-825f-d818c1dc68c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

