### PR TITLE
fix(abuse): handle object params in rate-limit key building

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -919,7 +919,7 @@ Http::shutdown()
 
             foreach ($request->getParams() as $key => $value) { // Set request params as potential abuse keys
                 if (! empty($value)) {
-                    $timeLimit->setParam('{param-' . $key . '}', (\is_array($value)) ? \json_encode($value) : $value);
+                    $timeLimit->setParam('{param-' . $key . '}', (\is_array($value) || \is_object($value)) ? \json_encode($value) : $value);
                 }
             }
 

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -539,7 +539,7 @@ Http::init()
 
                 foreach ($request->getParams() as $key => $value) {
                     if (! empty($value)) {
-                        $timeLimit->setParam('{param-' . $key . '}', (\is_array($value)) ? \json_encode($value) : $value);
+                        $timeLimit->setParam('{param-' . $key . '}', (\is_array($value) || \is_object($value)) ? \json_encode($value) : $value);
                     }
                 }
 

--- a/tests/e2e/Services/Account/AccountBase.php
+++ b/tests/e2e/Services/Account/AccountBase.php
@@ -139,6 +139,31 @@ trait AccountBase
         ];
     }
 
+    /**
+     * Regression: the abuse hook stringifies every request param into the
+     * rate-limit key. An empty JSON object in the body decodes to a stdClass,
+     * which used to be passed straight to the string-only setParam() and threw
+     * a TypeError before the action ran. The request must succeed instead of
+     * returning a 500.
+     */
+    public function testCreateAccountWithObjectParam(): void
+    {
+        $response = $this->client->call(Client::METHOD_POST, '/account', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ]), [
+            'userId' => ID::unique(),
+            'email' => uniqid() . 'objectparam@localhost.test',
+            'password' => 'password',
+            'name' => 'User Name',
+            'metadata' => (object) [], // serializes to `{}`, decoded as stdClass
+        ]);
+
+        $this->assertEquals(201, $response['headers']['status-code']);
+        $this->assertNotEmpty($response['body']['$id']);
+    }
+
     public function testEmailOTPSession(): void
     {
         $isConsoleProject = $this->getProject()['$id'] === 'console';


### PR DESCRIPTION
## Problem

Requests were crashing in the abuse / rate-limit hook with:

```
TypeError: Utopia\Abuse\Adapter::setParam(): Argument #2 ($value) must be of type string, stdClass given,
called in app/controllers/shared/api.php on line 542
and defined in vendor/utopia-php/abuse/src/Abuse/Adapter.php:35
```

## Root cause

The abuse hook (`Http::init()`, `groups(['api'])`) builds a rate-limit key by registering **every** request param as a `TimeLimit` template value:

```php
foreach ($request->getParams() as $key => $value) {
    if (! empty($value)) {
        $timeLimit->setParam('{param-' . $key . '}', (\is_array($value)) ? \json_encode($value) : $value);
    }
}
```

`Adapter::setParam(string $key, string $value)` only accepts a **string**, so any non-scalar param must be `json_encode`d first. The code only guarded the `is_array()` case — but a param can also be a `stdClass`, which fell straight through to `setParam()` and threw.

### Where the `stdClass` comes from

The framework's `Request::decodePayload()` (`vendor/utopia-php/http/src/Http/Request.php`) normally decodes bodies as associative arrays (`json_decode($raw, true)`). PHP, however, cannot distinguish an empty JSON object `{}` from an empty array `[]` once decoded that way — both become `[]` and re-encode as `[]`.

To preserve `{}` vs `[]` fidelity, `decodePayload()` takes a special path whenever the raw body contains `{}`: it decodes into objects and runs `toAssociative()`, which converts everything back to arrays **except empty objects, which it intentionally keeps as `stdClass`**:

```php
return $properties === [] ? $value : array_map($this->toAssociative(...), $properties);
//                          ^^^^^^ empty {} deliberately stays a stdClass
```

So a request body carrying an empty object (e.g. `{"config": {}}`) yields a param whose value is a `stdClass`. Non-empty objects become arrays and were handled; empty objects were not — hence the crash.

## Fix

Treat objects the same as arrays and JSON-encode them before passing to `setParam()`:

```php
$timeLimit->setParam('{param-' . $key . '}', (\is_array($value) || \is_object($value)) ? \json_encode($value) : $value);
```

The `stdClass` is a legitimate, intended value from the framework, so the correct place to handle it is the consumer. The same param loop is duplicated in the `abuse-reset` shutdown hook, which had the identical bug — a successful request with an object param would throw there before `$abuse->reset()` ran, leaving stale rate-limit state — so both hooks are fixed.

## Testing

Added `testCreateAccountWithObjectParam` in `tests/e2e/Services/Account/AccountBase.php` as a regression test. It's an E2E test because the abuse hook is HTTP middleware and the `stdClass` originates in vendored framework code — neither is a `src/` library eligible for a unit test.

How it reproduces the bug:

- Sends `POST /v1/account` (a rate-limited route, `abuse-limit` 10) with an extra body param `metadata` set to `(object) []`.
- The E2E Client `json_encode`s the body, so `metadata` serializes to a literal `{}`. The framework's `decodePayload()` sees `{}`, takes the `toAssociative()` path, and preserves the empty object as a `stdClass` (as described above).
- The abuse init hook iterates over **all** request params — including undeclared ones like `metadata`, which the route itself ignores — and `empty()` is always `false` for an object, so it isn't skipped. Before the fix this passed the `stdClass` straight to `setParam()` and threw a `TypeError`, returning a 500 before the action ran.
- The test asserts `201`, proving the hook now tolerates object params and the request completes normally.

```php
$response = $this->client->call(Client::METHOD_POST, '/account', [...], [
    'userId' => ID::unique(),
    'email' => uniqid() . 'objectparam@localhost.test',
    'password' => 'password',
    'name' => 'User Name',
    'metadata' => (object) [], // serializes to `{}`, decoded as stdClass
]);
$this->assertEquals(201, $response['headers']['status-code']);
```

- `composer lint` → passed on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
