### PR TITLE
fix: reject non-string resource tokens

### DIFF
--- a/app/init/resources/request.php
+++ b/app/init/resources/request.php
@@ -1089,6 +1089,10 @@ return function (Container $context): void {
     $context->set('resourceToken', function ($project, $dbForProject, $request, Authorization $authorization) {
         $tokenJWT = $request->getParam('token');
 
+        if (! \is_string($tokenJWT)) {
+            return new Document([]);
+        }
+
         if (! empty($tokenJWT) && ! $project->isEmpty()) { // JWT authentication
             // Use a large but reasonable maxAge to avoid auto-exp when token has no expiry
             $jwt = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), RESOURCE_TOKEN_ALGORITHM, RESOURCE_TOKEN_MAX_AGE, RESOURCE_TOKEN_LEEWAY); // Instantiate with key, algo, maxAge and leeway.

--- a/tests/e2e/Services/Tokens/TokensBase.php
+++ b/tests/e2e/Services/Tokens/TokensBase.php
@@ -191,6 +191,26 @@ trait TokensBase
         $this->assertEquals('No permissions provided for action \'read\'', $failedDownload['body']['message']);
     }
 
+    public function testPreviewFileWithInvalidTokenType(): void
+    {
+        $data = $this->setupBucketAndFile();
+        $fileId = $data['fileId'];
+        $bucketId = $data['bucketId'];
+        $guestHeaders = $data['guestHeaders'];
+
+        $response = $this->client->call(
+            Client::METHOD_GET,
+            '/storage/buckets/' . $bucketId . '/files/' . $fileId . '/preview',
+            $guestHeaders,
+            [
+                'token' => ['invalid']
+            ]
+        );
+
+        $this->assertEquals(400, $response['headers']['status-code']);
+        $this->assertEquals('general_argument_invalid', $response['body']['type']);
+    }
+
     public function testPreviewFileWithToken(): void
     {
         $data = $this->setupBucketAndFile();


### PR DESCRIPTION
## What does this PR do?

Validates that the resource token request parameter is a string before passing it to the JWT decoder.

Array-shaped `token` parameters were being resolved by the per-request `resourceToken` dependency before route parameter validation. This passed an array to `JWT::decode()` and raised an uncaught `TypeError`, returning a 500 response. Non-string values are now treated as invalid resource tokens, allowing normal endpoint validation to return a client error.

Adds an E2E regression test covering an array-shaped token on a file preview request.

## Test Plan

- `composer lint app/init/resources/request.php tests/e2e/Services/Tokens/TokensBase.php`
- `docker compose exec appwrite test tests/e2e/Services/Tokens`
  - 32 tests, 285 assertions

## Related PRs and Issues

- [Sentry CLOUD-3QGV](https://appwrite.sentry.io/issues/7690538355/)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
