### PR TITLE
chore: bump utopia-php/audit to 4.0.0 and utopia-php/usage to 0.15.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
         "appwrite/php-clamav": "2.0.*",
         "utopia-php/abuse": "2.0.*",
         "utopia-php/agents": "2.*",
-        "utopia-php/audit": "3.0.*",
+        "utopia-php/audit": "^4.0",
         "utopia-php/auth": "^0.10",
         "utopia-php/balancer": "0.4.*",
         "utopia-php/cache": "^5.0.0",
@@ -138,7 +138,7 @@
         "utopia-php/client": "^0.3.0",
         "open-runtimes/sdk-for-php": "0.11.*",
         "utopia-php/schedule": "^0.2.0",
-        "utopia-php/usage": "^0.14.0"
+        "utopia-php/usage": "^0.15.0"
     },
     "require-dev": {
         "ext-fileinfo": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c48f8231c05f749a35f140580a2c4c8",
+    "content-hash": "9481b6eabc4b962abea525da82d4e962",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3042,23 +3042,23 @@
         },
         {
             "name": "utopia-php/audit",
-            "version": "3.0.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/audit.git",
-                "reference": "2cec3e0204a10c68f4a38300bb27bbcf1a7c77e0"
+                "reference": "0c093d9ad0a22a5008c292fc138cf523d3ce35e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/audit/zipball/2cec3e0204a10c68f4a38300bb27bbcf1a7c77e0",
-                "reference": "2cec3e0204a10c68f4a38300bb27bbcf1a7c77e0",
+                "url": "https://api.github.com/repos/utopia-php/audit/zipball/0c093d9ad0a22a5008c292fc138cf523d3ce35e1",
+                "reference": "0c093d9ad0a22a5008c292fc138cf523d3ce35e1",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.5",
                 "utopia-php/database": "^7.0.0",
                 "utopia-php/fetch": "^1.1",
-                "utopia-php/query": "0.1.*",
+                "utopia-php/query": "0.6.*",
                 "utopia-php/validators": "^0.5"
             },
             "type": "library",
@@ -3081,9 +3081,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/audit/issues",
-                "source": "https://github.com/utopia-php/audit/tree/3.0.2"
+                "source": "https://github.com/utopia-php/audit/tree/4.0.0"
             },
-            "time": "2026-08-14T06:49:12+00:00"
+            "time": "2026-08-25T06:08:58+00:00"
         },
         {
             "name": "utopia-php/auth",
@@ -4525,24 +4525,27 @@
         },
         {
             "name": "utopia-php/query",
-            "version": "0.1.1",
+            "version": "0.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/query.git",
-                "reference": "964a10ed3185490505f4c0062f2eb7b89287fb27"
+                "reference": "abaebb2f3426bdbc6f44bab04254a668de937148"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/query/zipball/964a10ed3185490505f4c0062f2eb7b89287fb27",
-                "reference": "964a10ed3185490505f4c0062f2eb7b89287fb27",
+                "url": "https://api.github.com/repos/utopia-php/query/zipball/abaebb2f3426bdbc6f44bab04254a668de937148",
+                "reference": "abaebb2f3426bdbc6f44bab04254a668de937148",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4"
             },
             "require-dev": {
+                "brianium/paratest": "*",
                 "laravel/pint": "*",
+                "mongodb/mongodb": "^2.0",
                 "phpstan/phpstan": "*",
+                "phpunit/phpcov": "*",
                 "phpunit/phpunit": "^12.0"
             },
             "type": "library",
@@ -4565,9 +4568,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/query/issues",
-                "source": "https://github.com/utopia-php/query/tree/0.1.1"
+                "source": "https://github.com/utopia-php/query/tree/0.6.0"
             },
-            "time": "2026-03-03T09:05:14+00:00"
+            "time": "2026-08-21T11:03:36+00:00"
         },
         {
             "name": "utopia-php/queue",
@@ -5034,16 +5037,16 @@
         },
         {
             "name": "utopia-php/usage",
-            "version": "0.14.0",
+            "version": "0.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/usage.git",
-                "reference": "baeef33bbcb673265550c83fe437cfa5c400a1e0"
+                "reference": "e710b16a08a9dc184906c5b8cf698546238c7be0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/usage/zipball/baeef33bbcb673265550c83fe437cfa5c400a1e0",
-                "reference": "baeef33bbcb673265550c83fe437cfa5c400a1e0",
+                "url": "https://api.github.com/repos/utopia-php/usage/zipball/e710b16a08a9dc184906c5b8cf698546238c7be0",
+                "reference": "e710b16a08a9dc184906c5b8cf698546238c7be0",
                 "shasum": ""
             },
             "require": {
@@ -5051,7 +5054,7 @@
                 "psr/http-client": "^1.0",
                 "utopia-php/client": "^0.3",
                 "utopia-php/database": "^7.0.0",
-                "utopia-php/query": "0.1.*"
+                "utopia-php/query": "0.6.*"
             },
             "require-dev": {
                 "laravel/pint": "1.*",
@@ -5081,9 +5084,9 @@
             "description": "Light and Fast Usage library",
             "support": {
                 "issues": "https://github.com/utopia-php/usage/issues",
-                "source": "https://github.com/utopia-php/usage/tree/0.14.0"
+                "source": "https://github.com/utopia-php/usage/tree/0.15.0"
             },
-            "time": "2026-08-05T04:25:00+00:00"
+            "time": "2026-08-25T05:10:14+00:00"
         },
         {
             "name": "utopia-php/user-agent",
@@ -8552,5 +8555,5 @@
     "platform-dev": {
         "ext-fileinfo": "*"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Appwrite/Platform/Modules/Usage/Http/Action.php
+++ b/src/Appwrite/Platform/Modules/Usage/Http/Action.php
@@ -6,6 +6,7 @@ use Appwrite\Extend\Exception;
 use Utopia\Platform\Action as PlatformAction;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Query\Exception as QueryException;
+use Utopia\Query\Method as QueryMethod;
 use Utopia\Query\Query;
 use Utopia\Usage\UsageQuery;
 
@@ -93,13 +94,14 @@ abstract class Action extends PlatformAction
      *
      * @param array<string> $queries Raw Utopia query strings from the request.
      * @param array<string> $allowedAttributes Attributes the endpoint accepts as filters.
-     * @param array<string> $allowedMethods Query::TYPE_* values the endpoint accepts.
+     * @param array<QueryMethod> $allowedMethods Query methods the endpoint accepts.
      * @return array<Query>
      * @throws Exception
      */
     protected function parseFilterQueries(array $queries, array $allowedAttributes, array $allowedMethods): array
     {
         $parsed = $this->parseQueries($queries);
+        $allowedMethodNames = \array_map(static fn (QueryMethod $method): string => $method->value, $allowedMethods);
 
         foreach ($parsed as $query) {
             $attribute = $query->getAttribute();
@@ -108,7 +110,7 @@ abstract class Action extends PlatformAction
             if ($attribute === '') {
                 throw new Exception(
                     Exception::GENERAL_QUERY_INVALID,
-                    "Structural queries (limit, offset, order, select, …) are not allowed in queries[]. Allowed methods: " . \implode(', ', $allowedMethods)
+                    "Structural queries (limit, offset, order, select, …) are not allowed in queries[]. Allowed methods: " . \implode(', ', $allowedMethodNames)
                 );
             }
 
@@ -122,7 +124,7 @@ abstract class Action extends PlatformAction
             if (!\in_array($method, $allowedMethods, true)) {
                 throw new Exception(
                     Exception::GENERAL_QUERY_INVALID,
-                    "Query method '{$method}' is not supported. Allowed: " . \implode(', ', $allowedMethods)
+                    "Query method '{$method->value}' is not supported. Allowed: " . \implode(', ', $allowedMethodNames)
                 );
             }
         }

--- a/src/Appwrite/Platform/Modules/Usage/Http/Events/XList.php
+++ b/src/Appwrite/Platform/Modules/Usage/Http/Events/XList.php
@@ -13,6 +13,7 @@ use Appwrite\Utopia\Response;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Datetime as DatetimeValidator;
 use Utopia\Platform\Enum;
+use Utopia\Query\Method as QueryMethod;
 use Utopia\Query\Query;
 use Utopia\System\System;
 use Utopia\Usage\Tenant;
@@ -56,7 +57,7 @@ class XList extends Action
     ];
 
     /**
-     * Query::TYPE_* values supported on the filter surface.
+     * Query methods supported on the filter surface.
      * Equality / set membership / null-presence on dimension columns and
      * string prefix-match on path-shaped fields are useful; we deliberately
      * skip numeric inequality and full-text search since time range has its
@@ -64,13 +65,13 @@ class XList extends Action
      * these LowCardinality(String) columns.
      */
     protected const VALID_FILTER_METHODS = [
-        Query::TYPE_EQUAL,
-        Query::TYPE_NOT_EQUAL,
-        Query::TYPE_CONTAINS,
-        Query::TYPE_STARTS_WITH,
-        Query::TYPE_ENDS_WITH,
-        Query::TYPE_IS_NULL,
-        Query::TYPE_IS_NOT_NULL,
+        QueryMethod::Equal,
+        QueryMethod::NotEqual,
+        QueryMethod::Contains,
+        QueryMethod::StartsWith,
+        QueryMethod::EndsWith,
+        QueryMethod::IsNull,
+        QueryMethod::IsNotNull,
     ];
 
     public static function getName(): string

--- a/src/Appwrite/Platform/Modules/Usage/Http/Gauges/XList.php
+++ b/src/Appwrite/Platform/Modules/Usage/Http/Gauges/XList.php
@@ -12,6 +12,7 @@ use Appwrite\Utopia\Response;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Datetime as DatetimeValidator;
 use Utopia\Platform\Enum;
+use Utopia\Query\Method as QueryMethod;
 use Utopia\Query\Query;
 use Utopia\System\System;
 use Utopia\Usage\Tenant;
@@ -49,16 +50,16 @@ class XList extends Action
     protected const VALID_FILTER_ATTRIBUTES = ['service', 'resourceType', 'resourceId', 'ordinal'];
 
     /**
-     * Query::TYPE_* values supported on the filter surface. Gauges only
+     * Query methods supported on the filter surface. Gauges only
      * carry short low-cardinality string dimensions, so equality + null
      * presence is what makes sense; we skip contains/startsWith here since
      * they're rarely useful on values like 'bucket' / 'function'.
      */
     protected const VALID_FILTER_METHODS = [
-        Query::TYPE_EQUAL,
-        Query::TYPE_NOT_EQUAL,
-        Query::TYPE_IS_NULL,
-        Query::TYPE_IS_NOT_NULL,
+        QueryMethod::Equal,
+        QueryMethod::NotEqual,
+        QueryMethod::IsNull,
+        QueryMethod::IsNotNull,
     ];
 
     public static function getName(): string


### PR DESCRIPTION
## What does this PR do?

Bumps `utopia-php/audit` to **4.0.0** and `utopia-php/usage` to **0.15.0**.

Both libraries moved to `utopia-php/query` **0.6**, which replaces the `Query::TYPE_*` string constants with the `Utopia\Query\Method` enum.

**They have to move together.** Audit 4.0 and usage 0.15 both require `utopia-php/query: 0.6.*`, while the currently locked audit 3.0.2 and usage 0.14.0 both require `0.1.*`. Bumping either one alone leaves the tree unresolvable:

```
utopia-php/audit 4.0.0 requires utopia-php/query 0.6.*
  -> found utopia-php/query[0.6.0] but these were not loaded,
     likely because it conflicts with another require.
```

(Note `"utopia-php/usage": "^0.14.0"` excludes 0.15.0 — Composer's caret on a `0.x` version only allows the patch range.)

The lock diff is exactly three packages: `audit 3.0.2 → 4.0.0`, `usage 0.14.0 → 0.15.0`, `query 0.1.1 → 0.6.0`. Nothing else moves.

### Code changes

The audit surface needed no changes — CE only calls `new Audit(new AdapterDatabase($db))` and `->setup()`, and both signatures are identical between 3.0.2 and 4.0.0.

The usage endpoints did need adapting, in `src/Appwrite/Platform/Modules/Usage/Http/`:

- `VALID_FILTER_METHODS` in `Events/XList.php` and `Gauges/XList.php` referenced `Query::TYPE_EQUAL` and friends. Those constants no longer exist in query 0.6, so accessing them throws `Error: Undefined constant`. They now hold `Method` enum cases.
- `Action.php::parseFilterQueries()` compared `$query->getMethod()` — now a `Method` enum — against that list of strings with `in_array(..., true)`. That comparison is **always false**, so once the constants existed again every filter query on `/usage/events` and `/usage/gauges` would have been rejected with `GENERAL_QUERY_INVALID`. It now compares enum to enum, and the error messages render `$method->value` (interpolating the enum itself would have been a `TypeError`).

## Test Plan

Run against the branch, with vendor installed from the updated lock:

- `composer validate --strict` — passes; lock is in sync with `composer.json`.
- `composer check` (phpstan, full config) — **No errors**. Before the code changes it reported 13, which is how the two issues above were found.
- `composer lint` (pint) on the three changed files — passes.
- `vendor/bin/phpunit tests/unit/Platform` — 254 tests, 832 assertions, all pass.

Every CE call site into both libraries was checked against the released tags: `Audit::__construct`, `Audit::setup`, `Adapter\Database::__construct`, and `UsageQuery::{parse,aggregate,groupBy,groupByInterval}` are unchanged. `UsageQuery::parse()` is inherited from the base `Query`, and its new `$allowRaw` argument is defaulted, so the existing call still resolves. The nine `UsageQuery` statics removed in 0.15.0 (`extractGroupBy`, `isAggregate`, `removeGroupBy`, …) have no callers in CE.

Worth a reviewer's eye on the filter-method change specifically, since that path is only covered by e2e tests, which need a running stack.

## Related PRs and Issues

- utopia-php/monorepo#91 — audit migration to query 0.6 (released as audit 4.0.0)
- utopia-php/usage#4 — usage migration to query 0.6 (released as usage 0.15.0)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? — no API metadata changed; the filter surface accepts the same set of methods as before.
