### PR TITLE
fix(http): probe the database in the loop that waits for it

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -204,6 +204,13 @@ function createDatabase(Container $resources, string $resourceKey, string $dbNam
             $resource = $resources->get($resourceKey);
             /* @var $database Database */
             $database = is_callable($resource) ? $resource() : $resource;
+
+            // Building a handle reaches no backend, so this loop has to ask for
+            // a connection to learn whether one can be had. Without it the loop
+            // breaks on the first pass against a database still starting, and
+            // the wait it is here to perform falls to the create() retry below.
+            $database->ping();
+
             break; // exit loop on success
         } catch (\Throwable $e) {
             Console::warning("  └── Database not ready ({$dbName}). Retrying connection ({$attempts}): " . $e->getMessage());


### PR DESCRIPTION
## What

`createDatabase()` waits for a database to accept connections by building its handle in a try/catch and retrying, up to 15 times with a 2s sleep:

```php
while (true) {
    try {
        $resource = $resources->get($resourceKey);
        $database = is_callable($resource) ? $resource() : $resource;
        break; // exit loop on success
    } catch (\Throwable $e) {
        Console::warning("  └── Database not ready ({$dbName}). Retrying connection ({$attempts}): " . ...);
        sleep($sleep);
    }
}
```

Nothing in that `try` asks the database for anything. It worked because building a handle *used* to dial: `Utopia\Database\Adapter\Pool::setTimeout()` checked a connection out, so calling `->setTimeout(...)` while constructing the handle was the connectivity probe this loop was reading — by accident, but reliably.

[utopia-php/database#945](https://github.com/utopia-php/database/pull/945), released in **7.2.7**, stops that dial. Every concrete adapter records a timeout locally and applies it to the SQL it builds afterwards; none contacts the server. Opening a connection to set one only meant that *building a handle* failed while a backing was unreachable, reporting a database as down to a caller that had issued no query. (In Appwrite Cloud that was 196k Sentry events in 25 days from a worker call that constructs a handle and nothing else.)

This branch is on `"utopia-php/database": "^7.0.0"`, locked at 7.2.6, so the next dependency update takes 7.2.7.

## Why fix it now, if nothing is broken

Nothing breaks today, and I want to be precise about that rather than overstate it. Once 7.2.7 lands, this loop breaks on its first pass against a database that is still starting, and its `"Database not ready"` warning can never fire. The boot still survives, because the `create()` retry immediately below catches the connection error and waits there instead — I verified that rather than assuming it:

```
loop1 breaks immediately (no dial): true [dials=0]
create() threw PDOException
caught by CE's catch (\Exception): true
is a Duplicate (would break, not retry): false
```

So the wait silently relocates to a different loop with a different budget (15×2s there, versus this one's 15×2s — same here, but they are independent), and the loop written for the job stops doing it. This restores it.

Appwrite Cloud has the same function and did **not** survive, because its `create()` is a bare `try/catch` that swallows and continues rather than a retry loop. There the container crash-looped on boot until MySQL came up, killing an exec'd spec generation with SIGKILL. Fixed there in appwrite-labs/cloud#5438 with this same one-liner, verified in CI: container `RestartCount=0`, the loop logs the two retries it exists to perform, specs generate on the first attempt.

## Verification

- `Database::ping()` exists on both 7.2.6 and 7.2.7 (`Database.php:1643`, delegating through `Pool::ping()`), so this is safe before and after the bump.
- Pint clean.

## Not verified

- **No test covers this line.** It is boot code in `app/http.php`, reachable only by starting the server; no unit test can drive it. What exercised the equivalent change in cloud was a CI job that boots a container against a cold MySQL — appwrite/appwrite has no comparable job that I found, so this rests on the component-level check quoted above plus the cloud result, not on a red-then-green run in this repo.
- **I could not boot a real CE container against a cold MySQL** to confirm end to end; Docker was unavailable on my machine at the time. The claim that CE survives 7.2.7 without this change is reasoning plus the component test, not a live run.