### PR TITLE
chore: bump appwrite/browser to 0.3.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1480,7 +1480,7 @@ services:
       - _APP_ASSISTANT_OPENAI_API_KEY
   appwrite-browser:
     container_name: appwrite-browser
-    image: appwrite/browser:0.3.3
+    image: appwrite/browser:0.3.4
     networks:
       - appwrite
 


### PR DESCRIPTION
Bumps `appwrite/browser` 0.3.3 → 0.3.4.

0.3.4 is appwrite/docker-browser#17: Chromium relaunches when it dies instead of failing every subsequent capture with `Target page, context or browser has been closed` until the container is restarted, and `/v1/health` returns 503 while the browser is gone so a probe can act on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
