### PR TITLE
fix(vcs): require utopia-php/vcs ^5.2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,7 @@
         "utopia-php/telemetry": "^0.4",
         "utopia-php/user-agent": "0.1.*",
         "mustangostang/spyc": "0.6.*",
-        "utopia-php/vcs": "5.*.*",
+        "utopia-php/vcs": "^5.2.5",
         "utopia-php/websocket": "1.0.*",
         "dragonmantank/cron-expression": "3.4.*",
         "chillerlan/php-qrcode": "4.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c48f8231c05f749a35f140580a2c4c8",
+    "content-hash": "5a0cafb0613b8f7ca00d19903d5138bf",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -5169,16 +5169,16 @@
         },
         {
             "name": "utopia-php/vcs",
-            "version": "5.2.4",
+            "version": "5.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/vcs.git",
-                "reference": "b66555692fb8ac41d9e36c7e0929522cca439d4b"
+                "reference": "8e353113381328489b9a9a736156758c642c875c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/vcs/zipball/b66555692fb8ac41d9e36c7e0929522cca439d4b",
-                "reference": "b66555692fb8ac41d9e36c7e0929522cca439d4b",
+                "url": "https://api.github.com/repos/utopia-php/vcs/zipball/8e353113381328489b9a9a736156758c642c875c",
+                "reference": "8e353113381328489b9a9a736156758c642c875c",
                 "shasum": ""
             },
             "require": {
@@ -5220,10 +5220,10 @@
                 "vcs"
             ],
             "support": {
-                "source": "https://github.com/utopia-php/vcs/tree/5.2.4",
+                "source": "https://github.com/utopia-php/vcs/tree/5.2.5",
                 "issues": "https://github.com/utopia-php/vcs/issues"
             },
-            "time": "2026-08-21T13:45:11+00:00"
+            "time": "2026-08-25T09:26:43+00:00"
         },
         {
             "name": "utopia-php/websocket",
@@ -8552,5 +8552,5 @@
     "platform-dev": {
         "ext-fileinfo": "*"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Problem

`composer.lock` on `main` pins `utopia-php/vcs` **5.2.4** (`b66555692fb8`), the merge of utopia-php/monorepo#157. That release changed `GitHub::generateAccessToken()` to validate the PEM with `openssl_pkey_get_private()` and then pass the **raw string** to `new JWT(...)`. `adhocore/jwt` v1.1.4 reads a string key as a `file://` path, so a PEM string can never load:

```
Ahc\Jwt\JWTException: Invalid key: Should be resource of private key (code 12)
  vendor/adhocore/jwt/src/ValidatesJWT.php:126  validateKey
  vendor/adhocore/jwt/src/JWT.php:140           sign
  vendor/utopia-php/vcs/.../GitHub.php:663      encode
```

Every GitHub App installation-token mint throws, so `POST /v1/vcs/github/events`, `GET /v1/vcs/github/callback` and repository/branch listing all 500.

Not a flat 100% of requests: `initializeVariables()` short-circuits on a warm installation-token cache (`GITHUB_APP_JWT_EXPIRY - 60`, 8 min), so the failure recurs per installation on roughly an 8-minute cycle.

Secondary damage: uninstalling the GitHub App to work around the 500s fires the `installation.deleted` webhook, which clears `installationId`, `providerRepositoryId`, `providerBranch` and `repositoryId` from Functions and Sites. That path needs no GitHub token, so it succeeds while reinstall keeps failing.

## Fix

Require **^5.2.5** (`8e3531133813`, utopia-php/monorepo#160), which passes the parsed key object to the signer again while keeping 5.2.4's explicit error when the key is genuinely unreadable. 5.2.5 also adds a PHPStan stub correcting `adhocore/jwt`'s stale `string|resource` docblock, so the analyzer now rejects the string form rather than demanding it — that stale docblock is what made the 5.2.4 change look correct.

The constraint was `5.*.*`, so a build could resolve to any 5.x without anyone choosing it; that is how an untested minor reached a production build. `^5.2.5` sets a floor that keeps the broken release out.

## Verification

- Exactly one package moves in the lock: `utopia-php/vcs` 5.2.4 → 5.2.5. No other churn.
- Installed vendor tree confirmed to contain `new JWT($privateKeyObj, 'RS256')` — not just a lock diff.
- Drove the real installed adapter's `initializeVariables()` with a freshly generated 2048-bit PEM, doubling only the outbound HTTP call: it hits `/app/installations/{id}/access_tokens`, and the captured `Authorization` JWT verifies under RS256 against the matching public key.
- Reproduced the failure first: the same harness on 5.2.4 throws the exact production stack frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)