### PR TITLE
refactor: run the scheduler tasks on utopia-php/schedule

### DIFF
--- a/src/Appwrite/Platform/Tasks/Maintenance.php
+++ b/src/Appwrite/Platform/Tasks/Maintenance.php
@@ -6,6 +6,7 @@ use Appwrite\Certificates\Certificates;
 use Appwrite\Event\Message\Delete as DeleteMessage;
 use Appwrite\Event\Publisher\Certificate;
 use Appwrite\Event\Publisher\Delete as DeletePublisher;
+use Appwrite\Schedule\Source\Chores;
 use DateInterval;
 use DateTime;
 use Utopia\Console;
@@ -14,7 +15,9 @@ use Utopia\Database\DateTime as DatabaseDateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Query;
 use Utopia\Platform\Action;
+use Utopia\Schedule\Scheduler;
 use Utopia\System\System;
+use Utopia\Telemetry\Adapter as Telemetry;
 use Utopia\Validator\WhiteList;
 
 class Maintenance extends Action
@@ -34,10 +37,11 @@ class Maintenance extends Action
             ->inject('publisherForCertificates')
             ->inject('certificateIssuer')
             ->inject('publisherForDeletes')
+            ->inject('telemetry')
             ->callback($this->action(...));
     }
 
-    public function action(string $type, Database $dbForPlatform, Document $console, Certificate $publisherForCertificates, Certificates $certificateIssuer, DeletePublisher $publisherForDeletes): void
+    public function action(string $type, Database $dbForPlatform, Document $console, Certificate $publisherForCertificates, Certificates $certificateIssuer, DeletePublisher $publisherForDeletes, Telemetry $telemetry): void
     {
         Console::title('Maintenance V1');
         Console::success(APP_NAME . ' maintenance process v1 has started');
@@ -48,68 +52,128 @@ class Maintenance extends Action
         $schedulesDeletionRetention = (int) System::getEnv('_APP_MAINTENANCE_RETENTION_SCHEDULES', '86400'); // 1 Day
         $jobInitTime = System::getEnv('_APP_MAINTENANCE_START_TIME', '00:00'); // (hour:minutes)
 
+        // The next occurrence of the configured start time, which anchors the
+        // grid. Occurrences are anchor + k x interval, so the run stays pinned
+        // to that wall-clock time instead of drifting by however long each run
+        // takes, the way sleeping for the interval did.
         $now = new \DateTime();
         $now->setTimezone(new \DateTimeZone(date_default_timezone_get()));
         $next = new \DateTime($now->format("Y-m-d $jobInitTime"));
         $next->setTimezone(new \DateTimeZone(date_default_timezone_get()));
-        $delay = $next->getTimestamp() - $now->getTimestamp();
 
-        /**
-         * If time passed for the target day.
-         */
-        if ($delay <= 0) {
+        if ($next->getTimestamp() <= $now->getTimestamp()) {
             $next->add(\DateInterval::createFromDateString('1 days'));
-            $delay = $next->getTimestamp() - $now->getTimestamp();
         }
 
-        $action = function () use ($interval, $cacheRetention, $schedulesDeletionRetention, $usageStatsRetentionHourly, $dbForPlatform, $console, $publisherForDeletes, $publisherForCertificates, $certificateIssuer) {
-            $time = DatabaseDateTime::now();
+        // One entry per chore, not one closure over all of them. They share a
+        // cadence but nothing else: each enqueues to a different queue, and a
+        // failure in one says nothing about the next. Running them as one
+        // closure meant the first throw skipped every chore behind it -- and,
+        // under Console::loop, ended the loop for good.
+        $chores = [
+            'projects' => fn () => $this->notifyProjects($dbForPlatform, $publisherForDeletes, $usageStatsRetentionHourly),
+            'console' => fn () => $this->notifyConsole($console, $publisherForDeletes, $usageStatsRetentionHourly),
+            'connections' => fn () => $this->notifyDeleteConnections($publisherForDeletes),
+            'certificates' => fn () => $this->renewCertificates($dbForPlatform, $publisherForCertificates, $certificateIssuer),
+            'cache' => fn () => $this->notifyDeleteCache($cacheRetention, $publisherForDeletes),
+            'schedules' => fn () => $this->notifyDeleteSchedules($schedulesDeletionRetention, $publisherForDeletes),
+            'csv-exports' => fn () => $this->notifyDeleteCSVExports($publisherForDeletes),
+        ];
 
-            Console::info("[{$time}] Notifying workers with maintenance tasks every {$interval} seconds");
+        if ($type === 'trigger') {
+            foreach ($chores as $id => $chore) {
+                $this->chore($id, $chore);
+            }
 
-            // Iterate through project only if it was accessed in last 30 days
-            $dateInterval  = DateInterval::createFromDateString('30 days');
-            $before30days = (new DateTime())->sub($dateInterval);
-
-            $dbForPlatform->foreach(
-                'projects',
-                function (Document $project) use ($publisherForDeletes, $usageStatsRetentionHourly) {
-                    $publisherForDeletes->enqueue(new DeleteMessage(
-                        project: $project,
-                        type: DELETE_TYPE_MAINTENANCE,
-                        hourlyUsageRetentionDatetime: DatabaseDateTime::addSeconds(new \DateTime(), -1 * $usageStatsRetentionHourly),
-                    ));
-                },
-                [
-                    Query::equal('region', [System::getEnv('_APP_REGION', 'default')]),
-                    Query::greaterThanEqual('accessedAt', DatabaseDateTime::format($before30days)),
-                    Query::orderAsc('$sequence'), // accessedAt Can be updated during iteration
-                    Query::limit(1000),
-                ]
-            );
-
-            $publisherForDeletes->enqueue(new DeleteMessage(
-                project: $console,
-                type: DELETE_TYPE_MAINTENANCE,
-                hourlyUsageRetentionDatetime: DatabaseDateTime::addSeconds(new \DateTime(), -1 * $usageStatsRetentionHourly),
-            ));
-
-            $this->notifyDeleteConnections($publisherForDeletes);
-            $this->renewCertificates($dbForPlatform, $publisherForCertificates, $certificateIssuer);
-            $this->notifyDeleteCache($cacheRetention, $publisherForDeletes);
-            $this->notifyDeleteSchedules($schedulesDeletionRetention, $publisherForDeletes);
-            $this->notifyDeleteCSVExports($publisherForDeletes);
-        };
-
-        if ($type === 'loop') {
-            Console::info('Setting loop start time to ' . $next->format("Y-m-d H:i:s.v") . '. Delaying for ' . $delay . ' seconds.');
-
-            Console::loop(function () use ($action) {
-                $action();
-            }, $interval, $delay);
-        } elseif ($type === 'trigger') {
-            $action();
+            return;
         }
+
+        Console::info('Anchoring the maintenance grid to ' . $next->format('Y-m-d H:i:s.v') . ', every ' . $interval . ' seconds.');
+
+        $scheduler = new Scheduler(
+            source: new Chores(\array_keys($chores), $interval, \DateTimeImmutable::createFromMutable($next)),
+            // The chore set is a constant, so there is nothing to re-read.
+            syncSeconds: $interval,
+            // Deliberately left at its default, unlike the usage sweep: a
+            // maintenance run enqueues a delete for every project in the
+            // region, and replaying a missed day on every restart would be
+            // worse than skipping it -- which is what the old loop did.
+            telemetry: $telemetry,
+            onError: function (\Throwable $error): void {
+                Console::error('maintenance: reconcile failed: ' . $error->getMessage());
+            },
+        );
+
+        $scheduler->run(function (array $due) use ($chores): null {
+            foreach ($due as $occurrence) {
+                $chore = $chores[$occurrence->id] ?? null;
+
+                if ($chore === null) {
+                    continue;
+                }
+
+                $this->chore($occurrence->id, $chore);
+            }
+
+            return null;
+        });
+
+        // run() returns only if something stopped the loop. Say so loudly: a
+        // scheduler that has stopped scheduling still looks alive and Ready.
+        Console::error('maintenance: scheduler loop returned, scheduling has stopped');
+    }
+
+    /**
+     * Run one chore, containing its failure.
+     *
+     * Nothing dispatched may throw: the Scheduler records a dispatch error and
+     * rethrows it, which ends run() -- and the process then stays alive and
+     * idle, never exiting, so restartPolicy never fires.
+     *
+     * @param callable(): void $chore
+     */
+    private function chore(string $id, callable $chore): void
+    {
+        $time = DatabaseDateTime::now();
+
+        try {
+            $chore();
+        } catch (\Throwable $th) {
+            Console::error("[{$time}] maintenance chore '{$id}' failed, retrying next interval: " . $th->getMessage());
+        }
+    }
+
+    private function notifyProjects(Database $dbForPlatform, DeletePublisher $publisherForDeletes, int $usageStatsRetentionHourly): void
+    {
+        // Iterate through project only if it was accessed in last 30 days
+        $dateInterval = DateInterval::createFromDateString('30 days');
+        $before30days = (new DateTime())->sub($dateInterval);
+
+        $dbForPlatform->foreach(
+            'projects',
+            function (Document $project) use ($publisherForDeletes, $usageStatsRetentionHourly) {
+                $publisherForDeletes->enqueue(new DeleteMessage(
+                    project: $project,
+                    type: DELETE_TYPE_MAINTENANCE,
+                    hourlyUsageRetentionDatetime: DatabaseDateTime::addSeconds(new \DateTime(), -1 * $usageStatsRetentionHourly),
+                ));
+            },
+            [
+                Query::equal('region', [System::getEnv('_APP_REGION', 'default')]),
+                Query::greaterThanEqual('accessedAt', DatabaseDateTime::format($before30days)),
+                Query::orderAsc('$sequence'), // accessedAt Can be updated during iteration
+                Query::limit(1000),
+            ]
+        );
+    }
+
+    private function notifyConsole(Document $console, DeletePublisher $publisherForDeletes, int $usageStatsRetentionHourly): void
+    {
+        $publisherForDeletes->enqueue(new DeleteMessage(
+            project: $console,
+            type: DELETE_TYPE_MAINTENANCE,
+            hourlyUsageRetentionDatetime: DatabaseDateTime::addSeconds(new \DateTime(), -1 * $usageStatsRetentionHourly),
+        ));
     }
 
     private function notifyDeleteConnections(DeletePublisher $publisherForDeletes): void

--- a/src/Appwrite/Platform/Tasks/Schedule.php
+++ b/src/Appwrite/Platform/Tasks/Schedule.php
@@ -90,7 +90,7 @@ class Schedule extends Action
         $this->loop(fn () => (new ScheduleMessages())->action($publisherForMessaging, $getIsResourceBlocked, $dbForPlatform, $getProjectDB, $telemetry));
 
         if ($publisherForStatsResources !== null && $usageConnection !== null) {
-            $this->loop(fn () => (new StatsResources())->action($dbForPlatform, $publisherForStatsResources, $usageConnection));
+            $this->loop(fn () => (new StatsResources())->action($dbForPlatform, $publisherForStatsResources, $usageConnection, $telemetry));
         }
 
         while (true) {

--- a/src/Appwrite/Platform/Tasks/StatsResources.php
+++ b/src/Appwrite/Platform/Tasks/StatsResources.php
@@ -5,13 +5,16 @@ namespace Appwrite\Platform\Tasks;
 use Appwrite\Event\Message\StatsResources as StatsResourcesMessage;
 use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
 use Appwrite\Platform\Action;
+use Appwrite\Schedule\Source\Usage;
 use Appwrite\Usage\Concurrency;
 use Appwrite\Usage\Connection;
 use Utopia\Console;
 use Utopia\Database\Database;
-use Utopia\Database\DateTime;
-use Utopia\Database\Query;
+use Utopia\Database\Document;
+use Utopia\Schedule\Occurrence;
+use Utopia\Schedule\Scheduler;
 use Utopia\System\System;
+use Utopia\Telemetry\Adapter as Telemetry;
 
 class StatsResources extends Action
 {
@@ -31,57 +34,100 @@ class StatsResources extends Action
             ->inject('dbForPlatform')
             ->inject('publisherForStatsResources')
             ->inject('usageConnection')
+            ->inject('telemetry')
             ->callback($this->action(...));
     }
 
-    public function action(Database $dbForPlatform, StatsResourcesPublisher $publisherForStatsResources, Connection $usageConnection): void
+    public function action(Database $dbForPlatform, StatsResourcesPublisher $publisherForStatsResources, Connection $usageConnection, Telemetry $telemetry): void
     {
         if (!$usageConnection->isEnabled()) {
             Console::info('Usage statistics are disabled');
             return;
         }
 
-        $this->disableSubqueries();
-        // Floor of 1 guards against a zero/negative interval spinning the loop;
+        // Floor of 1 guards against a zero/negative cadence spinning the loop;
         // test stacks legitimately run short intervals (Cloud CI uses 2s).
         $interval = max(1, (int) System::getEnv('_APP_STATS_RESOURCES_INTERVAL', 3600));
 
-        Console::loop(function () use ($dbForPlatform, $publisherForStatsResources, $usageConnection): void {
-            // Nothing here may end the loop. An exception escaping this closure
-            // ends Console::loop, and the process then stays alive and idle: it
-            // never exits, so restartPolicy never fires, and with no liveness
-            // probe nothing observes that scheduling has stopped. A single
-            // transient ClickHouse timeout on one tick silently ended gauge
-            // collection for a whole region, and the task went on reporting
-            // Ready for weeks while queueing nothing.
-            try {
-                if (!$usageConnection->isReady()) {
-                    Console::error('stats resources: usage schema is not ready, skipping cycle');
-                    return;
-                }
+        $source = new Usage(
+            $dbForPlatform,
+            $interval,
+            System::getEnv('_APP_REGION', 'default'),
+        );
 
-                // Concurrency sampling reads the usage store; project scheduling
-                // reads the platform DB. They share no data, so a failure in the
-                // first must not cost the second -- that coupling is what turned
-                // one bad read into no scheduling at all.
-                try {
-                    $this->concurrency->sample($usageConnection->getUsage());
-                } catch (\Throwable $th) {
-                    Console::error('stats resources: concurrency sample failed, continuing: ' . $th->getMessage());
-                }
+        $scheduler = new Scheduler(
+            source: $source,
+            // Between snapshots the source only reports projects that became
+            // active, so the window's departures converge on the snapshot --
+            // which also re-reads every project document, keeping the payloads
+            // exactly as fresh as re-scanning each cycle used to.
+            syncSeconds: max(1, (int) ($interval / 10)),
+            snapshotSeconds: $interval,
+            // Catch up at most one missed run per project after a restart or a
+            // handover; older ones are dropped rather than replayed as a burst.
+            recoverSeconds: $interval,
+            telemetry: $telemetry,
+            onError: function (\Throwable $error): void {
+                Console::error('stats resources: reconcile failed: ' . $error->getMessage());
+            },
+        );
 
-                $last24Hours = (new \DateTime())->sub(new \DateInterval('P1D'));
-                $this->foreachDocument($dbForPlatform, 'projects', [
-                    Query::greaterThanEqual('accessedAt', DateTime::format($last24Hours)),
-                    Query::equal('region', [System::getEnv('_APP_REGION', 'default')]),
-                    Query::orderAsc('$sequence'), // accessedAt Can be updated during iteration
-                ], function ($project) use ($publisherForStatsResources): void {
-                    $publisherForStatsResources->enqueue(new StatsResourcesMessage(project: $project));
-                });
-            } catch (\Throwable $th) {
-                // Cost a cycle, not the process: the next tick retries in full.
-                Console::error('stats resources: cycle failed, retrying next interval: ' . $th->getMessage());
+        $scheduler->run(fn (array $due): null => $this->dispatch($due, $publisherForStatsResources, $usageConnection));
+
+        // run() returns only if something stopped the loop. Say so loudly: the
+        // failure this task had was that stopping looked like running.
+        Console::error('stats resources: scheduler loop returned, scheduling has stopped');
+    }
+
+    /**
+     * Nothing here may throw. The Scheduler records a dispatch error and
+     * rethrows it, which ends run() -- and the process then stays alive and
+     * idle: it never exits, so restartPolicy never fires, and with no liveness
+     * probe nothing observes that scheduling has stopped. A single transient
+     * ClickHouse timeout on one tick silently ended gauge collection for a
+     * whole region, and the task went on reporting Ready for weeks while
+     * queueing nothing.
+     *
+     * @param list<Occurrence> $due
+     */
+    private function dispatch(array $due, StatsResourcesPublisher $publisherForStatsResources, Connection $usageConnection): null
+    {
+        // Once per batch, not once per project: the schema being absent is a
+        // property of the store, and enqueueing work the worker cannot write
+        // is what skipping a cycle has always avoided.
+        try {
+            if (!$usageConnection->isReady()) {
+                Console::error('stats resources: usage schema is not ready, skipping ' . \count($due) . ' due run(s)');
+                return null;
             }
-        }, $interval);
+        } catch (\Throwable $th) {
+            Console::error('stats resources: readiness check failed, skipping cycle: ' . $th->getMessage());
+            return null;
+        }
+
+        foreach ($due as $occurrence) {
+            // Per occurrence, so one project's failure costs that project one
+            // cycle -- not the rest of the batch, and not the loop.
+            try {
+                if ($occurrence->id === Usage::CONCURRENCY) {
+                    $this->sample($usageConnection);
+                    continue;
+                }
+
+                $project = $occurrence->payload;
+                \assert($project instanceof Document);
+
+                $publisherForStatsResources->enqueue(new StatsResourcesMessage(project: $project));
+            } catch (\Throwable $th) {
+                Console::error('stats resources: ' . $occurrence->id . ' failed, retrying next interval: ' . $th->getMessage());
+            }
+        }
+
+        return null;
+    }
+
+    private function sample(Connection $usageConnection): void
+    {
+        $this->concurrency->sample($usageConnection->getUsage());
     }
 }

--- a/src/Appwrite/Schedule/Source/Chores.php
+++ b/src/Appwrite/Schedule/Source/Chores.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appwrite\Schedule\Source;
+
+use Utopia\Schedule\Source;
+use Utopia\Schedule\Source\Entry;
+use Utopia\Schedule\Source\Row;
+use Utopia\Schedule\Trigger\Interval;
+
+/**
+ * A fixed set of named chores sharing one cadence.
+ *
+ * The set is static -- it comes from code, not a database -- so there is no
+ * change feed and every reconcile is a handful of string comparisons. What
+ * the scheduler adds over a single loop is that each chore is its own
+ * schedule: one failing does not skip the others, and each reports its own
+ * dispatch telemetry.
+ */
+final readonly class Chores implements Source
+{
+    /**
+     * @param list<string> $ids
+     * @param \DateTimeImmutable|null $anchor phases the grid, e.g. to a
+     *        configured start-of-day, and holds it there without the drift
+     *        a sleep-based loop accumulates
+     */
+    public function __construct(
+        private array $ids,
+        private int $seconds,
+        private ?\DateTimeImmutable $anchor = null,
+    ) {
+    }
+
+    /**
+     * @return iterable<Row>
+     */
+    #[\Override]
+    public function snapshot(): iterable
+    {
+        foreach ($this->ids as $id) {
+            yield new Row(id: $id, version: (string) $this->seconds);
+        }
+    }
+
+    #[\Override]
+    public function make(Row $row): Entry
+    {
+        return new Entry(new Interval($this->seconds, $this->anchor));
+    }
+}

--- a/src/Appwrite/Schedule/Source/Usage.php
+++ b/src/Appwrite/Schedule/Source/Usage.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appwrite\Schedule\Source;
+
+use Utopia\Database\Database;
+use Utopia\Database\DateTime;
+use Utopia\Database\Document;
+use Utopia\Database\Query;
+use Utopia\Schedule\Changes;
+use Utopia\Schedule\Source;
+use Utopia\Schedule\Source\Entry;
+use Utopia\Schedule\Source\Row;
+use Utopia\Schedule\Trigger\Interval;
+
+/**
+ * Everything the usage scheduler runs: one schedule per recently-active
+ * project, plus the concurrency sampler.
+ *
+ * A project's occurrences are anchored on its own creation time, so the
+ * fleet's sweeps sit at fixed but distinct offsets inside the interval
+ * rather than all falling on the hour. The queue sees a steady trickle
+ * instead of one burst of every project at once, and the offsets survive
+ * restarts because they are derived from the project, not from boot time.
+ */
+class Usage implements Source, Changes
+{
+    /** The sampler is a schedule too, so it cannot be starved by the sweep. */
+    public const string CONCURRENCY = 'concurrency';
+
+    /**
+     * Subqueries the project documents are decoded without. These are
+     * relationship reads -- one query per document each -- and nothing
+     * here touches them.
+     *
+     * Scoped to this Database instance, unlike Action::disableSubqueries(),
+     * which reaches for Database::addFilter() and so rewrites the filter
+     * for the whole process.
+     */
+    private const array SKIP = [
+        'subQueryKeys', 'subQueryWebhooks', 'subQueryPlatforms', 'subQueryBlocks', 'subQueryDevKeys',
+        'subQueryPaymentMethods', 'subQueryDNSRecords', 'subQueryOrganizationKeys', 'subQueryAccountKeys', 'subQueryAppSecrets',
+    ];
+
+    private const int PAGE = 1_000;
+
+    public function __construct(
+        private readonly Database $dbForPlatform,
+        private readonly int $seconds,
+        private readonly string $region,
+    ) {
+    }
+
+    /**
+     * @return iterable<Row>
+     */
+    #[\Override]
+    public function snapshot(): iterable
+    {
+        yield new Row(id: self::CONCURRENCY, version: (string) $this->seconds);
+
+        yield from $this->rows(null);
+    }
+
+    /**
+     * @return iterable<Row>
+     */
+    #[\Override]
+    public function since(\DateTimeImmutable $moment): iterable
+    {
+        // A project enters the set by being accessed, so the change feed is
+        // the same query with a later floor. It cannot see one leaving --
+        // that needs the window to be re-evaluated, which the periodic
+        // snapshot does.
+        yield from $this->rows($moment);
+    }
+
+    #[\Override]
+    public function make(Row $row): Entry
+    {
+        if ($row->id === self::CONCURRENCY) {
+            return new Entry(new Interval($this->seconds));
+        }
+
+        $project = $row->data;
+        \assert($project instanceof Document);
+
+        return new Entry(new Interval($this->seconds, $this->anchor($project)), $project);
+    }
+
+    /**
+     * Recently-active projects in this region, paged.
+     *
+     * Throwing part-way through discards the batch rather than reading as a
+     * mass removal, so a failed page costs a sync, not the schedule set.
+     *
+     * @return iterable<Row>
+     */
+    private function rows(?\DateTimeImmutable $since): iterable
+    {
+        $window = (new \DateTime())->sub(new \DateInterval('P1D'));
+        $floor = $since instanceof \DateTimeImmutable
+            ? max($window, \DateTime::createFromImmutable($since))
+            : $window;
+
+        $cursor = null;
+
+        do {
+            $queries = [
+                Query::limit(self::PAGE),
+                Query::greaterThanEqual('accessedAt', DateTime::format($floor)),
+                Query::equal('region', [$this->region]),
+                Query::orderAsc('$sequence'), // accessedAt can be updated during iteration
+            ];
+
+            if ($cursor instanceof Document) {
+                $queries[] = Query::cursorAfter($cursor);
+            }
+
+            $projects = $this->page($queries);
+
+            foreach ($projects as $project) {
+                $updatedAt = (string) $project->getUpdatedAt();
+
+                yield new Row(
+                    // Config changes, not access, re-make the entry: accessedAt
+                    // moves on every request and would re-make constantly.
+                    id: (string) $project->getSequence(),
+                    version: $updatedAt,
+                    data: $project,
+                    activeFrom: $this->moment($updatedAt),
+                );
+            }
+
+            $cursor = \end($projects) ?: null;
+        } while (\count($projects) === self::PAGE);
+    }
+
+    /**
+     * @param array<Query> $queries
+     * @return array<Document>
+     */
+    protected function page(array $queries): array
+    {
+        return $this->dbForPlatform->skipFilters(
+            fn (): array => $this->dbForPlatform->find('projects', $queries),
+            self::SKIP,
+        );
+    }
+
+    /** Phase a project's grid to itself, so the fleet spreads. */
+    private function anchor(Document $project): ?\DateTimeImmutable
+    {
+        return $this->moment((string) $project->getCreatedAt());
+    }
+
+    private function moment(string $stamp): ?\DateTimeImmutable
+    {
+        try {
+            return $stamp === '' ? null : new \DateTimeImmutable($stamp);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/tests/unit/Schedule/Source/ChoresTest.php
+++ b/tests/unit/Schedule/Source/ChoresTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Schedule\Source;
+
+use Appwrite\Schedule\Source\Chores;
+use PHPUnit\Framework\TestCase;
+use Utopia\Schedule\Scheduler;
+use Utopia\Schedule\Source\Row;
+
+final class ChoresTest extends TestCase
+{
+    /** @var list<string> */
+    private const array IDS = ['projects', 'console', 'certificates', 'cache'];
+
+    public function testEveryChoreBecomesItsOwnSchedule(): void
+    {
+        $scheduler = new Scheduler(source: new Chores(self::IDS, 60), syncSeconds: 60);
+        $scheduler->reconcile(true);
+
+        $this->assertSame(\count(self::IDS), $scheduler->count());
+    }
+
+    /**
+     * The whole point of one schedule per chore: the chores behind a failing
+     * one still run. As a single closure, the first throw skipped the rest.
+     */
+    public function testAFailingChoreDoesNotSkipTheOthers(): void
+    {
+        $ran = [];
+
+        $scheduler = new Scheduler(source: new Chores(self::IDS, 1), syncSeconds: 60, recoverSeconds: 1);
+        $scheduler->run(function (array $due) use (&$ran, $scheduler): void {
+            foreach ($due as $occurrence) {
+                try {
+                    if ($occurrence->id === 'console') {
+                        throw new \RuntimeException('chore failed');
+                    }
+
+                    $ran[] = $occurrence->id;
+                } catch (\Throwable) {
+                    // Contained, as Maintenance::chore() does.
+                }
+            }
+
+            $scheduler->stop();
+        });
+
+        $this->assertContains('certificates', $ran);
+        $this->assertContains('cache', $ran);
+        $this->assertNotContains('console', $ran);
+    }
+
+    /**
+     * A sleep-based loop phases only its first run and then drifts by however
+     * long each run takes. An anchored grid does not.
+     */
+    public function testTheGridStaysPinnedToTheAnchor(): void
+    {
+        $anchor = new \DateTimeImmutable('2026-01-01 00:00:00');
+        $entry = (new Chores(['projects'], 86400, $anchor))->make(new Row(id: 'projects', version: '1'));
+
+        $dues = $entry->trigger->occurrencesBetween(
+            new \DateTimeImmutable('2026-06-01 12:00:00'),
+            new \DateTimeImmutable('2026-06-04 12:00:00'),
+        );
+
+        $this->assertNotEmpty($dues);
+
+        foreach ($dues as $due) {
+            $this->assertSame('00:00:00', $due->format('H:i:s'));
+        }
+    }
+
+    /**
+     * A maintenance run enqueues a delete for every project in the region, so
+     * a missed day must not be replayed on every restart.
+     */
+    public function testAMissedRunIsNotReplayedOnStartup(): void
+    {
+        $anchor = new \DateTimeImmutable('2026-01-01 00:00:00');
+
+        $scheduler = new Scheduler(source: new Chores(self::IDS, 86400, $anchor), syncSeconds: 86400);
+        $scheduler->reconcile(true);
+
+        $this->assertSame([], $scheduler->tick());
+    }
+}

--- a/tests/unit/Schedule/Source/UsageTest.php
+++ b/tests/unit/Schedule/Source/UsageTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Schedule\Source;
+
+use Appwrite\Schedule\Source\Usage;
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Schedule\Scheduler;
+
+final class UsageTest extends TestCase
+{
+    private const int INTERVAL = 60;
+
+    public function testEveryProjectBecomesItsOwnScheduleAlongsideTheSampler(): void
+    {
+        $scheduler = new Scheduler(source: $this->source(10), syncSeconds: 60, snapshotSeconds: 60);
+        $scheduler->reconcile(true);
+
+        $this->assertSame(11, $scheduler->count(), 'ten projects plus the concurrency sampler');
+    }
+
+    /**
+     * Anchoring each project on its own creation time is what turns the
+     * hourly stampede -- every project enqueued at once -- into a trickle.
+     */
+    public function testProjectsAreSpreadAcrossTheInterval(): void
+    {
+        $source = $this->source(self::INTERVAL);
+        $offsets = [];
+
+        foreach ($source->snapshot() as $row) {
+            if ($row->id === Usage::CONCURRENCY) {
+                continue;
+            }
+
+            $dues = $source->make($row)->trigger->occurrencesBetween(
+                new \DateTimeImmutable('@1800000000'),
+                new \DateTimeImmutable('@1800000060'),
+            );
+
+            $offsets[] = (int) $dues[0]->format('U') % self::INTERVAL;
+        }
+
+        $this->assertCount(self::INTERVAL, $offsets);
+        $this->assertSame($offsets, \array_unique($offsets), 'no two projects share an offset');
+    }
+
+    public function testTheSamplerIsNotAnchoredToAnyProject(): void
+    {
+        $source = $this->source(1);
+        $entry = $source->make(new \Utopia\Schedule\Source\Row(id: Usage::CONCURRENCY, version: '1'));
+
+        $this->assertNull($entry->payload, 'the sampler carries no project');
+    }
+
+    /**
+     * The version must not move when a project is merely accessed, or every
+     * sync would re-make every active project.
+     */
+    public function testRowsAreVersionedOnConfigChangesNotAccess(): void
+    {
+        foreach ($this->source(1)->snapshot() as $row) {
+            if ($row->id === Usage::CONCURRENCY) {
+                continue;
+            }
+
+            $this->assertSame('2026-01-01T00:00:00.000+00:00', $row->version);
+        }
+    }
+
+    private function source(int $projects): Usage
+    {
+        return new class ($this->createStub(Database::class), self::INTERVAL, 'fra', $projects) extends Usage {
+            public function __construct(Database $dbForPlatform, int $seconds, string $region, private int $projects)
+            {
+                parent::__construct($dbForPlatform, $seconds, $region);
+            }
+
+            /**
+             * @param array<mixed> $queries
+             * @return array<Document>
+             */
+            protected function page(array $queries): array
+            {
+                $page = [];
+
+                for ($i = 0; $i < $this->projects; $i++) {
+                    $page[] = new Document([
+                        '$id' => 'project' . $i,
+                        '$sequence' => (string) ($i + 1),
+                        // one second apart, so the anchors spread
+                        '$createdAt' => \gmdate('Y-m-d\TH:i:s.v\Z', 1700000000 + $i),
+                        '$updatedAt' => '2026-01-01T00:00:00.000+00:00',
+                    ]);
+                }
+
+                $this->projects = 0; // a single page
+
+                return $page;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What

Migrates the two remaining `Console::loop` tasks -- `stats-resources` and `maintenance` -- onto `utopia-php/schedule`, which is already a dependency and already runs the function, execution and message schedulers.

`Console::loop` has no callers left in server-ce after this.

## Why

Both tasks had the same shape: a single closure, looped. That gave them the same failure mode.

An exception escaping the closure ends `Console::loop`. The process then stays alive and idle -- it never exits, so `restartPolicy` never fires, and with no liveness probe nothing observes that scheduling has stopped. A single transient ClickHouse timeout ended gauge collection for a region, and the task went on reporting Ready for seven weeks while queueing nothing. `#13328` contained that for `stats-resources`; `maintenance` still had it, with no guard at all.

Containment was the floor, not the fix. What was missing was a signal.

## stats-resources: one schedule per project

Instead of one closure that scans and enqueues every project at once, each project is its own schedule, anchored on its own `$createdAt`. Occurrences land at fixed but distinct offsets inside the interval, so the queue sees a trickle instead of an hourly stampede, and the offsets survive restarts because they derive from the project rather than from boot time.

The concurrency sampler becomes a schedule too, so neither it nor the sweep can starve the other. Dispatch is guarded per occurrence.

Measured with the real `Scheduler` at per-project scale:

| entries | reconcile | memory | tick |
|---|---|---|---|
| 1 000 | 0.00 s | 2.0 MB | 0.37 ms |
| 10 000 | 0.01 s | 12.0 MB | 3.73 ms |
| 50 000 | 0.05 s | 56.5 MB | 21.79 ms |
| 100 000 | 0.09 s | 75.0 MB | 43.26 ms |

Linear, ~0.4 ms per 1 000 entries. At 100 000 projects a 1 s tick costs ~4% of one core. Per-region active project counts are orders of magnitude below that.

The source also reads projects with `skipFilters` instead of `Action::disableSubqueries()`, which reaches for the static `Database::addFilter()` and so rewrites the filter for the whole process. This was its only caller in server-ce.

## maintenance: one schedule per chore

Seven independent chores ran in sequence in one closure, so a throw in any of them skipped every chore behind it. `renewCertificates()` does the most I/O and sat fourth of seven. Each chore is now its own schedule on the shared cadence, guarded individually. The manual `trigger` path shares the guard -- previously a hand-run aborted halfway with no indication of what had not run.

This also fixes a drift. `Console::loop`'s third argument phased only the *first* run; after that the loop slept the interval, so the daily window crept later by however long each run took. Occurrences now sit on a grid anchored to `_APP_MAINTENANCE_START_TIME` and stay pinned to it.

`recoverSeconds` is deliberately left at its default here, unlike the usage sweep: a maintenance run enqueues a delete for every project in the region, so replaying a missed day on every restart would be worse than skipping it -- which is what the old loop did.

## Telemetry

Both schedulers report `errorTotal` (labelled by stage), `dispatchTotal` and `dispatchDelay` through the injected adapter, and take an `onError` for reconcile failures. A scheduler that stops scheduling now shows a rising error counter against a flat dispatch counter. That is the signal whose absence turned an incident into seven weeks.

Note that the guards are still load-bearing: the library records a dispatch error and then **rethrows** it, so a throwing handler still ends `run()`. Migrating does not replace containment.

## Testing

New unit tests covering the properties that matter, rather than the wiring:

- every chore/project becomes its own schedule
- a failing chore does not skip the ones behind it
- the grid stays pinned to its anchor (no drift)
- a missed maintenance day is not replayed on startup
- projects are spread across the interval, no two sharing an offset
- rows are versioned on config changes, not on access -- otherwise every sync re-makes every active project

```
OK (8 tests, 14 assertions)
```

Full unit suite: 1005 tests. Two pre-existing environmental failures locally (`ExtensionsTest::testMaxminddb` needs the extension, `KeyTest::testDecode` needs a signing key in env), both unrelated to these files.

`composer lint` and `composer analyze` (PHPStan level 4) clean on all touched files.

## Follow-up

`disableSubqueries()` loses its only server-ce caller here, which makes cloud's 30-line `StatsResources` override -- whose docblock already says *"delete the class if that call goes away"* -- deletable once this lands and is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
