### PR TITLE
fix(e2e): stop Databases testTimeout hanging on 12MB HTTP setup POSTs

### DIFF
--- a/tests/e2e/Client.php
+++ b/tests/e2e/Client.php
@@ -140,6 +140,11 @@ class Client
             }
         }
 
+        // libcurl sends Expect: 100-continue for POST bodies > 1KiB. Traefik/Swoole
+        // often never finish that handshake, so large uploads hang until CURLOPT_TIMEOUT
+        // with "0 bytes received" and HTTP status 100.
+        $formattedHeaders[] = 'Expect:';
+
         curl_setopt($ch, CURLOPT_PATH_AS_IS, 1);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);

--- a/tests/e2e/Client.php
+++ b/tests/e2e/Client.php
@@ -140,11 +140,6 @@ class Client
             }
         }
 
-        // libcurl sends Expect: 100-continue for POST bodies > 1KiB. Traefik/Swoole
-        // often never finish that handshake, so large uploads hang until CURLOPT_TIMEOUT
-        // with "0 bytes received" and HTTP status 100.
-        $formattedHeaders[] = 'Expect:';
-
         curl_setopt($ch, CURLOPT_PATH_AS_IS, 1);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -7631,14 +7631,20 @@ trait DatabasesBase
             $this->waitForAttribute($data['databaseId'], $data['$id'], 'longtext');
         }
 
+        // The fixture is ~12MB — just under Swoole's package_max_length. Posting it
+        // ten times over HTTP (headers + JSON escaping on top) stalls curl's
+        // Expect: 100-continue handshake under paratest. A 1MiB slice is enough
+        // for statement_timeout=1ms while staying well under the 12MiB ceiling.
+        $longtext = substr(file_get_contents(__DIR__ . '/../../../resources/longtext.txt'), 0, 1024 * 1024);
+
         for ($i = 0; $i < 10; $i++) {
-            $this->client->call(Client::METHOD_POST, $this->getRecordUrl($data['databaseId'], $data['$id']), array_merge([
+            $document = $this->client->call(Client::METHOD_POST, $this->getRecordUrl($data['databaseId'], $data['$id']), array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
             ], $this->getHeaders()), [
                 $this->getRecordIdParam() => ID::unique(),
                 'data' => [
-                    'longtext' => file_get_contents(__DIR__ . '/../../../resources/longtext.txt'),
+                    'longtext' => $longtext,
                 ],
                 'permissions' => [
                     Permission::read(Role::user($this->getUser()['$id'])),
@@ -7646,6 +7652,7 @@ trait DatabasesBase
                     Permission::delete(Role::user($this->getUser()['$id'])),
                 ]
             ]);
+            $this->assertEquals(201, $document['headers']['status-code']);
         }
 
         $response = $this->client->call(Client::METHOD_GET, $this->getRecordUrl($data['databaseId'], $data['$id']), array_merge([

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -7631,10 +7631,11 @@ trait DatabasesBase
             $this->waitForAttribute($data['databaseId'], $data['$id'], 'longtext');
         }
 
-        // The fixture is ~12MB — just under Swoole's package_max_length. Posting it
-        // ten times over HTTP (headers + JSON escaping on top) stalls curl's
-        // Expect: 100-continue handshake under paratest. A 1MiB slice is enough
-        // for statement_timeout=1ms while staying well under the 12MiB ceiling.
+        // The fixture is ~12MB, just under Swoole's 12MiB package_max_length /
+        // output_buffer_size. Ten concurrent HTTP creates of that size never
+        // complete under paratest (curl: 0 bytes, 120s) — isolated they take ~1s
+        // each. A 1MiB slice plus contains() still exceeds statement_timeout=1ms
+        // (notEqual on 1MiB returned 200 on DocumentsDB).
         $longtext = substr(file_get_contents(__DIR__ . '/../../../resources/longtext.txt'), 0, 1024 * 1024);
 
         for ($i = 0; $i < 10; $i++) {
@@ -7661,7 +7662,7 @@ trait DatabasesBase
             'x-appwrite-timeout' => 1,
         ], $this->getHeaders()), [
             'queries' => [
-                Query::notEqual('longtext', 'appwrite')->toString(),
+                Query::contains('longtext', ['needle-that-does-not-exist'])->toString(),
             ],
         ]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes the flaky `Tests / E2E / PostgreSQL (dedicated) / Databases` job.

**Assertion that never ran** (job died in setup):

```
$this->assertEquals(408, $response['headers']['status-code']);
```

after `GET` with `x-appwrite-timeout: 1`.

**Actual error** (same on every fail, different `DatabasesBase` subclasses):

```
Exception: Operation timed out after 120002 milliseconds with 0 bytes received with status code 100
/usr/src/code/tests/e2e/Client.php:223
/usr/src/code/tests/e2e/Services/Databases/DatabasesBase.php:7635
```

PHPUnit finishes (Tests ~1130, Assertions ~15140, Errors 1). This is not a runner death.

Failed examples on main (adjacent SHAs green):

- [run 32698593163](https://github.com/appwrite/appwrite/actions/runs/32698593163) job 97345691144 — `LegacyCustomClientTest::testTimeout`
- [run 32778249050](https://github.com/appwrite/appwrite/actions/runs/32778249050) job 97594637223 — `LegacyCustomServerTest::testTimeout`
- [run 32817703288](https://github.com/appwrite/appwrite/actions/runs/32817703288) job 97709651262 — `LegacyConsoleClientTest::testTimeout`
- Green: [run 32830457040](https://github.com/appwrite/appwrite/actions/runs/32830457040)

A previous attempt (#12873) bumped the e2e client timeout to 300s and was closed unmerged.

### Root cause

`testTimeout` copied utopia-php/database’s in-process setup (N × `tests/resources/longtext.txt`) onto HTTP.

1. `longtext.txt` is ~12.18MB. JSON-escaped it is ~12.29MB — just under Swoole’s `package_max_length` / `output_buffer_size` of 12MiB in `app/http.php`.
2. Ten concurrent HTTP creates of that size never complete under `paratest --processes 3` (curl: 0 bytes, 120s). Isolated they take ~1s each. CI reports **status 100** because libcurl adds `Expect: 100-continue` for POST bodies > 1KiB; that is the overlay, not the hang.
3. `x-appwrite-timeout: 1` is 1 **millisecond** (`Database::setTimeout(int $milliseconds)`). `notEqual` on a 1MiB slice returned **200** on DocumentsDB (filter is cheap; utopia’s own timeout tests say the same). `contains()` forces a substring walk, so 1ms still yields 408.

Bumping `CURLOPT_TIMEOUT` only waits longer on a stalled 12MB POST. Skipping the test would drop the 408 contract.

A global empty `Expect:` header in `tests/e2e/Client.php` was tried and **reverted**. It is not sufficient (full 12MB + Expect off still hung 3/7 with status 0) and it is a suite-wide regression: Storage `testCreateBucketFile` then threw `Recv failure: Connection reset by peer with status code 413` because curl sent the ~12MB chunk immediately and Traefik/Swoole RST’d instead of returning HTTP 413 for the Client to assert.

### Fix

`tests/e2e/Client.php` is unchanged vs `main` (no `Expect:` header).

`testTimeout` only:

- loads a 1MiB slice of `longtext.txt` once
- posts 10 documents and asserts **201** on each create
- queries with `Query::contains('longtext', ['needle-that-does-not-exist'])` and `x-appwrite-timeout: 1` so the **408** still fires

No production code change. No timeout bump, sleep, retry, or skip.

### Other CI failures on this PR (not patched here)

- **Project** [run 6510](https://github.com/appwrite/appwrite/actions/runs/32847224670) job 97796669345: `TemplatesCustomServerTest::testUpdateEmailTemplateOverwritesPrevious` — `Failed asserting that two strings are identical` (`-'Second subject…'` vs `+'First subject…'`) at `tests/e2e/Services/Project/TemplatesBase.php:249`. Known one-off list-after-update on main. Run 6514 Project succeeded. Left alone.
- **Storage** [run 6510](https://github.com/appwrite/appwrite/actions/runs/32847224670) and [run 6514](https://github.com/appwrite/appwrite/actions/runs/32848095660) job 97802802700: `Storage*Test::testCreateBucketFile` — `Recv failure: Connection reset by peer with status code 413` at `Client.php` / `StorageBase.php:343`. Caused by the global empty `Expect:` (now reverted). The test **intends** HTTP 413 for a 12MB chunk.
- **FunctionsSchedule** [run 6514](https://github.com/appwrite/appwrite/actions/runs/32848095660) job 97802802647: `FunctionsScheduleTest::testDeleteScheduledExecutionRequiresOwnership` — setup deployment 400 `Param "activate" is not optional.` That test **does** send `activate => true` with a multipart `code` upload. This is not the #13334 schedule-trigger miss (`assertEventually` / trigger `schedule`). It matches the Expect: multipart-parse fallout; scheduler is not re-patched here.

## Test Plan

VM, same stack/command/concurrency as CI (`COMPOSE_PROFILES=postgresql,mongodb`, `_APP_DB_ADAPTER=postgresql`, dedicated):

```
docker compose exec -T appwrite vendor/bin/paratest --processes 3 \
  /usr/src/code/tests/e2e/Services/Databases \
  --exclude-group abuseEnabled --exclude-group screenshots --exclude-group antivirus
```

Storage CI uses `--functional` and `nproc` (4 on this VM).

**Tight `testTimeout` (7 classes, processes=3):**

| Batch | Command | Result |
| --- | --- | --- |
| 1 | `--filter=testTimeout` with 1MiB + `notEqual` | 6/7 pass; DocumentsDBConsoleClientTest got **200** not 408 |
| 2 | full 12MB fixture + Expect disabled | 4/7 pass; 3 errors **status 0** / 120s / 0 bytes (no longer 100) |
| 3–6 | 1MiB + `contains` (Expect still on) | **4× 7/7 pass** (~7.3–7.7s, ~193 assertions) |
| 7–10 | 1MiB + `contains`, **Client.php reverted to main** | **4× 7/7 pass** (pass 1: 37.8s / 523 assertions cold; passes 2–4: 7.5s / 191, 7.7s / 187, 7.1s / 191) |

**Storage after Client.php revert (no 413 Client throw):**

| Batch | Command | Result |
| --- | --- | --- |
| create-file | `--functional --processes $(nproc) --filter=testCreateBucketFile` | **OK (21 tests, 492 assertions)** |
| suite | `--functional --processes $(nproc)` Storage | **OK (83 tests, 1368 assertions)** in 16.8s |

CI Storage fail was Tests: 83, Assertions: 1320, Errors: 3. Same 83 tests now complete without the RST/413 throw.

## Related PRs and Issues

- Closed timeout-bump attempt: #12873
- Flaky main jobs: [32698593163](https://github.com/appwrite/appwrite/actions/runs/32698593163), [32778249050](https://github.com/appwrite/appwrite/actions/runs/32778249050), [32817703288](https://github.com/appwrite/appwrite/actions/runs/32817703288)
- Do not touch FunctionsSchedule (#13334) or Presences (#13329)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09df3ce9-f413-4788-870e-261ac793986f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09df3ce9-f413-4788-870e-261ac793986f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

