### PR TITLE
fix(sites): stop parallel e2e tarball and latestDeploymentId races

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -434,6 +434,14 @@ class Jobs extends Action
         ]);
         $deployment = $dbForProject->getDocument('deployments', $deployment->getId());
 
+        // latestDeployment* must be written before activate(). activate() sets
+        // deploymentId then walks platform rules; under parallel Sites e2e that
+        // scan is slow enough that clients waiting on deploymentId observe a
+        // stale latestDeploymentId (still the previous deployment).
+        if (! $resource->isEmpty()) {
+            $this->updateLatestDeployment($dbForProject, $resource);
+        }
+
         if ($applied > 0 && $success && $deployment->getAttribute('activate') === true && ! $resource->isEmpty()) {
             $this->activate($dbForProject, $dbForPlatform, $project, $resource, $deployment, $bus);
         }
@@ -455,11 +463,9 @@ class Jobs extends Action
             BuildUsage::publish($usage, $resource, $deployment, $project, $publisherForUsage);
         }
 
-        // Keep the resource's "latest deployment" pointer + status current, and
-        // (re)activate its schedule so the scheduler enqueues cron executions
+        // (Re)activate its schedule so the scheduler enqueues cron executions
         // (sites have no scheduleId, so schedule() no-ops for them).
         if (! $resource->isEmpty()) {
-            $this->updateLatestDeployment($dbForProject, $resource);
             $this->schedule($dbForProject, $dbForPlatform, $resource);
         }
 
@@ -568,6 +574,7 @@ class Jobs extends Action
             Query::equal('resourceType', [$resource->getCollection()]),
             Query::equal('resourceInternalId', [$resource->getSequence()]),
             Query::orderDesc('$createdAt'),
+            Query::orderDesc('$sequence'),
         ]);
 
         if ($latest->isEmpty()) {

--- a/tests/e2e/Services/Sites/SitesBase.php
+++ b/tests/e2e/Services/Sites/SitesBase.php
@@ -245,15 +245,24 @@ trait SitesBase
     protected function packageSite(string $site): CURLFile
     {
         $folderPath = realpath(__DIR__ . '/../../../resources/sites') . "/$site";
-        $tarPath = "$folderPath/code.tar.gz";
+        // Unique archive per process: paratest --functional packs the same
+        // fixture from many methods at once. Sharing $folderPath/code.tar.gz
+        // lets one tar truncate the file another CURLFile is still reading
+        // (libcurl: "client mime read EOF fail, only N/M of needed bytes").
+        $tarPath = \sys_get_temp_dir() . '/appwrite-site-' . $site . '-' . \getmypid() . '-' . \uniqid('', true) . '.tar.gz';
 
-        Console::execute("cd $folderPath && tar --exclude code.tar.gz --exclude node_modules -czf code.tar.gz .", '', $this->stdout, $this->stderr);
+        Console::execute(
+            'tar --exclude code.tar.gz --exclude node_modules -czf ' . \escapeshellarg($tarPath) . ' -C ' . \escapeshellarg($folderPath) . ' .',
+            '',
+            $this->stdout,
+            $this->stderr
+        );
 
         if (filesize($tarPath) > 1024 * 1024 * 5) {
             throw new \Exception('Code package is too large. Use the chunked upload method instead.');
         }
 
-        return new CURLFile($tarPath, 'application/x-gzip', \basename($tarPath));
+        return new CURLFile($tarPath, 'application/x-gzip', 'code.tar.gz');
     }
 
     protected function createDeployment(string $siteId, mixed $params = []): mixed

--- a/tests/e2e/Services/Sites/SitesBase.php
+++ b/tests/e2e/Services/Sites/SitesBase.php
@@ -262,6 +262,12 @@ trait SitesBase
             throw new \Exception('Code package is too large. Use the chunked upload method instead.');
         }
 
+        register_shutdown_function(static function () use ($tarPath) {
+            if (\is_file($tarPath)) {
+                @\unlink($tarPath);
+            }
+        });
+
         return new CURLFile($tarPath, 'application/x-gzip', 'code.tar.gz');
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes the flaky **Tests / E2E / PostgreSQL (dedicated) / Sites** job (`e2e_service`, `--functional`, `--processes nproc`, `--exclude-group screenshots`).

This is a **job-level** flake: different tests fail, same job, nearby SHAs green. The failures share the Sites deployment create/activate path, not a single assertion.

### Failures on main

1. [run 6491](https://github.com/appwrite/appwrite/actions/runs/32817703288) job 97709651307 — `SitesCustomServerTest::testGetDeployment`
   ```
   Exception: client mime read EOF fail, only 317/606 of needed bytes read with status code 0
   tests/e2e/Client.php:223 → SitesBase.php createDeployment() multipart POST
   ```
2. [run 6478](https://github.com/appwrite/appwrite/actions/runs/32778249050) job 97594637236 — `SitesCustomServerTest::testUpdateDeploymentStatus`
   ```
   expected latestDeploymentId = deploymentId2
   actual still previous deploymentId1
   ```
   after `setupDeployment(..., activate: true)` at `SitesCustomServerTest.php:3157`
3. [run 6326](https://github.com/appwrite/appwrite/actions/runs/32370491865) — `testVariablesE2E` mime EOF `316/40907` **and** `testListSites` expected 1 site got 2 (leftover after the sibling failed mid-setup under `--functional`)

Also seen on PR #6512 / `patch/screenshot-timeout-60s` in the **Sites service** job (not the screenshots grouped job).

Green nearby: 6513, 6505, 6502, 6486, 6474, 6459, 6451.

### Root cause

Two bugs on the same create/activate path, both exposed by `paratest --functional --processes nproc`:

1. **Shared `code.tar.gz` (mime EOF + leftover `testListSites`)**
   `packageSite()` always wrote `$fixture/code.tar.gz`. With `--functional`, many methods pack the same fixture at once. One `tar -czf` truncates the file another process's `CURLFile` is still reading. libcurl then throws `client mime read EOF fail, only N/M of needed bytes` with status 0. That matches the observed sizes (`317/606` for `static-single-file`, `316/40907` for `astro`).
   A failed sibling that already called `setupSite()` and then died on the upload leaves a site in the worker's shared `ProjectCustom::$project`, so `testListSites` sees 2 instead of 1. That is cascade, not a separate product bug.

2. **`latestDeploymentId` written after `activate()`**
   `Jobs::finalize()` set `deploymentId` (activate) **then** walked platform rules **then** wrote `latestDeployment*`. `waitDeploymentActivated()` only waits on `deploymentId`. Under parallel Sites load the rules scan is slow enough that the next `getSite()` still shows the previous `latestDeploymentId`. `findOne` also ordered only by `$createdAt`, so same-second static builds could pick the older row.

Not Traefik/Swoole package size, not an empty `Expect:` header (`tests/e2e/Client.php` is unchanged — that caused Storage `testCreateBucketFile` 413 RST and was reverted from #13339). Not screenshot timeouts (#13340 / #13315 are `e2e_grouped --group=screenshots`; this job excludes that group).

### Fix

- `packageSite()` writes a unique temp archive per process (`/tmp/appwrite-site-{fixture}-{pid}-{uniqid}.tar.gz`) and uploads it as `code.tar.gz`. Unlinked on process shutdown after CURLFile has been read.
- `Jobs::finalize()` writes `latestDeployment*` **before** `activate()`, and breaks `$createdAt` ties with `$sequence`.

No timeout bump, sleep, retry loop, skip, or `Expect:` header.

## Test Plan

VM + GitHub, same stack/command/concurrency as CI:

```
COMPOSE_PROFILES=postgresql
_APP_DB_ADAPTER=postgresql
_APP_OPTIONS_ROUTER_PROTECTION=enabled

docker compose exec -T appwrite vendor/bin/paratest --processes "$(nproc)" --functional \
  /usr/src/code/tests/e2e/Services/Sites \
  --exclude-group abuseEnabled --exclude-group screenshots --exclude-group antivirus
```

| Batch | Command | Result |
| --- | --- | --- |
| GitHub CI (`fac203f4b2`) | `Tests / E2E / PostgreSQL (dedicated) / Sites` | **success** ([job 97814562249](https://github.com/appwrite/appwrite/actions/runs/32851740559/job/97814562249), 4m14s); all 46 checks green |
| GitHub CI (`7ac8c12a9f`) | same Sites job after shutdown unlink | **success** ([job 97835111051](https://github.com/appwrite/appwrite/actions/runs/32857979383/job/97835111051), 4m19s); all 44 checks green |
| named flake ×3 | `--filter 'testGetDeployment\|testUpdateDeploymentStatus\|testListSites'` `--functional --processes 4` | **3× OK (3 tests, 138 assertions)** ~11s each |
| create/activate path ×3 | `--filter 'testGetDeployment\|testUpdateDeploymentStatus\|testListSites\|testCreateDeployment\|testVariablesE2E'` | **8/9 pass ×3**; only `testVariablesE2E` failed. Astro upload `sourceSize=40602` (complete, not mime EOF 316/40907). Build stuck on `npm` after Alpine `TLS: unspecified error` to `dl-cdn.alpinelinux.org` — this nested VM's egress, not the flake. |
| full suite ×2 | CI command, `--processes 4` | **54/61 both times** (~5m, ~2988 assertions). Same 7 failures: astro/SSR builds left `status=building` (Alpine TLS / npm). **No mime EOF. No stale `latestDeploymentId`. `testGetDeployment`, `testUpdateDeploymentStatus`, `testListSites` passed both runs.** |

Greptile: 5/5 after the shutdown unlink; the P2 temp-archive leak is resolved.

## Related PRs and Issues

- Do not confuse with screenshot PRs #13340 / #13315 (`e2e_grouped --group=screenshots`)
- Do not touch FunctionsSchedule (#13334), Presences (#13329), Databases testTimeout (#13339)
- Flaky main jobs: [32817703288](https://github.com/appwrite/appwrite/actions/runs/32817703288), [32778249050](https://github.com/appwrite/appwrite/actions/runs/32778249050), [32370491865](https://github.com/appwrite/appwrite/actions/runs/32370491865)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fd8eef1-a164-48c8-93e8-95ad345752a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fd8eef1-a164-48c8-93e8-95ad345752a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

