### PR TITLE
fix(graphql): coerce empty JSON object variables to array

### DIFF
--- a/app/controllers/api/graphql.php
+++ b/app/controllers/api/graphql.php
@@ -276,11 +276,17 @@ function execute(
             }
         }
 
+        // JSON `{}` is decoded as stdClass; GraphQL requires ?array.
+        $variableValues = $indexed['variables'] ?? null;
+        if ($variableValues instanceof \stdClass) {
+            $variableValues = \get_object_vars($variableValues);
+        }
+
         $promises[] = GraphQL::promiseToExecute(
             $promiseAdapter,
             $schema,
             $source,
-            variableValues: $indexed['variables'] ?? null,
+            variableValues: $variableValues,
             operationName: $indexed['operationName'] ?? null,
             validationRules: $validations
         );

--- a/tests/e2e/Services/GraphQL/ContentTypeTest.php
+++ b/tests/e2e/Services/GraphQL/ContentTypeTest.php
@@ -51,6 +51,26 @@ final class ContentTypeTest extends Scope
         $this->assertEquals(197, $response['total']);
     }
 
+    public function testJSONObjectVariables()
+    {
+        $projectId = $this->getProject()['$id'];
+        $query = '{ localeGet { ip country continent currency } }';
+        $graphQLPayload = [
+            'query' => $query,
+            'variables' => new \stdClass(),
+        ];
+        $response = $this->client->call(Client::METHOD_POST, '/graphql', \array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+        ], $this->getHeaders()), $graphQLPayload);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertIsArray($response['body']['data']);
+        $this->assertArrayNotHasKey('errors', $response['body']);
+        $this->assertArrayHasKey('localeGet', $response['body']['data']);
+        $this->assertIsArray($response['body']['data']['localeGet']);
+    }
+
     public function testArrayBatchedJSONContentType()
     {
         $projectId = $this->getProject()['$id'];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes CLOUD-3QH3.

POST `/v1/graphql` crashed with:

```
GraphQL\GraphQL::promiseToExecute(): Argument #6 ($variableValues) must be of type ?array, stdClass given
```

Production (cloud 1.45.3) hit this on `graphql.query` with bodies like `{ localeGet { … } }` plus `"variables": {}`. GET already used `json_decode($variables, true)`, so empty objects became arrays. POST used `$request->getParams()` and passed `variables` through unchanged.

Utopia’s JSON decoder intentionally keeps empty objects as `stdClass` so `{}` and `[]` stay distinct. Changing that globally would affect every JSON param. GraphQL-php’s contract is `?array`, so this normalizes `stdClass` variables to an array at `execute()` — the GraphQL boundary shared by POST `/v1/graphql`, POST `/v1/graphql/mutation`, GET, and multipart.

## Test Plan

- Added `testJSONObjectVariables` in `tests/e2e/Services/GraphQL/ContentTypeTest.php`: POST JSON with `variables` as an empty object (`stdClass` → `"variables":{}`) and `{ localeGet { … } }`. Expects HTTP 200 and data, not a TypeError.
- Run: `docker compose exec appwrite test tests/e2e/Services/GraphQL/ContentTypeTest.php --filter=testJSONObjectVariables`

## Related PRs and Issues

- Fixes CLOUD-3QH3
- Sentry: https://appwrite.sentry.io/issues/CLOUD-3QH3

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-471a6301-a93f-453c-a831-3760687386b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-471a6301-a93f-453c-a831-3760687386b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

