### PR TITLE
fix(account): omit identity photo until V25 attribute exists

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1,6 +1,7 @@
 <?php
 
 use Ahc\Jwt\JWT;
+use Appwrite\Auth\Identity;
 use Appwrite\Auth\MFA\Type;
 use Appwrite\Auth\OAuth2\Exception as OAuth2Exception;
 use Appwrite\Auth\Validator\EmailWhitelist;
@@ -1994,6 +1995,15 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
             Query::equal('provider', [$provider]),
             Query::equal('providerUid', [$oauth2ID]),
         ]);
+
+        // Tokens always persist. Photo is optional and omitted until V25 has
+        // created that attribute, so OAuth login still succeeds mid-migration.
+        $identityTokens = Identity::withPhoto($dbForProject, [
+            'providerAccessToken' => $accessToken,
+            'providerRefreshToken' => $refreshToken,
+            'providerAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), (int) $accessTokenExpiry),
+        ], $oauth2->getUserPhoto($accessToken));
+
         if ($identity->isEmpty()) {
             // Before creating the identity, check if the email is already associated with another user
             $userId = $user->getId();
@@ -2010,7 +2020,7 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
             }
 
             try {
-                $dbForProject->createDocument('identities', new Document([
+                $dbForProject->createDocument('identities', new Document(\array_merge([
                     '$id' => ID::unique(),
                     '$permissions' => [
                         Permission::read(Role::any()),
@@ -2022,11 +2032,7 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
                     'provider' => $provider,
                     'providerUid' => $oauth2ID,
                     'providerEmail' => $providerEmail,
-                    'providerAccessToken' => $accessToken,
-                    'providerRefreshToken' => $refreshToken,
-                    'providerAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), (int) $accessTokenExpiry),
-                    'photo' => $oauth2->getUserPhoto($accessToken),
-                ]));
+                ], $identityTokens)));
             } catch (Duplicate) {
                 // The (provider, providerUid) unique index guards the same identity being connected to two users.
                 // A request that lost the race must not leave behind the user it just created.
@@ -2041,13 +2047,7 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
                 $failureRedirect(Exception::USER_ALREADY_EXISTS);
             }
         } else {
-            $identity = $dbForProject->updateDocument('identities', $identity->getId(), new Document([
-                'providerAccessToken' => $accessToken,
-                'providerRefreshToken' => $refreshToken,
-                'providerAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), (int) $accessTokenExpiry),
-                // Refresh the photo URL on every login so expired CDN links self-heal.
-                'photo' => $oauth2->getUserPhoto($accessToken),
-            ]));
+            $identity = $dbForProject->updateDocument('identities', $identity->getId(), new Document($identityTokens));
         }
 
         if (empty($user->getAttribute('name'))) {

--- a/src/Appwrite/Auth/Identity.php
+++ b/src/Appwrite/Auth/Identity.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Appwrite\Auth;
+
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+
+class Identity
+{
+    /**
+     * Include `photo` only when the identities collection already has that attribute.
+     *
+     * OAuth login stores the provider avatar URL on the identity. Cloud (and
+     * self-hosted upgrades) can run that write against project databases that
+     * have not yet received the V25 column. Writing `photo` in that window
+     * raises Structure and fails the entire session create.
+     *
+     * @param array<string, mixed> $attributes
+     * @return array<string, mixed>
+     */
+    public static function withPhoto(Database $dbForProject, array $attributes, string $photo): array
+    {
+        foreach ($dbForProject->getCollection('identities')->getAttribute('attributes', []) as $attribute) {
+            if ($attribute instanceof Document && $attribute->getId() === 'photo') {
+                $attributes['photo'] = $photo;
+                break;
+            }
+        }
+
+        return $attributes;
+    }
+}

--- a/src/Appwrite/Auth/Identity.php
+++ b/src/Appwrite/Auth/Identity.php
@@ -21,7 +21,13 @@ class Identity
     public static function withPhoto(Database $dbForProject, array $attributes, string $photo): array
     {
         foreach ($dbForProject->getCollection('identities')->getAttribute('attributes', []) as $attribute) {
-            if ($attribute instanceof Document && $attribute->getId() === 'photo') {
+            $attributeId = match (true) {
+                $attribute instanceof Document => $attribute->getId(),
+                \is_array($attribute) => $attribute['$id'] ?? '',
+                default => '',
+            };
+
+            if ($attributeId === 'photo') {
                 $attributes['photo'] = $photo;
                 break;
             }

--- a/tests/unit/Auth/IdentityTest.php
+++ b/tests/unit/Auth/IdentityTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Auth;
+
+use Appwrite\Auth\Identity;
+use PHPUnit\Framework\TestCase;
+use Utopia\Cache\Adapter\None as NoCache;
+use Utopia\Cache\Cache;
+use Utopia\Database\Adapter\Memory;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Exception\Structure;
+use Utopia\Database\Helpers\ID;
+use Utopia\Database\Helpers\Permission;
+use Utopia\Database\Helpers\Role;
+use Utopia\Database\Validator\Authorization;
+
+final class IdentityTest extends TestCase
+{
+    /**
+     * Mirrors the OAuth2 redirect identity create/update in account.php.
+     *
+     * CLOUD-3QHA: writing `photo` against a pre-V25 identities collection
+     * raises Structure and 500s the whole session. The write path must omit
+     * that field until the attribute exists, without dropping token fields.
+     */
+    public function testOAuthIdentityWriteSucceedsWhenPhotoAttributeIsAbsent(): void
+    {
+        $database = $this->database();
+        $this->createIdentitiesCollection($database, photo: false);
+
+        $photo = 'https://cdn.example/oauth2/photo.jpg';
+        $tokens = Identity::withPhoto($database, [
+            'providerAccessToken' => 'access-token',
+            'providerRefreshToken' => 'refresh-token',
+            'providerAccessTokenExpiry' => '2026-08-26T00:00:00.000+00:00',
+        ], $photo);
+
+        $this->assertArrayNotHasKey('photo', $tokens);
+        $this->assertSame('access-token', $tokens['providerAccessToken']);
+        $this->assertSame('refresh-token', $tokens['providerRefreshToken']);
+        $this->assertArrayHasKey('providerAccessTokenExpiry', $tokens);
+
+        $created = $database->createDocument('identities', new Document(\array_merge([
+            '$id' => ID::unique(),
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::user('user1')),
+                Permission::delete(Role::user('user1')),
+            ],
+            'userInternalId' => '1',
+            'userId' => 'user1',
+            'provider' => 'google',
+            'providerUid' => 'provider-uid',
+            'providerEmail' => 'user@example.com',
+        ], $tokens)));
+
+        $this->assertFalse($created->isEmpty());
+        $this->assertSame('access-token', $created->getAttribute('providerAccessToken'));
+        $this->assertSame('refresh-token', $created->getAttribute('providerRefreshToken'));
+        $this->assertNull($created->getAttribute('photo'));
+
+        $updated = $database->updateDocument('identities', $created->getId(), new Document(
+            Identity::withPhoto($database, [
+                'providerAccessToken' => 'rotated-access',
+                'providerRefreshToken' => 'rotated-refresh',
+                'providerAccessTokenExpiry' => '2026-08-26T00:00:00.000+00:00',
+            ], $photo)
+        ));
+
+        $this->assertSame('rotated-access', $updated->getAttribute('providerAccessToken'));
+        $this->assertSame('rotated-refresh', $updated->getAttribute('providerRefreshToken'));
+        $this->assertNull($updated->getAttribute('photo'));
+
+        try {
+            $database->createDocument('identities', new Document([
+                '$id' => ID::unique(),
+                'userInternalId' => '2',
+                'userId' => 'user2',
+                'provider' => 'google',
+                'providerUid' => 'other-uid',
+                'photo' => $photo,
+            ]));
+            $this->fail('Writing photo before V25 must raise Structure.');
+        } catch (Structure $exception) {
+            $this->assertStringContainsString('photo', $exception->getMessage());
+        }
+    }
+
+    public function testOAuthIdentityWritePersistsPhotoWhenAttributeExists(): void
+    {
+        $database = $this->database();
+        $this->createIdentitiesCollection($database, photo: true);
+
+        $photo = 'https://cdn.example/oauth2/photo.jpg';
+        $created = $database->createDocument('identities', new Document(
+            Identity::withPhoto($database, [
+                '$id' => ID::unique(),
+                'userInternalId' => '1',
+                'userId' => 'user1',
+                'provider' => 'google',
+                'providerUid' => 'provider-uid',
+                'providerEmail' => 'user@example.com',
+                'providerAccessToken' => 'access-token',
+                'providerRefreshToken' => 'refresh-token',
+                'providerAccessTokenExpiry' => '2026-08-26T00:00:00.000+00:00',
+            ], $photo)
+        ));
+
+        $this->assertSame($photo, $created->getAttribute('photo'));
+
+        $updated = $database->updateDocument('identities', $created->getId(), new Document(
+            Identity::withPhoto($database, [
+                'providerAccessToken' => 'rotated-access',
+                'providerRefreshToken' => 'rotated-refresh',
+                'providerAccessTokenExpiry' => '2026-08-26T00:00:00.000+00:00',
+            ], 'https://cdn.example/oauth2/photo-2.jpg')
+        ));
+
+        $this->assertSame('https://cdn.example/oauth2/photo-2.jpg', $updated->getAttribute('photo'));
+        $this->assertSame('rotated-access', $updated->getAttribute('providerAccessToken'));
+    }
+
+    private function database(): Database
+    {
+        $authorization = new Authorization();
+        $authorization->addRole(Role::any()->toString());
+
+        $database = new Database(new Memory(), new Cache(new NoCache()));
+        $database
+            ->setAuthorization($authorization)
+            ->setDatabase('identityPhoto')
+            ->setNamespace('identity_photo_' . \uniqid());
+        $database->create();
+
+        return $database;
+    }
+
+    private function createIdentitiesCollection(Database $database, bool $photo): void
+    {
+        $permissions = [
+            Permission::create(Role::any()),
+            Permission::read(Role::any()),
+            Permission::update(Role::any()),
+            Permission::delete(Role::any()),
+        ];
+        $database->createCollection('identities', [], [], $permissions, false);
+        $database->createAttribute('identities', 'userInternalId', Database::VAR_STRING, Database::LENGTH_KEY, false);
+        $database->createAttribute('identities', 'userId', Database::VAR_STRING, Database::LENGTH_KEY, false);
+        $database->createAttribute('identities', 'provider', Database::VAR_STRING, 128, false);
+        $database->createAttribute('identities', 'providerUid', Database::VAR_STRING, 2048, false);
+        $database->createAttribute('identities', 'providerEmail', Database::VAR_STRING, 320, false);
+        $database->createAttribute('identities', 'providerAccessToken', Database::VAR_STRING, 16384, false);
+        $database->createAttribute('identities', 'providerRefreshToken', Database::VAR_STRING, 16384, false);
+        $database->createAttribute('identities', 'providerAccessTokenExpiry', Database::VAR_STRING, 64, false);
+
+        if ($photo) {
+            $database->createAttribute('identities', 'photo', Database::VAR_STRING, 2048, false);
+        }
+    }
+}

--- a/tests/unit/Migration/MigrationVersionsTest.php
+++ b/tests/unit/Migration/MigrationVersionsTest.php
@@ -253,6 +253,7 @@ final class MigrationVersionsTest extends TestCase
             ->setNamespace('migration_identities_' . $projectId . '_' . \uniqid());
         $database->create();
         $database->createCollection('identities');
+        $database->createCollection('databases');
 
         $migration = new V25();
         $migration->setProject(

--- a/tests/unit/Migration/MigrationVersionsTest.php
+++ b/tests/unit/Migration/MigrationVersionsTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Migration;
 use Appwrite\Migration\Migration;
 use Appwrite\Migration\Version\V24;
 use Appwrite\Migration\Version\V25;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Utopia\Cache\Adapter\None as NoCache;
 use Utopia\Cache\Cache;
@@ -228,5 +229,53 @@ final class MigrationVersionsTest extends TestCase
             $this->assertContains('providerBranches', $attributes);
             $this->assertContains('providerPaths', $attributes);
         }
+    }
+
+    /**
+     * @return \Iterator<string, array{0: string, 1: string}>
+     */
+    public static function v25IdentityProjects(): \Iterator
+    {
+        yield 'project' => ['project', '1'];
+        yield 'console' => ['console', 'console'];
+    }
+
+    #[DataProvider('v25IdentityProjects')]
+    public function testV25CreatesPhotoAttributeOnIdentities(string $projectId, string $sequence): void
+    {
+        require_once __DIR__ . '/../../../app/init.php';
+
+        $authorization = new Authorization();
+        $database = new Database(new Memory(), new Cache(new NoCache()));
+        $database
+            ->setAuthorization($authorization)
+            ->setDatabase('migrationV25Identities')
+            ->setNamespace('migration_identities_' . $projectId . '_' . \uniqid());
+        $database->create();
+        $database->createCollection('identities');
+
+        $migration = new V25();
+        $migration->setProject(
+            new Document(['$id' => $projectId, '$sequence' => $sequence]),
+            $database,
+            $database,
+            $authorization,
+        );
+
+        $migrateCollections = new \ReflectionMethod($migration, 'migrateCollections');
+        \ob_start();
+        try {
+            $migrateCollections->invoke($migration);
+            $migrateCollections->invoke($migration);
+        } finally {
+            \ob_end_clean();
+        }
+
+        $attributes = [];
+        foreach ($database->getCollection('identities')->getAttribute('attributes', []) as $attribute) {
+            $attributes[] = $attribute instanceof Document ? $attribute->getAttribute('$id') : ($attribute['$id'] ?? '');
+        }
+
+        $this->assertContains('photo', $attributes);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes CLOUD-3QHA. Google OAuth login on cloud 1.45.7 fails with:

```
Invalid document structure: Unknown attribute: "photo"
```

on `GET /v1/account/sessions/oauth2/google/redirect`.

#13326 stores the provider avatar URL on `identities.photo` at OAuth login. V25 creates that optional attribute, but Cloud (and self-hosted upgrades) can run the new write path against project DBs that have not received the column yet. Structure then aborts the entire session create.

This change:

- Includes `photo` on identity create/update **only when** the identities collection already has that attribute. Token fields still persist. No catch-all of Structure.
- Leaves V25 as the schema migration. It already creates `photo` on both project and console identities (the collection lives in `common.php`, and the `identities` case is not gated on collection type).
- Adds a unit test that OAuth identity create/update succeeds when `photo` is absent (and still fails if `photo` is written anyway).
- Adds a V25 test that `photo` is created on project and console identities collections.

OAuth login succeeds immediately; avatars stay empty until V25 lands on that project DB.

## Test Plan

- `tests/unit/Auth/IdentityTest.php` — create/update identities without `photo` must not raise Structure; other identity fields are kept; writing `photo` against the old schema still raises Structure; with the attribute present, photo is stored.
- `tests/unit/Migration/MigrationVersionsTest.php` — `testV25CreatesPhotoAttributeOnIdentities` for project and console.

```bash
docker compose exec appwrite test tests/unit/Auth/IdentityTest.php
docker compose exec appwrite test tests/unit/Migration/MigrationVersionsTest.php --filter=testV25CreatesPhotoAttributeOnIdentities
```

## Related PRs and Issues

- Fixes CLOUD-3QHA
- Introduced by #13326

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74f0079c-1807-4698-85fb-91446042b9a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74f0079c-1807-4698-85fb-91446042b9a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

