### PR TITLE
fix: keep internal writes working when a migration has not run yet

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3560,16 +3560,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "7.2.6",
+            "version": "7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "eaae8fd6e4ebae049153f6d01c96e43453527c9d"
+                "reference": "d5b2ecaac3b89d80d01220482bc908384034cfea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/eaae8fd6e4ebae049153f6d01c96e43453527c9d",
-                "reference": "eaae8fd6e4ebae049153f6d01c96e43453527c9d",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/d5b2ecaac3b89d80d01220482bc908384034cfea",
+                "reference": "d5b2ecaac3b89d80d01220482bc908384034cfea",
                 "shasum": ""
             },
             "require": {
@@ -3614,9 +3614,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/7.2.6"
+                "source": "https://github.com/utopia-php/database/tree/7.3.0"
             },
-            "time": "2026-08-21T11:42:38+00:00"
+            "time": "2026-08-27T00:35:48+00:00"
         },
         {
             "name": "utopia-php/detector",
@@ -8552,5 +8552,5 @@
     "platform-dev": {
         "ext-fileinfo": "*"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Appwrite/Database/Factory.php
+++ b/src/Appwrite/Database/Factory.php
@@ -35,6 +35,7 @@ class Factory
         $database
             ->setDatabase($this->database)
             ->setAuthorization($this->authorization)
+            ->setDropUnknownAttributes(true)
             ->setNamespace($this->platformNamespace);
 
         $this->configureDocumentTypes($database);
@@ -57,7 +58,8 @@ class Factory
 
         $database
             ->setDatabase($this->database)
-            ->setAuthorization($this->authorization);
+            ->setAuthorization($this->authorization)
+            ->setDropUnknownAttributes(true);
 
         $this->configureDocumentTypes($database);
         $this->configureOptions($database, $timeout, $maxQueryValues, $metadata);
@@ -80,6 +82,7 @@ class Factory
         $database
             ->setDatabase($this->database)
             ->setAuthorization($this->authorization)
+            ->setDropUnknownAttributes(true)
             ->setSharedTables(true)
             ->setGlobalCollections($logsCollections)
             ->setNamespace('logsV1');
@@ -93,6 +96,10 @@ class Factory
         return $database;
     }
 
+    /**
+     * Databases and tables the caller owns. Unknown attributes stay a rejected write here:
+     * the schema is theirs, so dropping one would silently discard data they sent.
+     */
     public function tenant(
         Document $databaseDocument,
         Document $project,


### PR DESCRIPTION
> **Unblocked.** [utopia-php/database 7.3.0](https://github.com/utopia-php/database/releases/tag/7.3.0) tags `setDropUnknownAttributes()`; this branch bumps `composer.lock` to it.

## What

Enables `setDropUnknownAttributes(true)` on the database handles whose schema Appwrite owns: `platform()`, `project()` and `logs()`. `tenant()` is deliberately left strict.

## Why

An attribute added to a collection in `app/config/collections/*` is written by the new code the moment it deploys. The column only exists once the migration task has run. In the window between the two, **every** write to that collection throws `Invalid document structure: Unknown attribute`.

#13326 hit this on `identities.photoUrl`. `/v1/account/sessions/oauth2/:provider/redirect` 500'd on every login for every provider, on cloud and on any self-hosted instance that had deployed but not migrated, which is what #13355 reverted.

Reverting fixed that instance of the problem. This fixes the shape of it: for a schema Appwrite owns, an attribute the deployed schema does not have is now dropped with a warning naming the collection and the attribute, and the write completes with the columns that exist. The value is lost until the migration runs and the writer sends it again, which is the same outcome as the feature not having been deployed yet.

## Why tenant() stays strict

That schema belongs to the project, not to us. `Unknown attribute` there is the documented 400 (`document_invalid_structure` / `row_invalid_structure`) that every Databases and TablesDB write endpoint already maps and that the E2E suite asserts. Dropping an attribute there would turn a clear rejection into silently discarded data. The asymmetry is the point of the change, so it carries a comment on `tenant()`.

## Tests

The behaviour is proven in the library, where it lives: `testDropUnknownAttributes` in `utopia-php/database` drives `createDocument` and `updateDocument` through their public entry points and asserts the stored document afterwards, with the flag on and off. It was seen red against a pass-through implementation, failing with the production error verbatim.

There is no E2E for this seam here. Reproducing it needs an internal collection whose live schema is missing an attribute the code writes, and no public endpoint can put an instance into that state. The change in this repo is the four lines of wiring that select which handles opt in.

## Also needed

Cloud builds its own handles in `Appwrite\Cloud\Database\Factory`, so this change does not reach it. The matching cloud PR is appwrite-labs/cloud#5463.
