### PR TITLE
Refuse variable keys that are invalid env var names

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -1281,6 +1281,11 @@ return [
         'description' => 'Secret variables cannot be marked as non-secret. Please re-create the variable if this is your intention.',
         'code' => 400,
     ],
+    Exception::VARIABLE_INVALID_KEY => [
+        'name' => Exception::VARIABLE_INVALID_KEY,
+        'description' => 'Variable key is not a valid environment variable name. Update or delete the variable, then retry the deployment.',
+        'code' => 400,
+    ],
     Exception::GRAPHQL_NO_QUERY => [
         'name' => Exception::GRAPHQL_NO_QUERY,
         'description' => 'Param "query" is not optional.',

--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -4,6 +4,7 @@ namespace Appwrite\Deployment;
 
 use Ahc\Jwt\JWT;
 use Appwrite\Extend\Exception;
+use Appwrite\Platform\Modules\Compute\Validator\VariableKey;
 use OpenRuntimes\Orchestrator\Enum\CallbackEvent;
 use OpenRuntimes\Orchestrator\Enum\ReadFormat;
 use OpenRuntimes\Orchestrator\Jobs;
@@ -213,11 +214,18 @@ readonly class Deployments
         try {
             $this->jobs->create(...static::payload($this->project, $resource, $deployment, $this->platform, $source));
         } catch (\Throwable $error) {
+            // A refused variable key is the owner's to fix, so the build log
+            // carries the actual reason; anything else stays a generic
+            // internal error.
+            $buildLogs = $error instanceof Exception && $error->getType() === Exception::VARIABLE_INVALID_KEY
+                ? "\n" . $error->getMessage() . "\n"
+                : "\nAn internal error occurred while building. Please try again, and contact support if the problem persists.\n";
+
             // Guarded like the transition above: a cancel that landed while the
             // job was being submitted must not be reported as a failure.
             $this->dbForProject->updateDocuments('deployments', new Document([
                 'status' => 'failed',
-                'buildLogs' => "\nAn internal error occurred while building. Please try again, and contact support if the problem persists.\n",
+                'buildLogs' => $buildLogs,
                 'buildEndedAt' => DateTime::now(),
             ]), [
                 Query::equal('$id', [$deployment->getId()]),
@@ -589,6 +597,19 @@ readonly class Deployments
         }
         foreach ($resource->getAttribute('vars', []) as $var) {
             $vars[$var->getAttribute('key')] = $var->getAttribute('value', '');
+        }
+
+        // Keys that predate the VariableKey endpoint guard can hold bytes the
+        // orchestrator refuses in an env var name (a stray tab, UTF-16 text),
+        // which would reject the whole build job after submission. Refuse only
+        // what the cluster would refuse, before the job leaves this process.
+        foreach (\array_keys($vars) as $key) {
+            if (!VariableKey::isEnvVarName((string) $key)) {
+                throw new Exception(
+                    Exception::VARIABLE_INVALID_KEY,
+                    'Variable key ' . \json_encode((string) $key) . ' is not a valid environment variable name. Update or delete this variable, then retry the deployment.'
+                );
+            }
         }
 
         $apiKey = (new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', $timeout, 0))->encode([

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -348,6 +348,7 @@ class Exception extends \Exception
     public const string VARIABLE_NOT_FOUND = 'variable_not_found';
     public const string VARIABLE_ALREADY_EXISTS = 'variable_already_exists';
     public const string VARIABLE_CANNOT_UNSET_SECRET = 'variable_cannot_unset_secret';
+    public const string VARIABLE_INVALID_KEY = 'variable_invalid_key';
 
     /** Platform */
     public const string PLATFORM_NOT_FOUND = 'platform_not_found';

--- a/src/Appwrite/Platform/Modules/Compute/Validator/VariableKey.php
+++ b/src/Appwrite/Platform/Modules/Compute/Validator/VariableKey.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Appwrite\Platform\Modules\Compute\Validator;
+
+use Utopia\Validator\Text;
+
+/**
+ * Function, site and project variable keys become container environment
+ * variable names at build and runtime. Those must be C_IDENTIFIERs; a stray
+ * tab or an accented letter passes a plain length check but makes the build
+ * job manifest invalid, which fails every deployment for that resource.
+ * Reject at the input boundary instead.
+ *
+ * The endpoint rule here is deliberately stricter than the one Kubernetes
+ * enforces on an env var name (see isEnvVarName()), so that every accepted
+ * key is also portable to dotenv files, docker --env and POSIX shells.
+ */
+class VariableKey extends Text
+{
+    public function __construct(int $length = 0)
+    {
+        parent::__construct($length, 1);
+    }
+
+    public function getDescription(): string
+    {
+        $description = 'Value must contain only letters, digits and underscores and must not start with a digit';
+
+        if ($this->length !== 0) {
+            $description .= ', and be at most ' . $this->length . ' chars';
+        }
+
+        return $description . '.';
+    }
+
+    public function isValid(mixed $value): bool
+    {
+        return parent::isValid($value) && \preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $value) === 1;
+    }
+
+    /**
+     * The rule Kubernetes apimachinery enforces on an EnvVar name
+     * (IsEnvVarName): C_IDENTIFIER extended with hyphens and dots, refusing
+     * '.', '..' and any '..' prefix. Keys that predate the endpoint rule may
+     * violate the endpoint rule yet still deploy fine (e.g. MY-VAR); the
+     * build-layer guard uses this weaker rule so it only refuses keys the
+     * cluster would refuse anyway.
+     */
+    public static function isEnvVarName(string $key): bool
+    {
+        if ($key === '.' || $key === '..' || \str_starts_with($key, '..')) {
+            return false;
+        }
+
+        return \preg_match('/^[-._a-zA-Z][-._a-zA-Z0-9]*$/', $key) === 1;
+    }
+}

--- a/src/Appwrite/Platform/Modules/Functions/Http/Variables/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Variables/Create.php
@@ -5,6 +5,7 @@ namespace Appwrite\Platform\Modules\Functions\Http\Variables;
 use Appwrite\Event\Event as QueueEvent;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Base;
+use Appwrite\Platform\Modules\Compute\Validator\VariableKey;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
@@ -59,7 +60,7 @@ class Create extends Base
             ))
             ->param('functionId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Function unique ID.', false, ['dbForProject'])
             ->param('variableId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Variable ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
-            ->param('key', null, new Text(Database::LENGTH_KEY), 'Variable key. Max length: ' . Database::LENGTH_KEY  . ' chars.', false)
+            ->param('key', null, new VariableKey(Database::LENGTH_KEY), 'Variable key. Letters, digits and underscores only, must not start with a digit. Max length: ' . Database::LENGTH_KEY  . ' chars.', false)
             ->param('value', null, new Text(8192, 0), 'Variable value. Max length: 8192 chars.', false)
             ->param('secret', true, new Boolean(), 'Secret variables can be updated or deleted, but only functions can read them during build and runtime.', true)
             ->inject('response')

--- a/src/Appwrite/Platform/Modules/Functions/Http/Variables/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Variables/Update.php
@@ -5,6 +5,7 @@ namespace Appwrite\Platform\Modules\Functions\Http\Variables;
 use Appwrite\Event\Event as QueueEvent;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Base;
+use Appwrite\Platform\Modules\Compute\Validator\VariableKey;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
@@ -58,7 +59,7 @@ class Update extends Base
             ))
             ->param('functionId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Function unique ID.', false, ['dbForProject'])
             ->param('variableId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Variable unique ID.', false, ['dbForProject'])
-            ->param('key', null, new Nullable(new Text(255, 0)), 'Variable key. Max length: 255 chars.', true)
+            ->param('key', null, new Nullable(new VariableKey(255)), 'Variable key. Letters, digits and underscores only, must not start with a digit. Max length: 255 chars.', true)
             ->param('value', null, new Nullable(new Text(8192, 0)), 'Variable value. Max length: 8192 chars.', true)
             ->param('secret', null, new Nullable(new Boolean()), 'Secret variables can be updated or deleted, but only functions can read them during build and runtime.', true)
             ->inject('response')

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Create.php
@@ -4,6 +4,7 @@ namespace Appwrite\Platform\Modules\Project\Http\Project\Variables;
 
 use Appwrite\Event\Event as QueueEvent;
 use Appwrite\Extend\Exception;
+use Appwrite\Platform\Modules\Compute\Validator\VariableKey;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
@@ -54,7 +55,7 @@ class Create extends Action
                 ],
             ))
             ->param('variableId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Variable unique ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
-            ->param('key', null, new Text(Database::LENGTH_KEY), 'Variable key. Max length: ' . Database::LENGTH_KEY  . ' chars.')
+            ->param('key', null, new VariableKey(Database::LENGTH_KEY), 'Variable key. Letters, digits and underscores only, must not start with a digit. Max length: ' . Database::LENGTH_KEY  . ' chars.')
             ->param('value', null, new Text(8192, 0), 'Variable value. Max length: 8192 chars.')
             ->param('secret', true, new Boolean(), 'Secret variables can be updated or deleted, but only projects can read them during build and runtime.', true)
             ->inject('response')

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Update.php
@@ -4,6 +4,7 @@ namespace Appwrite\Platform\Modules\Project\Http\Project\Variables;
 
 use Appwrite\Event\Event as QueueEvent;
 use Appwrite\Extend\Exception;
+use Appwrite\Platform\Modules\Compute\Validator\VariableKey;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
@@ -53,7 +54,7 @@ class Update extends Action
                 ]
             ))
             ->param('variableId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Variable unique ID.', false, ['dbForProject'])
-            ->param('key', null, new Nullable(new Text(255, 0)), 'Variable key. Max length: 255 chars.', true)
+            ->param('key', null, new Nullable(new VariableKey(255)), 'Variable key. Letters, digits and underscores only, must not start with a digit. Max length: 255 chars.', true)
             ->param('value', null, new Nullable(new Text(8192, 0)), 'Variable value. Max length: 8192 chars.', true)
             ->param('secret', null, new Nullable(new Boolean()), 'Secret variables can be updated or deleted, but only projects can read them during build and runtime.', true)
             ->inject('response')

--- a/src/Appwrite/Platform/Modules/Sites/Http/Variables/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Variables/Create.php
@@ -5,6 +5,7 @@ namespace Appwrite\Platform\Modules\Sites\Http\Variables;
 use Appwrite\Event\Event as QueueEvent;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Base;
+use Appwrite\Platform\Modules\Compute\Validator\VariableKey;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
@@ -59,7 +60,7 @@ class Create extends Base
             ))
             ->param('siteId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Site unique ID.', false, ['dbForProject'])
             ->param('variableId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Variable ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
-            ->param('key', null, new Text(Database::LENGTH_KEY), 'Variable key. Max length: ' . Database::LENGTH_KEY  . ' chars.', false)
+            ->param('key', null, new VariableKey(Database::LENGTH_KEY), 'Variable key. Letters, digits and underscores only, must not start with a digit. Max length: ' . Database::LENGTH_KEY  . ' chars.', false)
             ->param('value', null, new Text(8192, 0), 'Variable value. Max length: 8192 chars.', false)
             ->param('secret', true, new Boolean(), 'Secret variables can be updated or deleted, but only sites can read them during build and runtime.', true)
             ->inject('response')

--- a/src/Appwrite/Platform/Modules/Sites/Http/Variables/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Variables/Update.php
@@ -5,6 +5,7 @@ namespace Appwrite\Platform\Modules\Sites\Http\Variables;
 use Appwrite\Event\Event as QueueEvent;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Base;
+use Appwrite\Platform\Modules\Compute\Validator\VariableKey;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
@@ -58,7 +59,7 @@ class Update extends Base
             ))
             ->param('siteId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Site unique ID.', false, ['dbForProject'])
             ->param('variableId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Variable unique ID.', false, ['dbForProject'])
-            ->param('key', null, new Nullable(new Text(255, 0)), 'Variable key. Max length: 255 chars.', true)
+            ->param('key', null, new Nullable(new VariableKey(255)), 'Variable key. Letters, digits and underscores only, must not start with a digit. Max length: 255 chars.', true)
             ->param('value', null, new Nullable(new Text(8192, 0)), 'Variable value. Max length: 8192 chars.', true)
             ->param('secret', null, new Nullable(new Boolean()), 'Secret variables can be updated or deleted, but only sites can read them during build and runtime.', true)
             ->inject('response')

--- a/tests/e2e/Services/Functions/FunctionsConsoleClientTest.php
+++ b/tests/e2e/Services/Functions/FunctionsConsoleClientTest.php
@@ -244,6 +244,20 @@ final class FunctionsConsoleClientTest extends Scope
 
         $this->assertEquals(400, $variable['headers']['status-code']);
 
+        // Test for a key that is not a valid env var name
+        foreach (['9KEY', 'MY KEY', 'MY-KEY', "TRAILING_TAB\t", "V\x00I\x00T\x00E"] as $invalidKey) {
+            $variable = $this->createVariable(
+                $functionId,
+                [
+                    'variableId' => ID::unique(),
+                    'key' => $invalidKey,
+                    'value' => 'TESTINGVALUE'
+                ]
+            );
+
+            $this->assertEquals(400, $variable['headers']['status-code'], 'Key ' . json_encode($invalidKey) . ' should be refused');
+        }
+
         // Test for invalid value
         $variable = $this->createVariable(
             $functionId,

--- a/tests/e2e/Services/Project/VariablesBase.php
+++ b/tests/e2e/Services/Project/VariablesBase.php
@@ -122,6 +122,52 @@ trait VariablesBase
         $this->assertSame(400, $variable['headers']['status-code']);
     }
 
+    public function testCreateVariableInvalidKey(): void
+    {
+        // Keys become container env var names; anything that is not a
+        // C_IDENTIFIER is refused at the endpoint.
+        $keys = [
+            '9KEY',
+            'MY KEY',
+            'MY-KEY',
+            'my.key',
+            'FOO=BAR',
+            "TRAILING_TAB\t",
+            'GRAVAÇÃO',
+            "V\x00I\x00T\x00E_GEMINI_API_KEY",
+        ];
+
+        foreach ($keys as $key) {
+            $response = $this->createVariable(ID::unique(), $key, 'value');
+
+            $this->assertSame(400, $response['headers']['status-code'], 'Key ' . \json_encode($key) . ' should be refused');
+        }
+    }
+
+    public function testUpdateVariableInvalidKeyLeavesVariableUnchanged(): void
+    {
+        $variable = $this->createVariable(
+            ID::unique(),
+            'VALID_KEY',
+            'valid-value',
+            false
+        );
+
+        $this->assertSame(201, $variable['headers']['status-code']);
+        $variableId = $variable['body']['$id'];
+
+        $updated = $this->updateVariable($variableId, "BAD KEY\t", 'new-value');
+        $this->assertSame(400, $updated['headers']['status-code']);
+
+        $get = $this->getVariable($variableId);
+        $this->assertSame(200, $get['headers']['status-code']);
+        $this->assertSame('VALID_KEY', $get['body']['key']);
+        $this->assertSame('valid-value', $get['body']['value']);
+
+        // Cleanup
+        $this->deleteVariable($variableId);
+    }
+
     public function testCreateVariableMissingKey(): void
     {
         $response = $this->createVariable(

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -360,6 +360,17 @@ final class SitesCustomServerTest extends Scope
         $this->assertEquals('', $secretVariable['body']['value']);
         $this->assertEquals(true, $secretVariable['body']['secret']);
 
+        // A key that is not a valid env var name is refused
+        foreach (['9KEY', 'MY KEY', 'MY-KEY', "TRAILING_TAB\t", "V\x00I\x00T\x00E"] as $invalidKey) {
+            $invalidVariable = $this->createVariable($siteId, [
+                'variableId' => ID::unique(),
+                'key' => $invalidKey,
+                'value' => 'siteValue',
+            ]);
+
+            $this->assertEquals(400, $invalidVariable['headers']['status-code'], 'Key ' . json_encode($invalidKey) . ' should be refused');
+        }
+
         $variable = $this->getVariable($siteId, $variable['body']['$id']);
 
         $this->assertEquals(200, $variable['headers']['status-code']);

--- a/tests/unit/Deployment/DeploymentsTest.php
+++ b/tests/unit/Deployment/DeploymentsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Deployment;
 
 use Appwrite\Deployment\Deployments;
+use Appwrite\Extend\Exception;
 use PHPUnit\Framework\TestCase;
 use Utopia\Config\Config;
 use Utopia\Database\Document;
@@ -125,5 +126,60 @@ final class DeploymentsTest extends TestCase
         ]);
 
         $this->assertSame(['users.read'], Deployments::scopes($site));
+    }
+
+    private function buildPayload(array $vars): array
+    {
+        // Presigned-URL and ephemeral-key signing both run before the
+        // variables are assembled, and refuse an empty key.
+        \putenv('_APP_OPENSSL_KEY_V1=unit-test-key');
+
+        $runtimeKey = \array_key_first(Config::getParam('runtimes-v2'));
+
+        return ExposedDeployments::submitPayload(
+            new Document(['$id' => 'project1', 'region' => 'default']),
+            new Document([
+                '$id' => 'function1',
+                '$collection' => 'functions',
+                'runtime' => $runtimeKey,
+                'vars' => \array_map(
+                    fn (string $key, string $value) => new Document(['key' => $key, 'value' => $value]),
+                    \array_keys($vars),
+                    \array_values($vars),
+                ),
+            ]),
+            new Document(['$id' => 'deployment1', 'buildCommands' => 'npm install']),
+            ['apiHostname' => 'localhost'],
+        );
+    }
+
+    public function testPayloadRefusesVariableKeyTheClusterWouldRefuse(): void
+    {
+        try {
+            $this->buildPayload(["V\x00I\x00T\x00E_KEY" => 'secret']);
+            $this->fail('Expected the invalid variable key to be refused before job submission');
+        } catch (Exception $error) {
+            $this->assertSame(Exception::VARIABLE_INVALID_KEY, $error->getType());
+            $this->assertStringContainsString(\json_encode("V\x00I\x00T\x00E_KEY"), $error->getMessage());
+            $this->assertStringNotContainsString('secret', $error->getMessage());
+        }
+    }
+
+    public function testPayloadKeepsLegacyKeysTheClusterAccepts(): void
+    {
+        // MY-VAR predates the strict endpoint rule but deploys fine; the
+        // build-layer guard must not take working deployments down with it.
+        $payload = $this->buildPayload(['MY-VAR' => 'v1', 'MY_VAR' => 'v2']);
+
+        $this->assertSame('v1', $payload['environment']['MY-VAR']);
+        $this->assertSame('v2', $payload['environment']['MY_VAR']);
+    }
+}
+
+final readonly class ExposedDeployments extends Deployments
+{
+    public static function submitPayload(Document $project, Document $resource, Document $deployment, array $platform): array
+    {
+        return static::payload($project, $resource, $deployment, $platform);
     }
 }

--- a/tests/unit/Platform/Modules/Compute/Validator/VariableKeyTest.php
+++ b/tests/unit/Platform/Modules/Compute/Validator/VariableKeyTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform\Modules\Compute\Validator;
+
+use Appwrite\Platform\Modules\Compute\Validator\VariableKey;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class VariableKeyTest extends TestCase
+{
+    public static function endpointKeys(): array
+    {
+        return [
+            'plain' => ['MY_KEY', true],
+            'lowercase' => ['my_key', true],
+            'leading underscore' => ['_KEY', true],
+            'digits after first char' => ['KEY_2', true],
+            'single letter' => ['a', true],
+
+            'empty' => ['', false],
+            'leading digit' => ['9KEY', false],
+            'space' => ['MY KEY', false],
+            'hyphen' => ['MY-KEY', false],
+            'dot' => ['my.key', false],
+            'equals sign' => ['FOO=BAR', false],
+            'trailing tab' => ["MY_KEY\t", false],
+            'accented letter' => ['GRAVAÇÃO', false],
+            'utf-16 bytes' => ["V\x00I\x00T\x00E", false],
+        ];
+    }
+
+    #[DataProvider('endpointKeys')]
+    public function testEndpointRule(string $key, bool $valid): void
+    {
+        $this->assertSame($valid, (new VariableKey())->isValid($key));
+    }
+
+    public function testEndpointRuleEnforcesMaxLength(): void
+    {
+        $validator = new VariableKey(4);
+
+        $this->assertTrue($validator->isValid('ABCD'));
+        $this->assertFalse($validator->isValid('ABCDE'));
+    }
+
+    public static function envVarNames(): array
+    {
+        return [
+            'plain' => ['MY_KEY', true],
+            // Keys that predate the endpoint rule and still deploy fine.
+            'hyphen' => ['MY-VAR', true],
+            'dot' => ['my.env-name', true],
+            'leading dot' => ['.profile', true],
+
+            'empty' => ['', false],
+            'single dot' => ['.', false],
+            'double dot' => ['..', false],
+            'double dot prefix' => ['..FOO', false],
+            'leading digit' => ['9FOO', false],
+            'space' => ['MY VAR', false],
+            'equals sign' => ['FOO=BAR', false],
+            'trailing tab' => ["EZVIZ_APP_SECRET\t", false],
+            'accented letter' => ['GRAVAÇÃO', false],
+            'utf-16 bytes' => ["V\x00I\x00T\x00E", false],
+        ];
+    }
+
+    #[DataProvider('envVarNames')]
+    public function testKubernetesRule(string $key, bool $valid): void
+    {
+        $this->assertSame($valid, VariableKey::isEnvVarName($key));
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Variable keys become container env var names at build and runtime. A key holding a stray tab or UTF-16 bytes (e.g. a `.env` file saved as UTF-16 and imported, storing every character with an interleaved NUL byte) passed the plain length check, was stored, and then invalidated the build job manifest at submission -- failing every deployment for that resource with an opaque "internal error", and (on cloud) a 500 out of the VCS webhook per affected push.

Two layers, two deliberately different rules:

- **Endpoint guard** -- new `Appwrite\Platform\Modules\Compute\Validator\VariableKey` on the function, site and project variable create/update endpoints. Requires a C_IDENTIFIER (`[A-Za-z_][A-Za-z0-9_]*`), so every accepted key is also portable to dotenv files, `docker --env` and POSIX shells.
- **Build guard** -- `Deployments::variables()` refuses keys via `VariableKey::isEnvVarName()`, the *Kubernetes* rule (apimachinery `IsEnvVarName`: hyphens and dots allowed, `.`/`..`/`..*` refused). Weaker than the endpoint rule on purpose: legacy keys like `MY-VAR` that deploy fine today keep deploying; only keys the cluster would reject anyway now fail fast -- before job submission, with the actual reason (key name JSON-encoded, value never printed) written to the deployment's `buildLogs` instead of the generic internal error.

The new `variable_invalid_key` error is 400-class, so the VCS webhook fan-out skips just the affected repository and continues to other projects (existing `code < 500` skip branch), the webhook returns 2xx, and the error handler does not publish it to the logging provider.

## Test plan

- `tests/unit/Platform/Modules/Compute/Validator/VariableKeyTest.php` -- both rules, 30 cases including synthetic UTF-16 and trailing-tab shapes matching defects seen in production.
- `tests/unit/Deployment/DeploymentsTest.php` -- drives `payload()`: an invalid key is refused before job submission (verified red with the guard reverted), and `MY-VAR` still builds.
- e2e: invalid keys 400 on project, function and site variable endpoints; invalid update leaves the variable unchanged.
- Existing e2e variable fixtures scanned -- none use a key the new rule refuses.

## Related PRs and Issues

- Companion cloud data cleanup: appwrite-labs/cloud#5363 (merged; reported/trimmed existing offending rows).
- Console fix for the ingestion origin (UTF-16 `.env` import): appwrite/console#3186.
