### PR TITLE
Fix TypeError when createDocument is called with null data

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
@@ -148,9 +148,9 @@ class Create extends Action
             ->callback($this->action(...));
     }
 
-    public function action(string $databaseId, ?string $documentId, string $collectionId, string|array|\stdClass $data, ?array $permissions, ?array $documents, ?string $transactionId, UtopiaResponse $response, Database $dbForProject, callable $getDatabasesDB, User $user, Event $queueForEvents, Context $usage, Event $queueForRealtime, FunctionPublisher $publisherForFunctions, Event $queueForWebhooks, array $plan, Authorization $authorization, EventProcessor $eventProcessor): void
+    public function action(string $databaseId, ?string $documentId, string $collectionId, string|array|\stdClass|null $data, ?array $permissions, ?array $documents, ?string $transactionId, UtopiaResponse $response, Database $dbForProject, callable $getDatabasesDB, User $user, Event $queueForEvents, Context $usage, Event $queueForRealtime, FunctionPublisher $publisherForFunctions, Event $queueForWebhooks, array $plan, Authorization $authorization, EventProcessor $eventProcessor): void
     {
-        $data = $this->normalizeData($data);
+        $data = $this->normalizeData($data ?? []);
 
         if ($documents !== null) {
             foreach ($documents as $key => $document) {

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -2842,19 +2842,45 @@ trait DatabasesBase
         /**
          * Test for SUCCESS
          * Bulk create with only documents/rows (no `data` key) must still work.
-         * Use books: movies has a relationship, and bulk create is not supported then.
+         * Use a dedicated collection: movies has a relationship (bulk create is
+         * rejected), and books is shared with fulltext search fixtures.
          */
+        $bulkCollection = $this->client->call(Client::METHOD_POST, $this->getContainerUrl($databaseId), [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            $this->getContainerIdParam() => ID::unique(),
+            'name' => 'Bulk without data key',
+            $this->getSecurityParam() => false,
+            'permissions' => [
+                Permission::create(Role::any()),
+                Permission::read(Role::any()),
+            ],
+        ]);
+        $this->assertEquals(201, $bulkCollection['headers']['status-code']);
+        $bulkCollectionId = $bulkCollection['body']['$id'];
+
+        if ($this->getSupportForAttributes()) {
+            $title = $this->createAttribute($databaseId, $bulkCollectionId, 'string', [
+                'key' => 'title',
+                'size' => 256,
+                'required' => false,
+            ]);
+            $this->assertEquals(202, $title['headers']['status-code']);
+            $this->waitForAllAttributes($databaseId, $bulkCollectionId);
+        }
+
         $bulkDocumentId = ID::unique();
         $bulkCreated = $this->client->call(
             Client::METHOD_POST,
-            $this->getRecordUrl($databaseId, $data['booksId']),
+            $this->getRecordUrl($databaseId, $bulkCollectionId),
             $headers,
             [
                 $this->getRecordResource() => [
                     [
                         '$id' => $bulkDocumentId,
                         'title' => 'Bulk without data key',
-                        'description' => 'Created without a data key',
                     ],
                 ],
             ]

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -2717,6 +2717,41 @@ trait DatabasesBase
             $missingId['body']['type']
         );
 
+        /**
+         * Test for FAILURE
+         * Omitted `data` (and no documents/rows) or JSON `data: null` must 400,
+         * not TypeError 500. DocumentsDB allows empty documents.
+         */
+        $missingDataCases = [
+            [
+                $this->getRecordIdParam() => ID::unique(),
+            ],
+            [
+                $this->getRecordIdParam() => ID::unique(),
+                'data' => null,
+            ],
+        ];
+        $missingDataType = $this->getRecordIdParam() === 'documentId'
+            ? Exception::DOCUMENT_MISSING_DATA
+            : Exception::ROW_MISSING_DATA;
+
+        foreach ($missingDataCases as $payload) {
+            $missingData = $this->client->call(
+                Client::METHOD_POST,
+                $this->getRecordUrl($databaseId, $data['moviesId']),
+                $headers,
+                $payload
+            );
+
+            $this->assertNotEquals(500, $missingData['headers']['status-code']);
+            if ($this->getDatabaseType() === 'documentsdb') {
+                $this->assertEquals(201, $missingData['headers']['status-code']);
+            } else {
+                $this->assertEquals(400, $missingData['headers']['status-code']);
+                $this->assertEquals($missingDataType, $missingData['body']['type']);
+            }
+        }
+
         $documentId = ID::unique();
         $invalid = $this->client->call(
             Client::METHOD_POST,
@@ -2803,6 +2838,30 @@ trait DatabasesBase
         );
 
         $this->assertEquals(404, $bulkNotCreated['headers']['status-code']);
+
+        /**
+         * Test for SUCCESS
+         * Bulk create with only documents/rows (no `data` key) must still work.
+         */
+        $bulkDocumentId = ID::unique();
+        $bulkCreated = $this->client->call(
+            Client::METHOD_POST,
+            $this->getRecordUrl($databaseId, $data['moviesId']),
+            $headers,
+            [
+                $this->getRecordResource() => [
+                    [
+                        '$id' => $bulkDocumentId,
+                        'title' => 'Bulk without data key',
+                        'releaseYear' => 2001,
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertEquals(201, $bulkCreated['headers']['status-code']);
+        $this->assertEquals(1, $bulkCreated['body']['total']);
+        $this->assertEquals('Bulk without data key', $bulkCreated['body'][$this->getRecordResource()][0]['title']);
     }
 
     public function testUpsertDocument(): void

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -2842,18 +2842,19 @@ trait DatabasesBase
         /**
          * Test for SUCCESS
          * Bulk create with only documents/rows (no `data` key) must still work.
+         * Use books: movies has a relationship, and bulk create is not supported then.
          */
         $bulkDocumentId = ID::unique();
         $bulkCreated = $this->client->call(
             Client::METHOD_POST,
-            $this->getRecordUrl($databaseId, $data['moviesId']),
+            $this->getRecordUrl($databaseId, $data['booksId']),
             $headers,
             [
                 $this->getRecordResource() => [
                     [
                         '$id' => $bulkDocumentId,
                         'title' => 'Bulk without data key',
-                        'releaseYear' => 2001,
+                        'description' => 'Created without a data key',
                     ],
                 ],
             ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes Sentry [CLOUD-3QJ7](https://appwrite.sentry.io/issues/CLOUD-3QJ7): `POST /v1/databases/{id}/collections/{id}/documents` TypeErrored with HTTP 500 when `data` was omitted or JSON `null`.

`data` is an optional HTTP param (so bulk `createDocuments` / `createRows` can send `documents`/`rows` instead), but `Create::action()` was typed `string|array|\stdClass $data` and not nullable. Utopia injects `null` for a missing or null JSON value, so PHP fataled before the existing empty-payload handling could throw `DOCUMENT_MISSING_DATA` / `ROW_MISSING_DATA`.

This change:
- Accepts `null` on `Create::action()` `$data`
- Coalesces to `[]` before `normalizeData()` so empty collections/tables creates still 400 via `getMissingDataException()`
- Does **not** make `data` required at the HTTP param layer (that would break bulk create)
- Does **not** invent a default document

TablesDB `createRow` / `createRows` subclasses this action, so one change covers both.

## Test Plan

Extended `tests/e2e/Services/Databases/DatabasesBase.php` `testCreateDocumentInvalidData`:
- POST createDocument/createRow with omitted `data` (and no `documents`/`rows`) returns 400 `DOCUMENT_MISSING_DATA` / `ROW_MISSING_DATA`, not 500
- POST with JSON `"data": null` returns 400, not 500 TypeError
- Existing happy path `testCreateDocument` still 201s with a real data object
- Bulk createDocuments/createRows with only `documents`/`rows` (no `data` key) still 201s on a dedicated collection/table without relationships (movies rejects bulk create; books is a shared fulltext fixture)

DocumentsDB allows empty documents (`getSupportForEmptyDocument()`), so that API still 201s on omitted/null `data` instead of 400.

## Related PRs and Issues

- Sentry: https://appwrite.sentry.io/issues/CLOUD-3QJ7
- Fixes CLOUD-3QJ7

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76c3cf17-3bf3-4843-b0f1-50ad10999550?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76c3cf17-3bf3-4843-b0f1-50ad10999550&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

