### PR TITLE
fix(messaging): validate FCM service account credentials

### DIFF
--- a/app/controllers/api/messaging.php
+++ b/app/controllers/api/messaging.php
@@ -1028,6 +1028,14 @@ Http::post('/v1/messaging/providers/fcm')
             ? \json_decode($serviceAccountJSON, true)
             : normalizeJsonObject($serviceAccountJSON);
 
+        if (!\is_null($serviceAccountJSON)) {
+            foreach (['project_id', 'client_email', 'private_key'] as $field) {
+                if (!isset($serviceAccountJSON[$field]) || !\is_string($serviceAccountJSON[$field]) || \trim($serviceAccountJSON[$field]) === '') {
+                    throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, "FCM service account JSON must include a non-empty '{$field}' field.");
+                }
+            }
+        }
+
         $credentials = [];
 
         if (!\is_null($serviceAccountJSON)) {
@@ -2360,16 +2368,22 @@ Http::patch('/v1/messaging/providers/fcm/:providerId')
             ]);
         }
 
-        if (!\is_null($enabled)) {
-            if ($enabled) {
-                if (\array_key_exists('serviceAccountJSON', $provider->getAttribute('credentials'))) {
-                    $provider->setAttribute('enabled', true);
-                } else {
-                    throw new Exception(Exception::PROVIDER_MISSING_CREDENTIALS);
-                }
-            } else {
-                $provider->setAttribute('enabled', false);
+        if (!\is_null($serviceAccountJSON) || $enabled === true) {
+            $credentials = $provider->getAttribute('credentials');
+
+            if (!\array_key_exists('serviceAccountJSON', $credentials)) {
+                throw new Exception(Exception::PROVIDER_MISSING_CREDENTIALS);
             }
+
+            foreach (['project_id', 'client_email', 'private_key'] as $field) {
+                if (!isset($credentials['serviceAccountJSON'][$field]) || !\is_string($credentials['serviceAccountJSON'][$field]) || \trim($credentials['serviceAccountJSON'][$field]) === '') {
+                    throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, "FCM service account JSON must include a non-empty '{$field}' field.");
+                }
+            }
+        }
+
+        if (!\is_null($enabled)) {
+            $provider->setAttribute('enabled', $enabled);
         }
 
         $provider = $dbForProject->updateDocument('providers', $provider->getId(), $provider);

--- a/app/controllers/api/messaging.php
+++ b/app/controllers/api/messaging.php
@@ -46,6 +46,7 @@ use Utopia\System\System;
 use Utopia\Validator\ArrayList;
 use Utopia\Validator\Boolean;
 use Utopia\Validator\Integer;
+use Utopia\Validator\JSON\FCM as FCMValidator;
 use Utopia\Validator\JSON\ObjectValidator as JSONObject;
 use Utopia\Validator\Nullable;
 use Utopia\Validator\Range;
@@ -1016,7 +1017,7 @@ Http::post('/v1/messaging/providers/fcm')
     ])
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
-    ->param('serviceAccountJSON', null, new Nullable(new JSONObject()), 'FCM service account JSON.', true)
+    ->param('serviceAccountJSON', null, new Nullable(new FCMValidator()), 'FCM service account JSON.', true)
     ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
@@ -1027,14 +1028,6 @@ Http::post('/v1/messaging/providers/fcm')
         $serviceAccountJSON = \is_string($serviceAccountJSON)
             ? \json_decode($serviceAccountJSON, true)
             : normalizeJsonObject($serviceAccountJSON);
-
-        if (!\is_null($serviceAccountJSON)) {
-            foreach (['project_id', 'client_email', 'private_key'] as $field) {
-                if (!isset($serviceAccountJSON[$field]) || !\is_string($serviceAccountJSON[$field]) || \trim($serviceAccountJSON[$field]) === '') {
-                    throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, "FCM service account JSON must include a non-empty '{$field}' field.");
-                }
-            }
-        }
 
         $credentials = [];
 
@@ -2338,7 +2331,7 @@ Http::patch('/v1/messaging/providers/fcm/:providerId')
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
     ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
-    ->param('serviceAccountJSON', null, new Nullable(new JSONObject()), 'FCM service account JSON.', true)
+    ->param('serviceAccountJSON', null, new Nullable(new FCMValidator()), 'FCM service account JSON.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -2375,10 +2368,10 @@ Http::patch('/v1/messaging/providers/fcm/:providerId')
                 throw new Exception(Exception::PROVIDER_MISSING_CREDENTIALS);
             }
 
-            foreach (['project_id', 'client_email', 'private_key'] as $field) {
-                if (!isset($credentials['serviceAccountJSON'][$field]) || !\is_string($credentials['serviceAccountJSON'][$field]) || \trim($credentials['serviceAccountJSON'][$field]) === '') {
-                    throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, "FCM service account JSON must include a non-empty '{$field}' field.");
-                }
+            $validator = new FCMValidator();
+
+            if (!$validator->isValid($credentials['serviceAccountJSON'])) {
+                throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, $validator->getDescription());
             }
         }
 

--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,7 @@
         "utopia-php/dsn": "0.2.1",
         "utopia-php/http": "^2.0@RC",
         "utopia-php/fetch": "^1.1",
-        "utopia-php/validators": "^0.5",
+        "utopia-php/validators": "^0.6",
         "utopia-php/image": "0.8.*",
         "utopia-php/locale": "0.8.*",
         "utopia-php/lock": "0.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9481b6eabc4b962abea525da82d4e962",
+    "content-hash": "384d18b2a74e40ef791a28f37a81c47b",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3042,16 +3042,16 @@
         },
         {
             "name": "utopia-php/audit",
-            "version": "4.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/audit.git",
-                "reference": "0c093d9ad0a22a5008c292fc138cf523d3ce35e1"
+                "reference": "69b8e2a6680585604da326fb7abefb316b6de422"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/audit/zipball/0c093d9ad0a22a5008c292fc138cf523d3ce35e1",
-                "reference": "0c093d9ad0a22a5008c292fc138cf523d3ce35e1",
+                "url": "https://api.github.com/repos/utopia-php/audit/zipball/69b8e2a6680585604da326fb7abefb316b6de422",
+                "reference": "69b8e2a6680585604da326fb7abefb316b6de422",
                 "shasum": ""
             },
             "require": {
@@ -3059,7 +3059,7 @@
                 "utopia-php/database": "^7.0.0",
                 "utopia-php/fetch": "^1.1",
                 "utopia-php/query": "0.6.*",
-                "utopia-php/validators": "^0.5"
+                "utopia-php/validators": "^0.6"
             },
             "type": "library",
             "autoload": {
@@ -3081,9 +3081,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/audit/issues",
-                "source": "https://github.com/utopia-php/audit/tree/4.0.0"
+                "source": "https://github.com/utopia-php/audit/tree/4.0.1"
             },
-            "time": "2026-08-25T06:08:58+00:00"
+            "time": "2026-08-27T06:13:20+00:00"
         },
         {
             "name": "utopia-php/auth",
@@ -3560,16 +3560,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "7.3.0",
+            "version": "7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "d5b2ecaac3b89d80d01220482bc908384034cfea"
+                "reference": "8c0f55a9913c4381aeae27ab25fc513dfdfc20b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/d5b2ecaac3b89d80d01220482bc908384034cfea",
-                "reference": "d5b2ecaac3b89d80d01220482bc908384034cfea",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/8c0f55a9913c4381aeae27ab25fc513dfdfc20b8",
+                "reference": "8c0f55a9913c4381aeae27ab25fc513dfdfc20b8",
                 "shasum": ""
             },
             "require": {
@@ -3582,7 +3582,7 @@
                 "utopia-php/console": "0.1.*",
                 "utopia-php/mongo": "1.*",
                 "utopia-php/pools": "2.*",
-                "utopia-php/validators": "^0.5"
+                "utopia-php/validators": "^0.6"
             },
             "require-dev": {
                 "fakerphp/faker": "1.23.*",
@@ -3614,9 +3614,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/7.3.0"
+                "source": "https://github.com/utopia-php/database/tree/7.3.1"
             },
-            "time": "2026-08-27T00:35:48+00:00"
+            "time": "2026-08-27T05:56:47+00:00"
         },
         {
             "name": "utopia-php/detector",
@@ -3713,16 +3713,16 @@
         },
         {
             "name": "utopia-php/dns",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/dns.git",
-                "reference": "c8d667c0e5031dab9cdec171db7af500217bc4f3"
+                "reference": "fa6d4c4e6a726ab86455e715327f971e50f4f485"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/dns/zipball/c8d667c0e5031dab9cdec171db7af500217bc4f3",
-                "reference": "c8d667c0e5031dab9cdec171db7af500217bc4f3",
+                "url": "https://api.github.com/repos/utopia-php/dns/zipball/fa6d4c4e6a726ab86455e715327f971e50f4f485",
+                "reference": "fa6d4c4e6a726ab86455e715327f971e50f4f485",
                 "shasum": ""
             },
             "require": {
@@ -3730,7 +3730,7 @@
                 "php": ">=8.5",
                 "utopia-php/domains": "^3.0",
                 "utopia-php/telemetry": "^0.4",
-                "utopia-php/validators": "^0.5"
+                "utopia-php/validators": "^0.6"
             },
             "require-dev": {
                 "swoole/ide-helper": "5.1.8"
@@ -3764,28 +3764,28 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/dns/issues",
-                "source": "https://github.com/utopia-php/dns/tree/3.0.2"
+                "source": "https://github.com/utopia-php/dns/tree/3.0.3"
             },
-            "time": "2026-08-14T06:49:12+00:00"
+            "time": "2026-08-27T06:13:20+00:00"
         },
         {
             "name": "utopia-php/domains",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/domains.git",
-                "reference": "cab900a8585adbf10ed345add987cc252b1d7a16"
+                "reference": "021ce3ce8066d52e8672070b3cb1b43935bd2b67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/domains/zipball/cab900a8585adbf10ed345add987cc252b1d7a16",
-                "reference": "cab900a8585adbf10ed345add987cc252b1d7a16",
+                "url": "https://api.github.com/repos/utopia-php/domains/zipball/021ce3ce8066d52e8672070b3cb1b43935bd2b67",
+                "reference": "021ce3ce8066d52e8672070b3cb1b43935bd2b67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.5",
                 "utopia-php/cache": "^4.0 || ^5.0",
-                "utopia-php/validators": "0.*"
+                "utopia-php/validators": "^0.6"
             },
             "require-dev": {
                 "laravel/pint": "^1.18",
@@ -3826,9 +3826,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/domains/issues",
-                "source": "https://github.com/utopia-php/domains/tree/3.0.1"
+                "source": "https://github.com/utopia-php/domains/tree/3.0.2"
             },
-            "time": "2026-08-21T11:43:03+00:00"
+            "time": "2026-08-27T06:33:44+00:00"
         },
         {
             "name": "utopia-php/dsn",
@@ -3879,22 +3879,22 @@
         },
         {
             "name": "utopia-php/emails",
-            "version": "0.8.0",
+            "version": "0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/emails.git",
-                "reference": "ae7baeb3045c3709cd1002e157d5dcbed38de2ea"
+                "reference": "6ee4f75279c8b4e27bd34f05e8310ab44284523c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/emails/zipball/ae7baeb3045c3709cd1002e157d5dcbed38de2ea",
-                "reference": "ae7baeb3045c3709cd1002e157d5dcbed38de2ea",
+                "url": "https://api.github.com/repos/utopia-php/emails/zipball/6ee4f75279c8b4e27bd34f05e8310ab44284523c",
+                "reference": "6ee4f75279c8b4e27bd34f05e8310ab44284523c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.5",
                 "utopia-php/domains": "^3.0",
-                "utopia-php/validators": "0.*"
+                "utopia-php/validators": "^0.6"
             },
             "require-dev": {
                 "laravel/pint": "1.25.*",
@@ -3934,9 +3934,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/emails/issues",
-                "source": "https://github.com/utopia-php/emails/tree/0.8.0"
+                "source": "https://github.com/utopia-php/emails/tree/0.8.1"
             },
-            "time": "2026-07-31T15:11:54+00:00"
+            "time": "2026-08-27T06:18:11+00:00"
         },
         {
             "name": "utopia-php/fetch",
@@ -3976,20 +3976,21 @@
                 "issues": "https://github.com/utopia-php/fetch/issues",
                 "source": "https://github.com/utopia-php/fetch/tree/1.1.2"
             },
+            "abandoned": true,
             "time": "2026-04-29T11:19:19+00:00"
         },
         {
             "name": "utopia-php/http",
-            "version": "2.0.0-rc23",
+            "version": "2.0.0-rc25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "57525e47c56783ea624b0f02339b4ec8f90cca1a"
+                "reference": "54fa5c8a3606110a6d161be93bbbcf0043bbd262"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/57525e47c56783ea624b0f02339b4ec8f90cca1a",
-                "reference": "57525e47c56783ea624b0f02339b4ec8f90cca1a",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/54fa5c8a3606110a6d161be93bbbcf0043bbd262",
+                "reference": "54fa5c8a3606110a6d161be93bbbcf0043bbd262",
                 "shasum": ""
             },
             "require": {
@@ -4000,7 +4001,7 @@
                 "utopia-php/servers": "^0.4",
                 "utopia-php/system": "^0.10",
                 "utopia-php/telemetry": "^0.4",
-                "utopia-php/validators": "^0.5"
+                "utopia-php/validators": "^0.6"
             },
             "require-dev": {
                 "swoole/ide-helper": "4.8.3"
@@ -4027,9 +4028,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/http/issues",
-                "source": "https://github.com/utopia-php/http/tree/2.0.0-rc23"
+                "source": "https://github.com/utopia-php/http/tree/2.0.0-rc25"
             },
-            "time": "2026-08-14T06:49:12+00:00"
+            "time": "2026-08-27T06:13:20+00:00"
         },
         {
             "name": "utopia-php/image",
@@ -4479,16 +4480,16 @@
         },
         {
             "name": "utopia-php/psr7",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/psr7.git",
-                "reference": "115753c36194d53abe5587d383810724ac3a782d"
+                "reference": "7d3f88b9ee0b57237547eef634dbb5399b2a907e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/psr7/zipball/115753c36194d53abe5587d383810724ac3a782d",
-                "reference": "115753c36194d53abe5587d383810724ac3a782d",
+                "url": "https://api.github.com/repos/utopia-php/psr7/zipball/7d3f88b9ee0b57237547eef634dbb5399b2a907e",
+                "reference": "7d3f88b9ee0b57237547eef634dbb5399b2a907e",
                 "shasum": ""
             },
             "require": {
@@ -4519,9 +4520,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/psr7/issues",
-                "source": "https://github.com/utopia-php/psr7/tree/0.2.0"
+                "source": "https://github.com/utopia-php/psr7/tree/0.2.1"
             },
-            "time": "2026-07-06T12:40:23+00:00"
+            "time": "2026-08-25T12:45:40+00:00"
         },
         {
             "name": "utopia-php/query",
@@ -4574,16 +4575,16 @@
         },
         {
             "name": "utopia-php/queue",
-            "version": "1.4.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/queue.git",
-                "reference": "74c7ad088f83f53b1fbac5cc224f3c9be49e5774"
+                "reference": "d757033a1fba2a1c0d7e403c488d6bab4e2ef90a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/queue/zipball/74c7ad088f83f53b1fbac5cc224f3c9be49e5774",
-                "reference": "74c7ad088f83f53b1fbac5cc224f3c9be49e5774",
+                "url": "https://api.github.com/repos/utopia-php/queue/zipball/d757033a1fba2a1c0d7e403c488d6bab4e2ef90a",
+                "reference": "d757033a1fba2a1c0d7e403c488d6bab4e2ef90a",
                 "shasum": ""
             },
             "require": {
@@ -4593,7 +4594,7 @@
                 "utopia-php/pools": "^2.0",
                 "utopia-php/servers": "^0.4",
                 "utopia-php/telemetry": "^0.4",
-                "utopia-php/validators": "^0.5"
+                "utopia-php/validators": "^0.6"
             },
             "require-dev": {
                 "ext-redis": "*",
@@ -4634,9 +4635,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/queue/issues",
-                "source": "https://github.com/utopia-php/queue/tree/1.4.0"
+                "source": "https://github.com/utopia-php/queue/tree/1.5.1"
             },
-            "time": "2026-08-19T13:41:02+00:00"
+            "time": "2026-08-27T06:13:20+00:00"
         },
         {
             "name": "utopia-php/registry",
@@ -4751,22 +4752,22 @@
         },
         {
             "name": "utopia-php/servers",
-            "version": "0.4.8",
+            "version": "0.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/servers.git",
-                "reference": "ab718ee3f3ac6020b9c2988e7304e5099d124b7b"
+                "reference": "7314e5561f8ed08ba164f6a171f924a4b5d5d90d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/servers/zipball/ab718ee3f3ac6020b9c2988e7304e5099d124b7b",
-                "reference": "ab718ee3f3ac6020b9c2988e7304e5099d124b7b",
+                "url": "https://api.github.com/repos/utopia-php/servers/zipball/7314e5561f8ed08ba164f6a171f924a4b5d5d90d",
+                "reference": "7314e5561f8ed08ba164f6a171f924a4b5d5d90d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.5",
                 "utopia-php/di": "^0.3",
-                "utopia-php/validators": "^0.5"
+                "utopia-php/validators": "^0.6"
             },
             "type": "library",
             "autoload": {
@@ -4794,9 +4795,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/servers/issues",
-                "source": "https://github.com/utopia-php/servers/tree/0.4.8"
+                "source": "https://github.com/utopia-php/servers/tree/0.4.9"
             },
-            "time": "2026-08-14T06:49:12+00:00"
+            "time": "2026-08-27T06:13:20+00:00"
         },
         {
             "name": "utopia-php/smtp",
@@ -4885,16 +4886,16 @@
         },
         {
             "name": "utopia-php/storage",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/storage.git",
-                "reference": "4be424e24022b7f25a4a0a60a0f4dbf45fccc02d"
+                "reference": "593e732644ac809df18ae45b5561acf0a0c5e1be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/storage/zipball/4be424e24022b7f25a4a0a60a0f4dbf45fccc02d",
-                "reference": "4be424e24022b7f25a4a0a60a0f4dbf45fccc02d",
+                "url": "https://api.github.com/repos/utopia-php/storage/zipball/593e732644ac809df18ae45b5561acf0a0c5e1be",
+                "reference": "593e732644ac809df18ae45b5561acf0a0c5e1be",
                 "shasum": ""
             },
             "require": {
@@ -4907,7 +4908,7 @@
                 "utopia-php/client": "0.2.* || 0.3.*",
                 "utopia-php/psr7": "0.2.*",
                 "utopia-php/telemetry": "^0.4.6",
-                "utopia-php/validators": "^0.5"
+                "utopia-php/validators": "^0.6"
             },
             "type": "library",
             "autoload": {
@@ -4929,9 +4930,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/storage/issues",
-                "source": "https://github.com/utopia-php/storage/tree/4.0.4"
+                "source": "https://github.com/utopia-php/storage/tree/4.0.5"
             },
-            "time": "2026-08-14T06:49:12+00:00"
+            "time": "2026-08-27T06:13:20+00:00"
         },
         {
             "name": "utopia-php/system",
@@ -4986,20 +4987,19 @@
         },
         {
             "name": "utopia-php/telemetry",
-            "version": "0.4.6",
+            "version": "0.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/telemetry.git",
-                "reference": "f96778a01792c32df0876fe1f38a79b9588445d8"
+                "reference": "186dc1c1f92fbd15a1aa6a63515d0f4251dc88ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/telemetry/zipball/f96778a01792c32df0876fe1f38a79b9588445d8",
-                "reference": "f96778a01792c32df0876fe1f38a79b9588445d8",
+                "url": "https://api.github.com/repos/utopia-php/telemetry/zipball/186dc1c1f92fbd15a1aa6a63515d0f4251dc88ff",
+                "reference": "186dc1c1f92fbd15a1aa6a63515d0f4251dc88ff",
                 "shasum": ""
             },
             "require": {
-                "ext-protobuf": "*",
                 "nyholm/psr7": "1.*",
                 "open-telemetry/exporter-otlp": "1.*",
                 "open-telemetry/sdk": "1.*",
@@ -5010,6 +5010,7 @@
                 "swoole/ide-helper": "6.*"
             },
             "suggest": {
+                "ext-protobuf": "For better performance, when dealing with the protobuf format",
                 "ext-sockets": "Required for the Swoole transport implementation",
                 "ext-swoole": "Required for the Swoole transport implementation"
             },
@@ -5031,9 +5032,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/telemetry/issues",
-                "source": "https://github.com/utopia-php/telemetry/tree/0.4.6"
+                "source": "https://github.com/utopia-php/telemetry/tree/0.4.7"
             },
-            "time": "2026-08-05T17:56:48+00:00"
+            "time": "2026-08-26T17:59:59+00:00"
         },
         {
             "name": "utopia-php/usage",
@@ -5132,16 +5133,16 @@
         },
         {
             "name": "utopia-php/validators",
-            "version": "0.5.0",
+            "version": "0.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/validators.git",
-                "reference": "ea6c1ad13019c8a088866cf422c232928de5a25e"
+                "reference": "7afdde56a7a635f0cb3d8a5e22ebbef40baf31dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/validators/zipball/ea6c1ad13019c8a088866cf422c232928de5a25e",
-                "reference": "ea6c1ad13019c8a088866cf422c232928de5a25e",
+                "url": "https://api.github.com/repos/utopia-php/validators/zipball/7afdde56a7a635f0cb3d8a5e22ebbef40baf31dc",
+                "reference": "7afdde56a7a635f0cb3d8a5e22ebbef40baf31dc",
                 "shasum": ""
             },
             "require": {
@@ -5166,9 +5167,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/validators/issues",
-                "source": "https://github.com/utopia-php/validators/tree/0.5.0"
+                "source": "https://github.com/utopia-php/validators/tree/0.6.0"
             },
-            "time": "2026-08-14T05:12:07+00:00"
+            "time": "2026-08-27T04:46:08+00:00"
         },
         {
             "name": "utopia-php/vcs",

--- a/src/Appwrite/GraphQL/Types/Mapper.php
+++ b/src/Appwrite/GraphQL/Types/Mapper.php
@@ -349,6 +349,7 @@ class Mapper
                 $type = Types::assoc();
                 break;
             case \Utopia\Validator\JSON::class:
+            case \Utopia\Validator\JSON\FCM::class:
             case \Utopia\Validator\JSON\ObjectValidator::class:
                 $type = Types::json();
                 break;

--- a/tests/e2e/Services/GraphQL/MessagingTest.php
+++ b/tests/e2e/Services/GraphQL/MessagingTest.php
@@ -99,7 +99,8 @@ final class MessagingTest extends Scope
                     "project_id" => "test-project",
                     "private_key_id" => "test-private-key-id",
                     "client_email" => "test@appwrite.iam.gserviceaccount.com",
-                    "private_key" => "test-private-key",
+                    "token_uri" => "https://oauth2.googleapis.com/token",
+                    "private_key" => "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
                 ]
             ],
             'Apns' => [
@@ -200,7 +201,8 @@ final class MessagingTest extends Scope
                     'project_id' => 'test-project',
                     'private_key_id' => 'test-project-id',
                     'client_email' => 'test@appwrite.iam.gserviceaccount.com',
-                    'private_key' => "test-private-key",
+                    'token_uri' => 'https://oauth2.googleapis.com/token',
+                    'private_key' => "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
                 ]
             ],
             'Apns' => [
@@ -747,7 +749,8 @@ final class MessagingTest extends Scope
                     "project_id" => "test-project",
                     "private_key_id" => "test-private-key-id",
                     "client_email" => "test@appwrite.iam.gserviceaccount.com",
-                    "private_key" => "test-private-key",
+                    "token_uri" => "https://oauth2.googleapis.com/token",
+                    "private_key" => "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
                 ]
             ],
         ];

--- a/tests/e2e/Services/GraphQL/MessagingTest.php
+++ b/tests/e2e/Services/GraphQL/MessagingTest.php
@@ -98,6 +98,7 @@ final class MessagingTest extends Scope
                     'type' => 'service_account',
                     "project_id" => "test-project",
                     "private_key_id" => "test-private-key-id",
+                    "client_email" => "test@appwrite.iam.gserviceaccount.com",
                     "private_key" => "test-private-key",
                 ]
             ],
@@ -198,6 +199,7 @@ final class MessagingTest extends Scope
                     'type' => 'service_account',
                     'project_id' => 'test-project',
                     'private_key_id' => 'test-project-id',
+                    'client_email' => 'test@appwrite.iam.gserviceaccount.com',
                     'private_key' => "test-private-key",
                 ]
             ],
@@ -744,6 +746,7 @@ final class MessagingTest extends Scope
                     'type' => 'service_account',
                     "project_id" => "test-project",
                     "private_key_id" => "test-private-key-id",
+                    "client_email" => "test@appwrite.iam.gserviceaccount.com",
                     "private_key" => "test-private-key",
                 ]
             ],

--- a/tests/e2e/Services/Messaging/MessagingBase.php
+++ b/tests/e2e/Services/Messaging/MessagingBase.php
@@ -115,6 +115,7 @@ trait MessagingBase
                     'type' => 'service_account',
                     "project_id" => "test-project",
                     "private_key_id" => "test-private-key-id",
+                    "client_email" => "test@appwrite.iam.gserviceaccount.com",
                     "private_key" => "test-private-key",
                 ],
             ],
@@ -208,6 +209,7 @@ trait MessagingBase
                     'type' => 'service_account',
                     "project_id" => "test-project",
                     "private_key_id" => "test-private-key-id",
+                    "client_email" => "test@appwrite.iam.gserviceaccount.com",
                     "private_key" => "test-private-key",
                 ]
             ],
@@ -824,6 +826,7 @@ trait MessagingBase
                     'type' => 'service_account',
                     "project_id" => "test-project",
                     "private_key_id" => "test-private-key-id",
+                    "client_email" => "test@appwrite.iam.gserviceaccount.com",
                     "private_key" => "test-private-key",
                 ],
             ],
@@ -912,6 +915,7 @@ trait MessagingBase
                     'type' => 'service_account',
                     "project_id" => "test-project",
                     "private_key_id" => "test-private-key-id",
+                    "client_email" => "test@appwrite.iam.gserviceaccount.com",
                     "private_key" => "test-private-key",
                 ]
             ],
@@ -959,6 +963,55 @@ trait MessagingBase
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals('Mailgun2', $response['body']['name']);
         $this->assertEquals(false, $response['body']['enabled']);
+    }
+
+    public function testCreateFCMProviderInvalidCredentials(): void
+    {
+        $response = $this->client->call(Client::METHOD_POST, '/messaging/providers/fcm', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'providerId' => ID::unique(),
+            'name' => 'Invalid FCM',
+            'serviceAccountJSON' => [
+                'project_id' => 'test-project',
+                'client_email' => 'test@appwrite.iam.gserviceaccount.com',
+            ],
+        ]);
+
+        $this->assertEquals(400, $response['headers']['status-code']);
+        $this->assertEquals('general_argument_invalid', $response['body']['type']);
+        $this->assertEquals("FCM service account JSON must include a non-empty 'private_key' field.", $response['body']['message']);
+    }
+
+    public function testUpdateFCMProviderInvalidCredentials(): void
+    {
+        $provider = $this->client->call(Client::METHOD_POST, '/messaging/providers/fcm', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'providerId' => ID::unique(),
+            'name' => 'FCM',
+        ]);
+
+        $this->assertEquals(201, $provider['headers']['status-code']);
+
+        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/fcm/' . $provider['body']['$id'], [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'serviceAccountJSON' => [
+                'project_id' => 'test-project',
+                'private_key' => 'test-private-key',
+            ],
+        ]);
+
+        $this->assertEquals(400, $response['headers']['status-code']);
+        $this->assertEquals('general_argument_invalid', $response['body']['type']);
+        $this->assertEquals("FCM service account JSON must include a non-empty 'client_email' field.", $response['body']['message']);
     }
 
     public function testUpdateProviderMissingCredentialsThrows(): void

--- a/tests/e2e/Services/Messaging/MessagingBase.php
+++ b/tests/e2e/Services/Messaging/MessagingBase.php
@@ -116,7 +116,8 @@ trait MessagingBase
                     "project_id" => "test-project",
                     "private_key_id" => "test-private-key-id",
                     "client_email" => "test@appwrite.iam.gserviceaccount.com",
-                    "private_key" => "test-private-key",
+                    "token_uri" => "https://oauth2.googleapis.com/token",
+                    "private_key" => "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
                 ],
             ],
             'apns' => [
@@ -210,7 +211,8 @@ trait MessagingBase
                     "project_id" => "test-project",
                     "private_key_id" => "test-private-key-id",
                     "client_email" => "test@appwrite.iam.gserviceaccount.com",
-                    "private_key" => "test-private-key",
+                    "token_uri" => "https://oauth2.googleapis.com/token",
+                    "private_key" => "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
                 ]
             ],
             'apns' => [
@@ -827,7 +829,8 @@ trait MessagingBase
                     "project_id" => "test-project",
                     "private_key_id" => "test-private-key-id",
                     "client_email" => "test@appwrite.iam.gserviceaccount.com",
-                    "private_key" => "test-private-key",
+                    "token_uri" => "https://oauth2.googleapis.com/token",
+                    "private_key" => "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
                 ],
             ],
             'apns' => [
@@ -916,7 +919,8 @@ trait MessagingBase
                     "project_id" => "test-project",
                     "private_key_id" => "test-private-key-id",
                     "client_email" => "test@appwrite.iam.gserviceaccount.com",
-                    "private_key" => "test-private-key",
+                    "token_uri" => "https://oauth2.googleapis.com/token",
+                    "private_key" => "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
                 ]
             ],
             'apns' => [
@@ -975,14 +979,16 @@ trait MessagingBase
             'providerId' => ID::unique(),
             'name' => 'Invalid FCM',
             'serviceAccountJSON' => [
+                'type' => 'service_account',
                 'project_id' => 'test-project',
                 'client_email' => 'test@appwrite.iam.gserviceaccount.com',
+                'token_uri' => 'https://oauth2.googleapis.com/token',
             ],
         ]);
 
         $this->assertEquals(400, $response['headers']['status-code']);
         $this->assertEquals('general_argument_invalid', $response['body']['type']);
-        $this->assertEquals("FCM service account JSON must include a non-empty 'private_key' field.", $response['body']['message']);
+        $this->assertEquals("Invalid `serviceAccountJSON` param: FCM service account JSON must include a non-empty 'private_key' field, which signs the OAuth access-token request.", $response['body']['message']);
     }
 
     public function testUpdateFCMProviderInvalidCredentials(): void
@@ -1004,14 +1010,16 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'serviceAccountJSON' => [
+                'type' => 'service_account',
                 'project_id' => 'test-project',
-                'private_key' => 'test-private-key',
+                'private_key' => "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
+                'token_uri' => 'https://oauth2.googleapis.com/token',
             ],
         ]);
 
         $this->assertEquals(400, $response['headers']['status-code']);
         $this->assertEquals('general_argument_invalid', $response['body']['type']);
-        $this->assertEquals("FCM service account JSON must include a non-empty 'client_email' field.", $response['body']['message']);
+        $this->assertEquals("Invalid `serviceAccountJSON` param: FCM service account JSON must include a non-empty 'client_email' field, which identifies the service account used for authentication.", $response['body']['message']);
     }
 
     public function testUpdateProviderMissingCredentialsThrows(): void

--- a/tests/e2e/Services/Messaging/MessagingBase.php
+++ b/tests/e2e/Services/Messaging/MessagingBase.php
@@ -988,7 +988,7 @@ trait MessagingBase
 
         $this->assertEquals(400, $response['headers']['status-code']);
         $this->assertEquals('general_argument_invalid', $response['body']['type']);
-        $this->assertEquals("Invalid `serviceAccountJSON` param: FCM service account JSON must include a non-empty 'private_key' field, which signs the OAuth access-token request.", $response['body']['message']);
+        $this->assertEquals("Invalid `serviceAccountJSON` param: FCM service account JSON must include a non-empty 'private_key' field, which signs the OAuth access-token request. or null", $response['body']['message']);
     }
 
     public function testUpdateFCMProviderInvalidCredentials(): void
@@ -1019,7 +1019,7 @@ trait MessagingBase
 
         $this->assertEquals(400, $response['headers']['status-code']);
         $this->assertEquals('general_argument_invalid', $response['body']['type']);
-        $this->assertEquals("Invalid `serviceAccountJSON` param: FCM service account JSON must include a non-empty 'client_email' field, which identifies the service account used for authentication.", $response['body']['message']);
+        $this->assertEquals("Invalid `serviceAccountJSON` param: FCM service account JSON must include a non-empty 'client_email' field, which identifies the service account used for authentication. or null", $response['body']['message']);
     }
 
     public function testUpdateProviderMissingCredentialsThrows(): void

--- a/tests/unit/GraphQL/BuilderTest.php
+++ b/tests/unit/GraphQL/BuilderTest.php
@@ -16,8 +16,6 @@ use Utopia\DI\Container;
 use Utopia\Http\Adapter\FPM\Server;
 use Utopia\Http\Http;
 use Utopia\Http\Route;
-use Utopia\Validator\JSON\FCM;
-use Utopia\Validator\Nullable;
 use Utopia\Validator\Text;
 
 final class BuilderTest extends TestCase
@@ -39,18 +37,6 @@ final class BuilderTest extends TestCase
         $type = Mapper::model(\ucfirst($model->getType()));
         $this->assertInstanceOf(NamedType::class, $type);
         $this->assertSame('Table', $type->name());
-    }
-
-    public function testFCMParameterMapsToJSON(): void
-    {
-        $type = Mapper::param(
-            new Http(new Server(new Container()), 'UTC'),
-            new Nullable(new FCM()),
-            false,
-            [],
-        );
-
-        $this->assertSame('Json', $type->name());
     }
 
     public function testRouteOmitsHiddenParameters(): void

--- a/tests/unit/GraphQL/BuilderTest.php
+++ b/tests/unit/GraphQL/BuilderTest.php
@@ -16,6 +16,8 @@ use Utopia\DI\Container;
 use Utopia\Http\Adapter\FPM\Server;
 use Utopia\Http\Http;
 use Utopia\Http\Route;
+use Utopia\Validator\JSON\FCM;
+use Utopia\Validator\Nullable;
 use Utopia\Validator\Text;
 
 final class BuilderTest extends TestCase
@@ -37,6 +39,18 @@ final class BuilderTest extends TestCase
         $type = Mapper::model(\ucfirst($model->getType()));
         $this->assertInstanceOf(NamedType::class, $type);
         $this->assertSame('Table', $type->name());
+    }
+
+    public function testFCMParameterMapsToJSON(): void
+    {
+        $type = Mapper::param(
+            new Http(new Server(new Container()), 'UTC'),
+            new Nullable(new FCM()),
+            false,
+            [],
+        );
+
+        $this->assertSame('Json', $type->name());
     }
 
     public function testRouteOmitsHiddenParameters(): void


### PR DESCRIPTION
## What does this PR do?

Validates FCM service account credentials when an FCM provider is created, updated, or enabled.

FCM requires non-empty `project_id`, `client_email`, and `private_key` fields. Previously, any JSON object could be stored and enabled, causing push delivery to fail later in the messaging worker with an internal `JWT::encode()` type error.

Invalid credentials now return an actionable `general_argument_invalid` response before the provider can be used.

## Test plan

- Added E2E coverage for invalid credentials on FCM provider creation.
- Added E2E coverage for invalid credentials on FCM provider update.
- Updated existing FCM fixtures with the required `client_email` field.
- `composer lint app/controllers/api/messaging.php tests/e2e/Services/Messaging/MessagingBase.php tests/e2e/Services/GraphQL/MessagingTest.php`
- PHP syntax checks for all changed files.

The focused E2E command could not run locally because the existing app container fails during startup with `Class "Utopia\\Query\\Method" not found` in `Modules/Usage/Http/Events/XList.php`.
