### PR TITLE
fix: persist postgres data by mounting the volume at PGDATA

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1691,7 +1691,7 @@ services:
     networks:
       - appwrite
     volumes:
-      - appwrite-postgresql:/var/lib/postgresql/18/data:rw
+      - appwrite-postgresql:/var/lib/postgresql:rw
     environment:
       - POSTGRES_DB=${_APP_DB_SCHEMA}
       - POSTGRES_USER=${_APP_DB_USER}


### PR DESCRIPTION
## What

Mount the `appwrite-postgresql` named volume at `/var/lib/postgresql` instead of `/var/lib/postgresql/18/data`.

## Why

`appwrite/postgres:0.1.0` declares `VOLUME /var/lib/postgresql` and sets `PGDATA=/var/lib/postgresql/18/docker`. The compose file mounted the named volume at `/var/lib/postgresql/18/data` — a *sibling* of `PGDATA`, not `PGDATA` itself.

Because the mount did not cover the declared `VOLUME`, Docker satisfied it with a fresh **anonymous** volume on every container creation, and that anonymous volume is where all Postgres data actually lived. The named `appwrite-postgresql` volume stayed empty.

The practical effect: Postgres data survived a container *restart*, but was discarded by any container *recreate* — `docker compose down`, `up --force-recreate`, an image bump, or the documented `--entrypoint="upgrade"` flow. Postgres is the default platform database in 2.0, so a stock install loses its console users, projects, and data on the first upgrade.

## Evidence

On a running stack before this change, the postgres container has two mounts — the named volume is empty and unused, while an anonymous volume holds the real `PGDATA`:

```
volume appwrite_appwrite-postgresql               -> /var/lib/postgresql/18/data   (0 entries)
volume eda99efc301c7023...b202ff3e   (ANONYMOUS)  -> /var/lib/postgresql           (real PGDATA)
```

Reproduced with this repo's compose file, creating a row and then recreating only the postgres container:

| Mount | rows before recreate | rows after recreate | named volume entries |
|---|---|---|---|
| `…/18/data` (before) | 1 | `ERROR: relation "survives" does not exist` | 0 |
| `/var/lib/postgresql` (after) | 1 | **1** | 1 |

Also caught end to end: seeding a 1.9.6 install with `users=1 projects=1 teams=1`, stopping it (volumes kept), then starting 2.0.0 on the same volumes showed `users=0 projects=0 teams=0` *before* `migrate` ever ran. The same upgrade against MariaDB — whose mount is correct — preserved everything and passed a full data verification.

`mariadb` (`/var/lib/mysql`) and `mongodb` (`/data/db`) are mounted correctly and are unaffected.

## Note for existing installs

This does not recover data already stranded in an anonymous volume. Operators upgrading a Postgres install should back up first — the old data directory is still present as a dangling anonymous volume (`docker volume ls -qf dangling=true`) and can be copied into the named volume if needed.

## Test plan

- [x] `npm run lint:compose` (Prettier) passes
- [x] `docker compose config` validates
- [x] Data survives `docker compose rm -sf postgresql` + `up` with the patched file
- [x] Named volume is populated; no anonymous mount remains on the container
