### PR TITLE
fix: persist postgres data and warn when upgrade ignores --database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1691,7 +1691,7 @@ services:
     networks:
       - appwrite
     volumes:
-      - appwrite-postgresql:/var/lib/postgresql/18/data:rw
+      - appwrite-postgresql:/var/lib/postgresql:rw
     environment:
       - POSTGRES_DB=${_APP_DB_SCHEMA}
       - POSTGRES_USER=${_APP_DB_USER}

--- a/src/Appwrite/Platform/Tasks/Upgrade.php
+++ b/src/Appwrite/Platform/Tasks/Upgrade.php
@@ -30,7 +30,7 @@ class Upgrade extends Install
             ->param('image', 'appwrite', new Text(0), 'Main appwrite docker image', true)
             ->param('interactive', 'Y', new Text(1), 'Run an interactive session', true)
             ->param('no-start', false, new Boolean(true), 'Run an interactive session', true)
-            ->param('database', 'mongodb', new Text(length: 0), 'Database to use (mongodb|mariadb|postgresql)', true)
+            ->param('database', '', new Text(length: 0, min: 0), 'Ignored: an upgrade always keeps the database the installation already uses', true)
             ->param('topology', 'combined', new WhiteList(['combined', 'separate']), 'Worker and scheduler topology (combined|separate)', true)
             ->param('migrate', false, new Boolean(true), 'Run database migration after upgrade', true)
             ->callback($this->action(...));
@@ -64,7 +64,9 @@ class Upgrade extends Install
             return;
         }
 
-        // Detect database from existing installation (CLI param is intentionally ignored)
+        // An upgrade always keeps the engine the installation already uses, so the
+        // requested value is only kept to tell the user it is being ignored.
+        $requestedDatabase = $database;
         $database = null;
         $compose = new Compose($data);
         foreach ($compose->getServices() as $service) {
@@ -87,6 +89,14 @@ class Upgrade extends Install
             // Pre-1.9.0 installations only supported MariaDB
             $database = 'mariadb';
             Console::info('No _APP_DB_ADAPTER found in existing configuration, defaulting to mariadb.');
+        }
+
+        if ($requestedDatabase !== '' && $requestedDatabase !== $database) {
+            Console::warning(
+                "Ignoring --database={$requestedDatabase}: this installation uses {$database} and an upgrade preserves it."
+                . " Appwrite cannot move an existing installation between database engines;"
+                . " switching requires a new installation and transferring your data into it."
+            );
         }
 
         $this->lockedDatabase = $database;


### PR DESCRIPTION
Two self-hosted 2.0 release fixes found while testing the 1.9.6 → 2.0.0 upgrade path. Both are already on `2.0.x` (pushed directly); this PR carries them to `main`.

---

## 1. Postgres data was never written to the named volume

`appwrite/postgres:0.1.0` declares `VOLUME /var/lib/postgresql` and sets `PGDATA=/var/lib/postgresql/18/docker`, but the compose file mounted the named volume at `/var/lib/postgresql/18/data` — a *sibling* of `PGDATA`, not `PGDATA` itself.

Because the mount did not cover the declared `VOLUME`, Docker satisfied it with a fresh **anonymous** volume on every container creation, and that is where all Postgres data actually lived. The named `appwrite-postgresql` volume stayed empty.

Data therefore survived a container *restart* but was discarded by any container *recreate* — `docker compose down`, `up --force-recreate`, an image bump, or the documented `--entrypoint="upgrade"` flow. Postgres is the default platform database in 2.0, so a stock install lost its console users, projects and data on the first upgrade.

On a running stack before the fix:

```
volume appwrite_appwrite-postgresql              -> /var/lib/postgresql/18/data   (0 entries)
volume eda99efc301c7023...b202ff3e  (ANONYMOUS)  -> /var/lib/postgresql           (real PGDATA)
```

Reproduced with this repo's compose file, creating a row and recreating only the postgres container:

| Mount | rows before recreate | rows after recreate | named volume entries |
|---|---|---|---|
| `…/18/data` (before) | 1 | `ERROR: relation "survives" does not exist` | 0 |
| `/var/lib/postgresql` (after) | 1 | **1** | 1 |

Also caught end to end: seeding a 1.9.6 install with `users=1 projects=1 teams=1`, stopping it (volumes kept), then starting 2.0.0 on the same volumes showed `users=0 projects=0 teams=0` *before* `migrate` ever ran. The same upgrade against MariaDB — whose mount is correct — preserved everything and passed a full data verification.

`mariadb` (`/var/lib/mysql`) and `mongodb` (`/data/db`) are mounted correctly and unaffected.

**Note for existing installs:** this does not recover data already stranded in an anonymous volume. Operators upgrading a Postgres install should back up first — the old data directory is still present as a dangling anonymous volume (`docker volume ls -qf dangling=true`) and can be copied into the named volume if needed.

## 2. `upgrade --database=...` was silently discarded

The upgrade task accepts `--database` but always re-derives the engine from the existing installation and locks it, so the flag was dropped without a word. Someone running `upgrade --database=postgresql` on a 1.9.x MongoDB install got no indication that the request was ignored and that their platform database was still MongoDB — which matters now that 2.0 makes Postgres the default for *fresh* installs while every upgraded install keeps whatever it had.

The parameter now defaults to an empty string so an explicit value can be told apart from the default, and a warning is emitted when it differs from the detected engine:

```
Ignoring --database=postgresql: this installation uses mongodb and an upgrade preserves it.
Appwrite cannot move an existing installation between database engines; switching requires
a new installation and transferring your data into it.
```

Behaviour is otherwise unchanged — the detected engine is still what the upgrade uses.

## Test plan

- [x] `npm run lint:compose` (Prettier) passes; `docker compose config` validates
- [x] Data survives `docker compose rm -sf postgresql` + `up` with the patched compose; named volume populated, no anonymous mount left
- [x] `upgrade --database=postgresql` against a MongoDB install → warns
- [x] `upgrade` with no flag → no warning
- [x] `upgrade --database=mongodb` matching the existing engine → no warning
- [x] All three still complete with `Installation files created.`
- [x] Pint PSR-12 passes on `Upgrade.php`

Per `AGENTS.md`, CLI tasks are not unit-tested (`tests/unit` covers local `src` libraries; e2e covers the HTTP surface), so the installer change is verified by running the real `upgrade` task against a 1.9.6-shaped install rather than by an added test.
