### PR TITLE
fix: migrate onboarding and schedule project id in V25

### DIFF
--- a/src/Appwrite/Migration/Version/V25.php
+++ b/src/Appwrite/Migration/Version/V25.php
@@ -62,9 +62,40 @@ class V25 extends Migration
                 case 'projects':
                     if ($collectionType === 'console') {
                         try {
+                            $this->createAttributeFromCollection($this->dbForProject, $id, 'onboarding');
+                        } catch (Throwable $th) {
+                            Console::warning("Failed to create attribute \"onboarding\" in collection {$id}: {$th->getMessage()}");
+                        }
+
+                        try {
                             $this->createIndexFromCollection($this->dbForProject, $id, '_key_accessedAt');
                         } catch (Throwable $th) {
                             Console::warning("Failed to create index \"_key_accessedAt\" from {$id}: {$th->getMessage()}");
+                        }
+                    }
+                    $this->dbForProject->purgeCachedCollection($id);
+                    break;
+
+                case 'schedules':
+                    if ($collectionType === 'console') {
+                        try {
+                            $this->createAttributeFromCollection($this->dbForProject, $id, 'projectInternalId');
+                        } catch (Throwable $th) {
+                            Console::warning("Failed to create attribute \"projectInternalId\" in collection {$id}: {$th->getMessage()}");
+                        }
+
+                        $this->dbForProject->purgeCachedCollection($id);
+
+                        $indexes = [
+                            '_key_region_resourceType_projectInternalId_resourceId',
+                            '_key_project_internal_id_region',
+                        ];
+                        foreach ($indexes as $index) {
+                            try {
+                                $this->createIndexFromCollection($this->dbForProject, $id, $index);
+                            } catch (Throwable $th) {
+                                Console::warning("Failed to create index \"{$index}\" from {$id}: {$th->getMessage()}");
+                            }
                         }
                     }
                     $this->dbForProject->purgeCachedCollection($id);


### PR DESCRIPTION
Already on `2.0.x` as `2b1052a1a0`; this carries it to `main`.

## Problem

Two console schema changes made since 1.9.6 never reach an upgraded installation.

The boot-time sync in `app/http.php:144-177` creates **missing collections**, but line 151 is `if (!$database->getCollection($key)->isEmpty()) continue;` — so it skips collections that already exist and never adds new attributes to them. `V25` had no case for either attribute, and never calls `Migration::createCollection()`.

The result is silent, because `setDropUnknownAttributes()` (added in #13357) makes the platform handle discard writes to columns that do not exist yet rather than throwing:

- **`projects.onboarding`** — written by the API shutdown hook (`app/controllers/shared/api.php:1189-1222`) on every matching request, and read by the console "Get started" checklist (`Projects/Http/Stages/XList.php:72`). On an upgraded install the column never appears, so every one of those writes is dropped and the checklist stays at 0/14 forever.
- **`schedules.projectInternalId`** plus indexes `_key_region_resourceType_projectInternalId_resourceId` and `_key_project_internal_id_region` — written by `Projects/Http/Schedules/Create.php:134` on every schedule create. No reader today, so this one is latent rather than user-visible, but the schema drifts from `app/config/collections/platform.php` and the indexes never materialise.

## Fix

Add both to `V25::migrateCollections()` using the same guarded `try`/`catch` + `Console::warning` style as the surrounding cases, so a re-run warns instead of aborting.

## Verification

Upgraded a seeded 1.9.6 install to 2.0.0 on MariaDB (chosen because its volume mount is correct, so storage is not a variable):

```
                                       1.9.6   after 2.0.0 boot   after migrate
_console_projects.onboarding             0            0               1
_console_schedules.projectInternalId     0            0               1
_console_notifications table             0            1               1   (boot-sync, unrelated)
```

Seeded data is untouched across the upgrade — `users=1 projects=1 teams=1` before and after — and a full API verification passes: database/collection/attributes survive, 4 documents intact including unicode, empty string, 50k text and custom permissions, and writes work after the upgrade.

Idempotent — a second `migrate` run warns and completes with data intact:

```
Failed to create attribute "onboarding" in collection projects: Attribute already exists in metadata
Failed to create attribute "projectInternalId" in collection schedules: Attribute already exists in metadata
Failed to create index "_key_region_resourceType_projectInternalId_resourceId" from schedules: Index already exists
Failed to create index "_key_project_internal_id_region" from schedules: Index already exists
Migration completed
onboarding=1   projectInternalId=1   users=1
```

## Test plan

- [x] Pint PSR-12 passes on `V25.php`
- [x] 1.9.6 → 2.0.0 upgrade on MariaDB: both columns created, data preserved
- [x] Second `migrate` run is a no-op

Per `AGENTS.md`, migrations are exercised through the real upgrade path rather than unit tests.
