### PR TITLE
fix(specs): emit valid OpenAPI item types for array parameters

### DIFF
--- a/src/Appwrite/SDK/Specification/Format.php
+++ b/src/Appwrite/SDK/Specification/Format.php
@@ -432,7 +432,7 @@ abstract class Format
             return \in_array($default, $schema['enum'], true);
         }
 
-        if (isset($schema['items']['enum'])) {
+        if (\is_array($schema['items'] ?? null) && isset($schema['items']['enum'])) {
             return \is_array($default) && empty(\array_diff($default, $schema['items']['enum']));
         }
 

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -750,9 +750,15 @@ class OpenAPI3 extends Format
                     case \Utopia\Validator\ArrayList::class:
                         /** @var ArrayList $validator */
                         $node['schema']['type'] = 'array';
-                        $node['schema']['items'] = [
-                            'type' => $validator->getValidator()->getType(),
-                        ];
+                        // Validator::TYPE_FLOAT is gettype()'s 'double', and TYPE_MIXED has no
+                        // OpenAPI equivalent at all. Emitting either verbatim produces a schema
+                        // no OpenAPI parser accepts, so an SDK cannot be generated from the spec.
+                        $itemType = $validator->getValidator()->getType();
+                        $node['schema']['items'] = match ($itemType) {
+                            Validator::TYPE_FLOAT => ['type' => 'number', 'format' => 'double'],
+                            Validator::TYPE_MIXED => [],
+                            default => ['type' => $itemType],
+                        };
                         if (($param['example'] ?? '') !== '') {
                             $node['schema']['example'] = $param['example'];
                         }

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -756,7 +756,7 @@ class OpenAPI3 extends Format
                         $itemType = $validator->getValidator()->getType();
                         $node['schema']['items'] = match ($itemType) {
                             Validator::TYPE_FLOAT => ['type' => 'number', 'format' => 'double'],
-                            Validator::TYPE_MIXED => [],
+                            Validator::TYPE_MIXED => new \stdClass(),
                             default => ['type' => $itemType],
                         };
                         if (($param['example'] ?? '') !== '') {

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -54,7 +54,9 @@ use Utopia\Validator\ArrayList;
 use Utopia\Validator\Assoc;
 use Utopia\Validator\Boolean as BooleanValidator;
 use Utopia\Validator\Domain;
+use Utopia\Validator\FloatValidator;
 use Utopia\Validator\HexColor;
+use Utopia\Validator\Integer as IntegerValidator;
 use Utopia\Validator\JSON;
 use Utopia\Validator\Nullable;
 use Utopia\Validator\Range;
@@ -322,6 +324,33 @@ final class FormatTest extends TestCase
         $this->assertEqualsWithDelta(2.5, $properties['ratio']['example'], PHP_FLOAT_EPSILON);
         $this->assertTrue($properties['enabled']['example']);
         $this->assertSame('["one","two"]', $properties['text']['example']);
+    }
+
+    public function testArrayListItemTypesAreValidOpenApiTypes(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route('POST', '/v1/tests'))
+            ->desc('Create test')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'createTest',
+                description: 'Create test.',
+                auth: [],
+                responses: [],
+            ))
+            ->param('percents', [], new ArrayList(new FloatValidator()), 'Percents.', optional: true)
+            ->param('counts', [], new ArrayList(new IntegerValidator()), 'Counts.', optional: true)
+            ->param('labels', [], new ArrayList(new Text(16)), 'Labels.', optional: true);
+
+        $spec = (new OpenAPI3(new Container(), [], [$route], [], [], 0, 'console'))->parse();
+        $properties = $spec['paths']['/tests']['post']['requestBody']['content']['application/json']['schema']['properties'];
+
+        $this->assertSame(['type' => 'number', 'format' => 'double'], $properties['percents']['items']);
+        $this->assertSame(['type' => 'integer'], $properties['counts']['items']);
+        $this->assertSame(['type' => 'string'], $properties['labels']['items']);
     }
 
     public function testMethodParameterOverridesFilterAndReplaceRouteParams(): void

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -86,6 +86,29 @@ class TestFormat extends Format
     }
 }
 
+class MixedValidator extends \Utopia\Validator
+{
+    public function getDescription(): string
+    {
+        return 'Mixed value';
+    }
+
+    public function isArray(): bool
+    {
+        return false;
+    }
+
+    public function isValid($value): bool
+    {
+        return true;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE_MIXED;
+    }
+}
+
 final class FormatTest extends TestCase
 {
     private TestFormat $format;
@@ -343,7 +366,8 @@ final class FormatTest extends TestCase
             ))
             ->param('percents', [], new ArrayList(new FloatValidator()), 'Percents.', optional: true)
             ->param('counts', [], new ArrayList(new IntegerValidator()), 'Counts.', optional: true)
-            ->param('labels', [], new ArrayList(new Text(16)), 'Labels.', optional: true);
+            ->param('labels', [], new ArrayList(new Text(16)), 'Labels.', optional: true)
+            ->param('values', [], new ArrayList(new MixedValidator()), 'Values.', optional: true);
 
         $spec = (new OpenAPI3(new Container(), [], [$route], [], [], 0, 'console'))->parse();
         $properties = $spec['paths']['/tests']['post']['requestBody']['content']['application/json']['schema']['properties'];
@@ -351,6 +375,8 @@ final class FormatTest extends TestCase
         $this->assertSame(['type' => 'number', 'format' => 'double'], $properties['percents']['items']);
         $this->assertSame(['type' => 'integer'], $properties['counts']['items']);
         $this->assertSame(['type' => 'string'], $properties['labels']['items']);
+        $this->assertInstanceOf(\stdClass::class, $properties['values']['items']);
+        $this->assertSame('{}', json_encode($properties['values']['items']));
     }
 
     public function testMethodParameterOverridesFilterAndReplaceRouteParams(): void


### PR DESCRIPTION
`ArrayList` copied its inner validator's `gettype()` name straight into `items.type`, so a list of floats emitted `"type": "double"` — a format, not an OpenAPI type. `Validator::TYPE_MIXED` had the same problem with no OpenAPI equivalent at all.

Any spec carrying one of those fails schema parsing, which blocks SDK generation for the whole platform. It surfaced on the Cloud manager spec (`POST /manager/databases/metrics` takes `ArrayList(FloatValidator)` parameters), where `php app/cli.php sdks` aborted with `Unsupported schema type 'double'`.

Floats now emit `{"type": "number", "format": "double"}` and mixed emits no type, matching how scalar float parameters were already handled a few cases below.

## Test

`tests/unit/SDK/Specification/FormatTest.php::testArrayListItemTypesAreValidOpenApiTypes` asserts the emitted `items` schema for float, integer and string lists. Seen red on `main` (`'type' => 'double'`) and green with the fix.