### PR TITLE
Bump Open Runtimes orchestrator to 1.7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -136,7 +136,7 @@
         "league/csv": "9.14.*",
         "enshrined/svg-sanitize": "0.22.*",
         "utopia-php/client": "^0.3.0",
-        "open-runtimes/sdk-for-php": "0.11.*",
+        "open-runtimes/sdk-for-php": "0.13.*",
         "utopia-php/schedule": "^0.2.0",
         "utopia-php/usage": "^0.15.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "384d18b2a74e40ef791a28f37a81c47b",
+    "content-hash": "c372c1e88974c7a9765b892b230897d3",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -1079,16 +1079,16 @@
         },
         {
             "name": "open-runtimes/sdk-for-php",
-            "version": "0.11.1",
+            "version": "0.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/open-runtimes/sdk-for-php.git",
-                "reference": "2db10da2fa7163d096bfd8343a44ae99a2852527"
+                "reference": "30d963dafa4af53c2a401601809fb768483ac27e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/open-runtimes/sdk-for-php/zipball/2db10da2fa7163d096bfd8343a44ae99a2852527",
-                "reference": "2db10da2fa7163d096bfd8343a44ae99a2852527",
+                "url": "https://api.github.com/repos/open-runtimes/sdk-for-php/zipball/30d963dafa4af53c2a401601809fb768483ac27e",
+                "reference": "30d963dafa4af53c2a401601809fb768483ac27e",
                 "shasum": ""
             },
             "require": {
@@ -1116,9 +1116,9 @@
             "description": "PHP SDK for the Open Runtimes orchestrator: jobs, deployments, sandboxes, and pools.",
             "support": {
                 "issues": "https://github.com/open-runtimes/sdk-for-php/issues",
-                "source": "https://github.com/open-runtimes/sdk-for-php/tree/0.11.1"
+                "source": "https://github.com/open-runtimes/sdk-for-php/tree/0.13.0"
             },
-            "time": "2026-08-19T12:49:14+00:00"
+            "time": "2026-08-26T19:28:48+00:00"
         },
         {
             "name": "open-telemetry/api",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1585,7 +1585,7 @@ services:
     # One image carrying every orchestrator control plane. Appwrite drives the
     # jobs plane today; the per-plane images exist for Kubernetes, where each
     # scales, fails and gets RBAC on its own.
-    image: ghcr.io/open-runtimes/orchestrator/orchestrator:1.3.0
+    image: ghcr.io/open-runtimes/orchestrator/orchestrator:1.7.2
     restart: unless-stopped
     user: root
     networks:
@@ -1600,8 +1600,8 @@ services:
       - DOCKER_NETWORK=appwrite
       - ARTIFACT_ENDPOINT=http://orchestrator:8080
       # Sidecars ship with the service and move with it, so they share its tag.
-      - JOB_SIDECAR_IMAGE=ghcr.io/open-runtimes/orchestrator/job-sidecar:1.3.0
-      - WORKLOAD_SIDECAR_IMAGE=ghcr.io/open-runtimes/orchestrator/workload-sidecar:1.3.0
+      - JOB_SIDECAR_IMAGE=ghcr.io/open-runtimes/orchestrator/job-sidecar:1.7.2
+      - WORKLOAD_SIDECAR_IMAGE=ghcr.io/open-runtimes/orchestrator/workload-sidecar:1.7.2
 
   mariadb:
     image: mariadb:10.11


### PR DESCRIPTION
## Summary

- bump the orchestrator, job-sidecar, and workload-sidecar images from 1.3.0 to 1.7.2
- bump open-runtimes/sdk-for-php from 0.11.1 to 0.13.0
- refresh the Composer lock file

Release: https://github.com/open-runtimes/orchestrator/releases/tag/v1.7.2

## Validation

- `composer validate --strict --no-check-publish`
- targeted PHPStan analysis of the Open Runtimes SDK call sites
- `docker compose -f docker-compose.yml config -q`
- verified all four 1.7.2 multi-architecture image manifests in GHCR