### PR TITLE
feat: make the database batch limit configurable

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -472,6 +472,15 @@ return [
                 'question' => '',
                 'filter' => 'password'
             ],
+            [
+                'name' => '_APP_LIMIT_DATABASE_BATCH',
+                'description' => 'Maximum number of rows or documents accepted by a single bulk database operation (createRows, upsertRows, updateRows, deleteRows and their document equivalents). Raising it increases memory use and query size per request, so tune it to what your database can handle. Default value is: 100.',
+                'introduction' => '2.0.0',
+                'default' => '100',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
         ],
     ],
     [

--- a/app/init/constants.php
+++ b/app/init/constants.php
@@ -89,7 +89,9 @@ const APP_COLLECTIONS_SUBQUERIES = [
 const APP_LIMIT_WRITE_RATE_DEFAULT = 60; // Default maximum write rate per rate period
 const APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT = 60; // Default maximum write rate period in seconds
 const APP_LIMIT_LIST_DEFAULT = 25; // Default maximum number of items to return in list API calls
-const APP_LIMIT_DATABASE_BATCH = 100; // Default maximum batch size for database operations
+// Default maximum batch size for database operations. Self-hosted operators can raise this
+// for their own hardware; on Cloud the plan's databasesBatchSize takes precedence.
+\define('APP_LIMIT_DATABASE_BATCH', \max(1, (int) System::getEnv('_APP_LIMIT_DATABASE_BATCH', 100)));
 const APP_LIMIT_DATABASE_TRANSACTION = 100; // Default maximum operations per transaction
 const APP_KEY_ACCESS = 24 * 60 * 60; // 24 hours
 const APP_USER_ACCESS = 24 * 60 * 60; // 24 hours

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -235,6 +235,7 @@ services:
       - _APP_MIGRATION_HOST
       - _APP_GEO_SECRET
       - _APP_GEO_ENDPOINT
+      - _APP_LIMIT_DATABASE_BATCH
   appwrite-console:
     logging:
       driver: json-file
@@ -319,6 +320,7 @@ services:
       - _APP_LOGGING_FORMAT
       - _APP_LOGGING_CONFIG_REALTIME
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_LIMIT_DATABASE_BATCH
       - _APP_POOL_ADAPTER=swoole
 
   appwrite-worker:
@@ -473,6 +475,7 @@ services:
       - _APP_MIGRATION_HOST
       - _APP_MAINTENANCE_RETENTION_AUDIT
       - _APP_MAINTENANCE_RETENTION_AUDIT_CONSOLE
+      - _APP_LIMIT_DATABASE_BATCH
 
   appwrite-task-scheduler:
     entrypoint: schedule
@@ -706,6 +709,7 @@ services:
       - _APP_LOGGING_FORMAT
       - _APP_QUEUE_NAME
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_LIMIT_DATABASE_BATCH
   appwrite-worker-builds:
     profiles:
       - separate


### PR DESCRIPTION
Reported by a self-hosted user bulk-loading ~31k rows from inside a Function: `upsertRows` (and `createRows` / `updateRows` / `deleteRows`) reject more than 100 rows with

```
Invalid `rows` param: Value must a valid array no longer than 100 items
```

`APP_LIMIT_DATABASE_BATCH` was a hard-coded `100`. On Cloud a plan raises the ceiling through `databasesBatchSize`, but self-hosted had no equivalent lever, so a 31k-row load became 300+ sequential calls against a fixed Function timeout — on hardware the operator owns and is best placed to size.

## Change

Read the constant from `_APP_LIMIT_DATABASE_BATCH`, defaulting to `100`, and forward it to the services that serve these endpoints.

Every call site already reads `$plan['databasesBatchSize'] ?? APP_LIMIT_DATABASE_BATCH` (12 of them across TablesDB, DocumentsDB, VectorsDB and the legacy Databases routes), so only the fallback becomes configurable — **the Cloud plan value still takes precedence and Cloud behaviour is unchanged**.

The value is clamped to a minimum of 1 so a malformed setting cannot disable bulk writes outright. It is deliberately **not** capped at the top: the description warns that memory use and query size grow with it, and the operator owns that trade-off. Existing installations that set nothing keep exactly today's limit of 100.

## Verification

Against a running stack, reproducing the reported failure and then lifting it:

| `_APP_LIMIT_DATABASE_BATCH` | 100 rows | 150 rows | 1000 rows | 1500 rows |
|---|---|---|---|---|
| unset (default 100) | `201` | `400` — *no longer than 100 items* | — | — |
| `1000` | `201` | `201` | `201` | `400` — *no longer than 1000 items* |

The cap lands on exactly the configured value and the error message reflects it. Restoring the default reproduces the original `400` at 150 rows.

Also verified the installer path: `install` writes `_APP_LIMIT_DATABASE_BATCH="100"` to `.env` and the rendered `docker-compose.yml` forwards it.

## Test plan

- [x] `php -l` clean; Pint PSR-12 passes on both PHP files
- [x] `npm run lint:compose` (Prettier) passes
- [x] Unit suite: 1071 tests pass
- [x] Default unchanged at 100; raising the variable lifts the cap; lowering restores it
- [x] Installer writes and forwards the variable
