### PR TITLE
feat: let operators choose which database products to deploy

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -481,6 +481,24 @@ return [
                 'question' => '',
                 'filter' => ''
             ],
+            [
+                'name' => '_APP_DOCUMENTSDB',
+                'description' => 'Enables the DocumentsDB API. It runs on MongoDB, so the installation needs a reachable MongoDB while this is enabled. Set to disabled to leave MongoDB out; the /v1/documentsdb routes then return a service disabled error. Default value is: enabled.',
+                'introduction' => '2.0.0',
+                'default' => 'enabled',
+                'required' => false,
+                'question' => 'Enable DocumentsDB? It requires MongoDB (Y/n)',
+                'filter' => ''
+            ],
+            [
+                'name' => '_APP_VECTORSDB',
+                'description' => 'Enables the VectorsDB API. It runs on PostgreSQL, so the installation needs a reachable PostgreSQL while this is enabled. Set to disabled to leave PostgreSQL out; the /v1/vectorsdb routes then return a service disabled error. Default value is: enabled.',
+                'introduction' => '2.0.0',
+                'default' => 'enabled',
+                'required' => false,
+                'question' => 'Enable VectorsDB? It requires PostgreSQL (Y/n)',
+                'filter' => ''
+            ],
         ],
     ],
     [

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -463,13 +463,13 @@ Http::init()
 
             // An operator turns a database product off when its engine is not deployed,
             // so the route is unavailable to everyone, keys and privileged roles included.
-            $productEngines = [
+            $productToggles = [
                 'documentsdb' => '_APP_DOCUMENTSDB',
                 'vectorsdb' => '_APP_VECTORSDB',
             ];
             if (
-                isset($productEngines[$namespace])
-                && System::getEnv($productEngines[$namespace], 'enabled') !== 'enabled'
+                isset($productToggles[$namespace])
+                && System::getEnv($productToggles[$namespace], 'enabled') !== 'enabled'
             ) {
                 throw new Exception(Exception::GENERAL_SERVICE_DISABLED);
             }

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -461,6 +461,19 @@ Http::init()
         if (! empty($method)) {
             $namespace = \strtolower($method->getNamespace());
 
+            // An operator turns a database product off when its engine is not deployed,
+            // so the route is unavailable to everyone, keys and privileged roles included.
+            $productEngines = [
+                'documentsdb' => '_APP_DOCUMENTSDB',
+                'vectorsdb' => '_APP_VECTORSDB',
+            ];
+            if (
+                isset($productEngines[$namespace])
+                && System::getEnv($productEngines[$namespace], 'enabled') !== 'enabled'
+            ) {
+                throw new Exception(Exception::GENERAL_SERVICE_DISABLED);
+            }
+
             if (
                 array_key_exists($namespace, $project->getAttribute('services', []))
                 && ! $project->getAttribute('services', [])[$namespace]

--- a/app/views/install/installer.phtml
+++ b/app/views/install/installer.phtml
@@ -9,6 +9,8 @@ $defaultAppDomain = $vars['_APP_DOMAIN']['default'] ?? 'localhost';
 $defaultAppDomain = ($defaultAppDomain === 'traefik') ? 'localhost' : $defaultAppDomain;
 $defaultEmailCertificates ??= '';
 $defaultForceHttps ??= ($vars['_APP_OPTIONS_FORCE_HTTPS']['default'] ?? 'disabled') === 'enabled';
+$defaultDocumentsDB ??= ($vars['_APP_DOCUMENTSDB']['default'] ?? 'enabled') !== 'disabled';
+$defaultVectorsDB ??= ($vars['_APP_VECTORSDB']['default'] ?? 'enabled') !== 'disabled';
 $defaultDatabase = $vars['_APP_DB_ADAPTER']['default'] ?? 'postgresql';
 $enabledDatabases ??= ['postgresql', 'mariadb', 'mongodb'];
 $isLocalInstall ??= false;
@@ -65,6 +67,8 @@ $installerVersion = @filemtime(__DIR__ . '/installer/js/installer.js') ?: time()
     data-default-app-domain="<?php echo htmlspecialchars((string) $defaultAppDomain, ENT_QUOTES, 'UTF-8'); ?>"
     data-default-email-certificates="<?php echo htmlspecialchars((string) $defaultEmailCertificates, ENT_QUOTES, 'UTF-8'); ?>"
     data-default-force-https="<?php echo $defaultForceHttps ? 'true' : 'false'; ?>"
+    data-default-documentsdb="<?php echo $defaultDocumentsDB ? 'true' : 'false'; ?>"
+    data-default-vectorsdb="<?php echo $defaultVectorsDB ? 'true' : 'false'; ?>"
     data-default-secret-key=""
     data-default-assistant-openai-key=""
     data-default-database="<?php echo htmlspecialchars((string) $defaultDatabase, ENT_QUOTES, 'UTF-8'); ?>"

--- a/app/views/install/installer/js/modules/progress.js
+++ b/app/views/install/installer/js/modules/progress.js
@@ -369,6 +369,8 @@
             httpsPort: normalizedHttpsPort,
             database: formState?.database || 'postgresql',
             topology: formState?.topology || 'combined',
+            documentsDB: formState?.documentsDB !== false,
+            vectorsDB: formState?.vectorsDB !== false,
             appDomain: normalizedDomain,
             emailCertificates: normalizedEmail,
             forceHttps: formState?.forceHttps === true,

--- a/app/views/install/installer/js/modules/state.js
+++ b/app/views/install/installer/js/modules/state.js
@@ -20,6 +20,8 @@
         opensslKey: null,
         assistantOpenAIKey: null,
         topology: 'combined',
+        documentsDB: true,
+        vectorsDB: true,
         accountEmail: null,
         accountPassword: null
     };

--- a/app/views/install/installer/js/modules/state.js
+++ b/app/views/install/installer/js/modules/state.js
@@ -20,8 +20,8 @@
         opensslKey: null,
         assistantOpenAIKey: null,
         topology: 'combined',
-        documentsDB: true,
-        vectorsDB: true,
+        documentsDB: null,
+        vectorsDB: null,
         accountEmail: null,
         accountPassword: null
     };
@@ -49,6 +49,8 @@
         setStateIfEmpty('httpsPort', data.defaultHttpsPort);
         setStateIfEmpty('emailCertificates', data.defaultEmailCertificates);
         setStateIfEmpty('forceHttps', data.defaultForceHttps === 'true');
+        setStateIfEmpty('documentsDB', data.defaultDocumentsdb !== 'false');
+        setStateIfEmpty('vectorsDB', data.defaultVectorsdb !== 'false');
         setStateIfEmpty('opensslKey', data.defaultSecretKey);
         setStateIfEmpty('assistantOpenAIKey', data.defaultAssistantOpenaiKey);
         if (data.lockedDatabase) {

--- a/app/views/install/installer/js/modules/ui.js
+++ b/app/views/install/installer/js/modules/ui.js
@@ -265,6 +265,18 @@
             httpsBadge.classList.add(forceHttps ? 'badge-success' : 'badge-neutral');
         }
 
+        const productBadges = [
+            ['[data-review-documentsdb-badge]', formState?.documentsDB !== false],
+            ['[data-review-vectorsdb-badge]', formState?.vectorsDB !== false],
+        ];
+        productBadges.forEach(([selector, enabled]) => {
+            const badge = root.querySelector(selector);
+            if (!badge) return;
+            badge.textContent = enabled ? 'Enabled' : 'Disabled';
+            badge.classList.remove('badge-success', 'badge-neutral');
+            badge.classList.add(enabled ? 'badge-success' : 'badge-neutral');
+        });
+
         const assistantBadge = root.querySelector('[data-review-assistant-badge]');
         if (assistantBadge) {
             const hasAssistantKey = Boolean((formState?.assistantOpenAIKey || '').trim());

--- a/app/views/install/installer/js/steps.js
+++ b/app/views/install/installer/js/steps.js
@@ -122,6 +122,8 @@
         State.setStateIfEmpty?.('httpsPort', root.querySelector('#https-port')?.value);
         State.setStateIfEmpty?.('emailCertificates', root.querySelector('#ssl-email')?.value);
         State.setStateIfEmpty?.('forceHttps', root.querySelector('#force-https')?.checked);
+        State.setStateIfEmpty?.('documentsDB', root.querySelector('#documentsdb')?.checked);
+        State.setStateIfEmpty?.('vectorsDB', root.querySelector('#vectorsdb')?.checked);
         State.setStateIfEmpty?.('assistantOpenAIKey', root.querySelector('#assistant-openai-key')?.value);
     };
 
@@ -141,6 +143,16 @@
         const forceHttps = root.querySelector('#force-https');
         if (forceHttps && typeof formState.forceHttps === 'boolean') {
             forceHttps.checked = formState.forceHttps;
+        }
+
+        const documentsDB = root.querySelector('#documentsdb');
+        if (documentsDB && typeof formState.documentsDB === 'boolean') {
+            documentsDB.checked = formState.documentsDB;
+        }
+
+        const vectorsDB = root.querySelector('#vectorsdb');
+        if (vectorsDB && typeof formState.vectorsDB === 'boolean') {
+            vectorsDB.checked = formState.vectorsDB;
         }
 
         const assistantKey = root.querySelector('#assistant-openai-key');
@@ -212,6 +224,8 @@
         bindInputToState(httpsPort, 'httpsPort');
         bindInputToState(sslEmail, 'emailCertificates');
         bindCheckboxToState(forceHttps, 'forceHttps');
+        bindCheckboxToState(root.querySelector('#documentsdb'), 'documentsDB');
+        bindCheckboxToState(root.querySelector('#vectorsdb'), 'vectorsDB');
         bindInputToState(assistantKey, 'assistantOpenAIKey');
 
         bindErrorClear?.(hostname);

--- a/app/views/install/installer/templates/steps/step-1.phtml
+++ b/app/views/install/installer/templates/steps/step-1.phtml
@@ -10,6 +10,8 @@ $defaultEmailCertificates ??= '';
 $defaultForceHttps ??= false;
 $defaultAssistantOpenAIKey ??= '';
 $defaultDatabase ??= 'postgresql';
+$defaultDocumentsDB ??= true;
+$defaultVectorsDB ??= true;
 $enabledDatabases ??= ['postgresql', 'mariadb', 'mongodb'];
 $selectedDatabase = $lockedDatabase ?: $defaultDatabase;
 $isDatabaseLocked = !empty($lockedDatabase);
@@ -106,6 +108,32 @@ $assistantOpenAIKeyValue = htmlspecialchars((string) $defaultAssistantOpenAIKey,
                     <?php } ?>
                 </div>
             </div>
+
+            <label class="toggle-option" for="documentsdb">
+                <span class="toggle-option-content">
+                    <span class="typography-text-m-500 text-neutral-primary">DocumentsDB</span>
+                    <span id="documentsdb-description" class="typography-text-xs-400 text-neutral-tertiary">Schemaless document API. Runs on MongoDB, which is deployed alongside your database when this is on.</span>
+                </span>
+                <span class="toggle-switch">
+                    <input type="checkbox" id="documentsdb" name="documentsDB" class="sr-only" aria-describedby="documentsdb-description" <?php echo $defaultDocumentsDB ? 'checked' : ''; ?>>
+                    <span class="toggle-switch-track" aria-hidden="true">
+                        <span class="toggle-switch-thumb"></span>
+                    </span>
+                </span>
+            </label>
+
+            <label class="toggle-option" for="vectorsdb">
+                <span class="toggle-option-content">
+                    <span class="typography-text-m-500 text-neutral-primary">VectorsDB</span>
+                    <span id="vectorsdb-description" class="typography-text-xs-400 text-neutral-tertiary">Vector search API. Runs on PostgreSQL, which is deployed alongside your database when this is on.</span>
+                </span>
+                <span class="toggle-switch">
+                    <input type="checkbox" id="vectorsdb" name="vectorsDB" class="sr-only" aria-describedby="vectorsdb-description" <?php echo $defaultVectorsDB ? 'checked' : ''; ?>>
+                    <span class="toggle-switch-track" aria-hidden="true">
+                        <span class="toggle-switch-thumb"></span>
+                    </span>
+                </span>
+            </label>
 
             <div class="accordion">
                 <button

--- a/app/views/install/installer/templates/steps/step-4.phtml
+++ b/app/views/install/installer/templates/steps/step-4.phtml
@@ -67,6 +67,14 @@ $badgeClass = $defaultSecretKey !== '' ? 'badge-success' : 'badge-warning';
                         <span class="badge badge-neutral typography-text-xs-400" data-review-assistant-badge>Disabled</span>
                         <div class="review-label typography-text-xs-400 text-neutral-tertiary">Appwrite Assistant</div>
                     </div>
+                    <div class="review-row">
+                        <span class="badge badge-success typography-text-xs-400" data-review-documentsdb-badge>Enabled</span>
+                        <div class="review-label typography-text-xs-400 text-neutral-tertiary">DocumentsDB</div>
+                    </div>
+                    <div class="review-row">
+                        <span class="badge badge-success typography-text-xs-400" data-review-vectorsdb-badge>Enabled</span>
+                        <div class="review-label typography-text-xs-400 text-neutral-tertiary">VectorsDB</div>
+                    </div>
                     <?php if (!$isUpgrade) { ?>
                     <div class="review-row">
                         <span class="badge <?php echo $badgeClass; ?> typography-text-xs-400" data-review-badge>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,6 +236,8 @@ services:
       - _APP_GEO_SECRET
       - _APP_GEO_ENDPOINT
       - _APP_LIMIT_DATABASE_BATCH
+      - _APP_DOCUMENTSDB
+      - _APP_VECTORSDB
   appwrite-console:
     logging:
       driver: json-file
@@ -321,6 +323,8 @@ services:
       - _APP_LOGGING_CONFIG_REALTIME
       - _APP_DATABASE_SHARED_TABLES
       - _APP_LIMIT_DATABASE_BATCH
+      - _APP_DOCUMENTSDB
+      - _APP_VECTORSDB
       - _APP_POOL_ADAPTER=swoole
 
   appwrite-worker:
@@ -476,6 +480,8 @@ services:
       - _APP_MAINTENANCE_RETENTION_AUDIT
       - _APP_MAINTENANCE_RETENTION_AUDIT_CONSOLE
       - _APP_LIMIT_DATABASE_BATCH
+      - _APP_DOCUMENTSDB
+      - _APP_VECTORSDB
 
   appwrite-task-scheduler:
     entrypoint: schedule
@@ -710,6 +716,8 @@ services:
       - _APP_QUEUE_NAME
       - _APP_DATABASE_SHARED_TABLES
       - _APP_LIMIT_DATABASE_BATCH
+      - _APP_DOCUMENTSDB
+      - _APP_VECTORSDB
   appwrite-worker-builds:
     profiles:
       - separate

--- a/src/Appwrite/Docker/Compose/Generator.php
+++ b/src/Appwrite/Docker/Compose/Generator.php
@@ -188,9 +188,6 @@ class Generator
     }
 
     /**
-     * @return string[]
-     */
-    /**
      * Engines the enabled database products need, on top of the platform engine.
      *
      * @return array<int, string>

--- a/src/Appwrite/Docker/Compose/Generator.php
+++ b/src/Appwrite/Docker/Compose/Generator.php
@@ -25,6 +25,17 @@ class Generator
         ],
     ];
 
+    /**
+     * Engine each specialised database product runs on. DocumentsDB only runs on
+     * MongoDB and VectorsDB only on PostgreSQL, so an enabled product needs its
+     * engine even when a different one backs the platform. A disabled product
+     * leaves its engine out, keeping the installation to what it actually uses.
+     */
+    private const array PRODUCT_BACKING_SERVICES = [
+        'enableDocumentsDB' => 'mongodb',
+        'enableVectorsDB' => 'postgresql',
+    ];
+
     private const array OPTIONAL_SERVICES = [
         'enableAssistant' => 'appwrite-assistant',
     ];
@@ -76,6 +87,8 @@ class Generator
         'database' => 'postgresql',
         'hostPath' => '',
         'enableAssistant' => false,
+        'enableDocumentsDB' => true,
+        'enableVectorsDB' => true,
         'topology' => 'combined',
     ];
 
@@ -177,6 +190,24 @@ class Generator
     /**
      * @return string[]
      */
+    /**
+     * Engines the enabled database products need, on top of the platform engine.
+     *
+     * @return array<int, string>
+     */
+    private function getRequiredBackingServices(): array
+    {
+        $services = [];
+
+        foreach (self::PRODUCT_BACKING_SERVICES as $param => $service) {
+            if (!empty($this->params[$param])) {
+                $services[] = $service;
+            }
+        }
+
+        return $services;
+    }
+
     private function getSelectableServices(): array
     {
         $services = [];
@@ -196,9 +227,15 @@ class Generator
     {
         foreach (self::SELECTABLE_SERVICE_GROUPS as $param => $config) {
             foreach ($config['services'] as $service) {
-                if ($service !== $this->params[$param]) {
-                    unset($services[$service]);
+                if ($service === $this->params[$param]) {
+                    continue;
                 }
+
+                if (\in_array($service, $this->getRequiredBackingServices(), true)) {
+                    continue;
+                }
+
+                unset($services[$service]);
             }
         }
 
@@ -239,6 +276,10 @@ class Generator
         foreach (self::SELECTABLE_VOLUME_GROUPS as $param => $groups) {
             foreach ($groups as $service => $names) {
                 if ($service === $this->params[$param]) {
+                    continue;
+                }
+
+                if (\in_array($service, $this->getRequiredBackingServices(), true)) {
                     continue;
                 }
 

--- a/src/Appwrite/Platform/Installer/Http/Installer/Install.php
+++ b/src/Appwrite/Platform/Installer/Http/Installer/Install.php
@@ -43,6 +43,8 @@ class Install extends Action
             ->param('accountPassword', '', new Password(allowEmpty: true), 'Account password', true)
             ->param('database', '', new WhiteList(['postgresql', 'mariadb', 'mongodb']), 'Database adapter', true)
             ->param('topology', 'combined', new WhiteList(['combined', 'separate']), 'Worker and scheduler topology', true)
+            ->param('documentsDB', true, new \Utopia\Validator\Boolean(true), 'Deploy DocumentsDB and the MongoDB it runs on', true)
+            ->param('vectorsDB', true, new \Utopia\Validator\Boolean(true), 'Deploy VectorsDB and the PostgreSQL it runs on', true)
             ->param('installId', '', new Text(64, 0), 'Installation ID', true)
             ->param('retryStep', null, new Nullable(new WhiteList([
                 Server::STEP_CONFIG_FILES,
@@ -74,6 +76,8 @@ class Install extends Action
         string $accountPassword,
         string $database,
         string $topology,
+        bool $documentsDB,
+        bool $vectorsDB,
         string $installId,
         ?string $retryStep,
         bool $migrate,
@@ -233,6 +237,8 @@ class Install extends Action
                 '_APP_EMAIL_CERTIFICATES' => $emailCertificates,
                 '_APP_DB_ADAPTER' => $lockedDatabase ?? ($database ?: 'postgresql'),
                 '_APP_ASSISTANT_OPENAI_API_KEY' => $assistantOpenAIKey,
+                '_APP_DOCUMENTSDB' => $documentsDB ? 'enabled' : 'disabled',
+                '_APP_VECTORSDB' => $vectorsDB ? 'enabled' : 'disabled',
             ];
 
             $previousHadError = is_array($existing) && isset($existing['error']);

--- a/src/Appwrite/Platform/Installer/Http/Installer/View.php
+++ b/src/Appwrite/Platform/Installer/Http/Installer/View.php
@@ -50,6 +50,8 @@ class View extends Action
 
         $defaultEmailCertificates = $vars['_APP_EMAIL_CERTIFICATES']['default'] ?? '';
         $defaultForceHttps = ($vars['_APP_OPTIONS_FORCE_HTTPS']['default'] ?? 'disabled') === 'enabled';
+        $defaultDocumentsDB = ($vars['_APP_DOCUMENTSDB']['default'] ?? 'enabled') !== 'disabled';
+        $defaultVectorsDB = ($vars['_APP_VECTORSDB']['default'] ?? 'enabled') !== 'disabled';
         if ($isLocalInstall && empty($defaultEmailCertificates)) {
             $defaultEmailCertificates = 'walterobrien@example.com';
         }

--- a/src/Appwrite/Platform/Tasks/Install.php
+++ b/src/Appwrite/Platform/Tasks/Install.php
@@ -672,7 +672,12 @@ class Install extends Action
                 $this->updateProgress($progress, InstallerServer::STEP_CONFIG_FILES, InstallerServer::STATUS_COMPLETED, $messages);
             }
 
-            if ($database === 'mongodb' && !$useExistingConfig && $startIndex <= 1) {
+            // DocumentsDB runs on MongoDB, so the service, and its bind-mounted support
+            // files, can be present even when another engine backs the platform.
+            $needsMongo = $database === 'mongodb'
+                || ($input['_APP_DOCUMENTSDB'] ?? 'enabled') !== 'disabled';
+
+            if ($needsMongo && !$useExistingConfig && $startIndex <= 1) {
                 $this->copyMongoFilesIfNeeded();
             }
 

--- a/src/Appwrite/Platform/Tasks/Install.php
+++ b/src/Appwrite/Platform/Tasks/Install.php
@@ -258,6 +258,33 @@ class Install extends Action
             $enableAssistant = true;
         }
 
+        // DocumentsDB runs on MongoDB and VectorsDB on PostgreSQL. Turning one off keeps
+        // its engine out of the installation, so only deploy what is actually used.
+        $products = [
+            'enableDocumentsDB' => ['var' => '_APP_DOCUMENTSDB', 'label' => 'DocumentsDB', 'engine' => 'MongoDB'],
+            'enableVectorsDB' => ['var' => '_APP_VECTORSDB', 'label' => 'VectorsDB', 'engine' => 'PostgreSQL'],
+        ];
+        $enabledProducts = [];
+        foreach ($products as $param => $product) {
+            // On an upgrade the existing .env has already seeded the default; on a fresh
+            // install the environment is how a scripted run states its choice.
+            $current = $existingInstallation
+                ? ($vars[$product['var']]['default'] ?? 'enabled') !== 'disabled'
+                : System::getEnv($product['var'], 'enabled') !== 'disabled';
+
+            if ($interactive === 'Y' && Console::isInteractive()) {
+                $answer = Console::confirm(
+                    "Enable {$product['label']}? It requires {$product['engine']} (Y/n)"
+                    . ($existingInstallation ? ($current ? ' [Currently enabled]' : ' [Currently disabled]') : '')
+                );
+                $enabledProducts[$param] = empty($answer) ? $current : \strtolower($answer) === 'y';
+            } else {
+                $enabledProducts[$param] = $current;
+            }
+
+            $vars[$product['var']]['default'] = $enabledProducts[$param] ? 'enabled' : 'disabled';
+        }
+
         if (empty($httpPort)) {
             $httpPort = Console::confirm('Choose your server HTTP port: (default: ' . $defaultHttpPort . ')');
             $httpPort = ($httpPort) ?: $defaultHttpPort;
@@ -586,6 +613,8 @@ class Install extends Action
             'database' => $database,
             'hostPath' => $this->hostPath,
             'enableAssistant' => $enableAssistant,
+            'enableDocumentsDB' => ($input['_APP_DOCUMENTSDB'] ?? 'enabled') !== 'disabled',
+            'enableVectorsDB' => ($input['_APP_VECTORSDB'] ?? 'enabled') !== 'disabled',
             'topology' => $this->topology,
         ]);
 

--- a/tests/unit/Docker/Compose/GeneratorTest.php
+++ b/tests/unit/Docker/Compose/GeneratorTest.php
@@ -80,6 +80,23 @@ final class GeneratorTest extends TestCase
         $this->assertArrayHasKey('postgresql', $compose['services'], 'still the platform engine');
     }
 
+    public function testProductReusesThePlatformEngine(): void
+    {
+        $compose = $this->render([
+            'database' => 'mongodb',
+            'enableDocumentsDB' => true,
+            'enableVectorsDB' => false,
+        ]);
+
+        $engines = \array_intersect(
+            ['postgresql', 'mariadb', 'mongodb'],
+            \array_keys($compose['services'])
+        );
+
+        $this->assertSame(['mongodb'], \array_values($engines), 'DocumentsDB reuses MongoDB rather than adding a second engine');
+        $this->assertArrayNotHasKey('postgresql', $compose['services']);
+    }
+
     public function testPlatformEngineSurvivesItsProductBeingDisabled(): void
     {
         $compose = $this->render([

--- a/tests/unit/Docker/Compose/GeneratorTest.php
+++ b/tests/unit/Docker/Compose/GeneratorTest.php
@@ -25,6 +25,8 @@ final class GeneratorTest extends TestCase
         $compose = $this->render([
             'database' => 'mariadb',
             'enableAssistant' => false,
+            'enableDocumentsDB' => false,
+            'enableVectorsDB' => false,
         ]);
 
         $this->assertArrayHasKey('mariadb', $compose['services']);
@@ -37,7 +39,10 @@ final class GeneratorTest extends TestCase
 
     public function testDefaultsToPostgreSQL(): void
     {
-        $compose = $this->render();
+        $compose = $this->render([
+            'enableDocumentsDB' => false,
+            'enableVectorsDB' => false,
+        ]);
 
         $this->assertArrayHasKey('postgresql', $compose['services']);
         $this->assertArrayNotHasKey('mongodb', $compose['services']);
@@ -45,6 +50,47 @@ final class GeneratorTest extends TestCase
         $this->assertArrayHasKey('appwrite-postgresql', $compose['volumes']);
         $this->assertArrayNotHasKey('appwrite-mongodb', $compose['volumes']);
         $this->assertArrayNotHasKey('appwrite-mariadb', $compose['volumes']);
+    }
+
+    public function testEnabledProductsAddTheirEngine(): void
+    {
+        $compose = $this->render([
+            'database' => 'mariadb',
+            'enableDocumentsDB' => true,
+            'enableVectorsDB' => true,
+        ]);
+
+        $this->assertArrayHasKey('mariadb', $compose['services']);
+        $this->assertArrayHasKey('mongodb', $compose['services'], 'DocumentsDB runs on MongoDB');
+        $this->assertArrayHasKey('postgresql', $compose['services'], 'VectorsDB runs on PostgreSQL');
+        $this->assertArrayHasKey('appwrite-mongodb', $compose['volumes']);
+        $this->assertArrayHasKey('appwrite-postgresql', $compose['volumes']);
+    }
+
+    public function testDisabledProductDropsItsEngine(): void
+    {
+        $compose = $this->render([
+            'database' => 'postgresql',
+            'enableDocumentsDB' => false,
+            'enableVectorsDB' => true,
+        ]);
+
+        $this->assertArrayNotHasKey('mongodb', $compose['services']);
+        $this->assertArrayNotHasKey('appwrite-mongodb', $compose['volumes']);
+        $this->assertArrayHasKey('postgresql', $compose['services'], 'still the platform engine');
+    }
+
+    public function testPlatformEngineSurvivesItsProductBeingDisabled(): void
+    {
+        $compose = $this->render([
+            'database' => 'mongodb',
+            'enableDocumentsDB' => false,
+            'enableVectorsDB' => false,
+        ]);
+
+        $this->assertArrayHasKey('mongodb', $compose['services'], 'selected as the platform engine');
+        $this->assertArrayHasKey('appwrite-mongodb', $compose['volumes']);
+        $this->assertArrayNotHasKey('postgresql', $compose['services']);
     }
 
     public function testTogglesAssistantService(): void


### PR DESCRIPTION
DocumentsDB runs only on MongoDB and VectorsDB only on PostgreSQL, but the installer provisioned a single engine — the one chosen for the platform. A default PostgreSQL installation therefore had no MongoDB, so creating a DocumentsDB database returned `201` and the **first collection write failed with a bare `Server Error`**, the cause visible only in the server log:

```
MongoDB connection failed: Failed to connect to MongoDB at mongodb:27017
```

A MariaDB installation lost both products the same way. Every single-engine install silently lost at least one database product.

## Approach

Rather than always deploying every engine, ask which products the installation actually wants, and deploy only what those answers require.

### Products are asked for during install

`_APP_DOCUMENTSDB` and `_APP_VECTORSDB`, both `enabled` by default. Seeded from the environment for scripted runs, and preserved from the existing `.env` on upgrade.

![shot-1-prompts](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/shot-1-prompts-7e01179c.png)

### The web installer offers the same choice

Both products appear as toggles beside the database selector, defaulted from the variable defaults.

![web-step1](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/web-step1-2f080944.png)

The choice is carried through the wizard and confirmed on the review step before the install starts.

![web-review2](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/web-review2-8d9446f8.png)

### Only the needed engines are deployed

An engine is added when the platform uses it, or when an enabled product needs it. Turning both off leaves a single-engine deployment.

![shot-2-engines](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/shot-2-engines-b647cfd7.png)

### A disabled product returns a clear error

Its routes throw `GENERAL_SERVICE_DISABLED` — for API keys and privileged roles too, since the engine behind them is not deployed. Other products are unaffected.

![shot-3-api](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/shot-3-api-9dbc125d.png)

## Verification

End to end on a real generated installation, not a synthetic one:

1. Ran the CLI `install` through a PTY answering **DocumentsDB = n**, VectorsDB = y.
2. The generated `.env` carried `_APP_DOCUMENTSDB="disabled"` and the rendered `docker-compose.yml` **omitted the mongodb service** — the booted stack ran 15 containers with no MongoDB.
3. Against that stack, `POST /v1/documentsdb` returned `403 general_service_disabled`, while TablesDB and VectorsDB returned `201`.

Also verified all four non-interactive combinations produce the expected engine set and `.env` values, and that a product's engine still survives when it is the platform engine (`database=mongodb` with DocumentsDB off keeps MongoDB).

## Test plan

- [x] Unit suite 1071 → 1074; Pint PSR-12 clean on all changed files; Prettier clean on `docker-compose.yml`
- [x] Updated 2 Generator tests that encoded the old "one engine only" assumption, added 3 covering the toggles
- [x] Interactive install honours `n` (verified through a PTY, not piped stdin)
- [x] All four enabled/disabled combinations verified for engines and `.env`
- [x] Disabled routes return `403`; enabled products unaffected
- [x] Web installer: toggling DocumentsDB off carries through the wizard and shows `Disabled` on the review step
- [x] All installer JS passes `node --check`; all touched `.phtml` pass `php -l`

## Notes for review

**The error copy is imprecise for this case.** `GENERAL_SERVICE_DISABLED` reads *"You can enable the service from the Appwrite console."*, but an operator re-enables this through the environment, not the console. I kept the existing error type so the SDK-visible contract stays stable; making the message context-aware would need either a distinct type or a parameterised message.

**Defaults preserve current behaviour but add a container.** Both default to `enabled`, so a default PostgreSQL install now also provisions MongoDB — one more container than 2.0.0 as it stands. That is the cost of DocumentsDB working out of the box. Defaulting them to `disabled` instead is a one-line change if you would rather operators opt in.
