### PR TITLE
chore(deps): pin utopia-php/platform to 1.0.0-rc18

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,32 +40,6 @@
     "prefer-stable": true,
     "repositories": [
         {
-            "type": "package",
-            "package": {
-                "name": "utopia-php/platform",
-                "version": "1.0.999",
-                "source": {
-                    "url": "https://github.com/utopia-php/monorepo.git",
-                    "type": "git",
-                    "reference": "cursor/multi-job-queue-platform-f0c8"
-                },
-                "autoload": {
-                    "psr-4": {
-                        "Utopia\\Platform\\": "packages/platform/src/Platform"
-                    }
-                },
-                "require": {
-                    "php": ">=8.5",
-                    "ext-json": "*",
-                    "ext-redis": "*",
-                    "utopia-php/cli": "^0.24",
-                    "utopia-php/http": "^2.0@RC",
-                    "utopia-php/queue": "0.23.* || 0.24.* || ^1.0.0",
-                    "utopia-php/servers": "^0.4"
-                }
-            }
-        },
-        {
             "type": "vcs",
             "url": "https://github.com/utopia-php/auth"
         },
@@ -115,7 +89,7 @@
         "utopia-php/logger": "0.8.*",
         "utopia-php/messaging": "^2.1",
         "utopia-php/migration": "^2.0.0",
-        "utopia-php/platform": "^1.0@RC",
+        "utopia-php/platform": "1.0.0-rc18",
         "utopia-php/pools": "2.*",
         "utopia-php/span": "3.0.*",
         "utopia-php/queue": "^1.3.0",
@@ -157,8 +131,7 @@
         "ext-phpiredis": "*"
     },
     "config": {
-        "platform": {
-        },
+        "platform": {},
         "audit": {
             "abandoned": "report"
         },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c372c1e88974c7a9765b892b230897d3",
+    "content-hash": "55334da9d9e92ccd15b3c9c18d49d92d",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -4400,11 +4400,17 @@
         },
         {
             "name": "utopia-php/platform",
-            "version": "1.0.999",
+            "version": "1.0.0-rc18",
             "source": {
                 "type": "git",
-                "url": "https://github.com/utopia-php/monorepo.git",
-                "reference": "cursor/multi-job-queue-platform-f0c8"
+                "url": "https://github.com/utopia-php/platform.git",
+                "reference": "aab0b18f26cf851e8f48d6a6bb36e92ed597ce50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/utopia-php/platform/zipball/aab0b18f26cf851e8f48d6a6bb36e92ed597ce50",
+                "reference": "aab0b18f26cf851e8f48d6a6bb36e92ed597ce50",
+                "shasum": ""
             },
             "require": {
                 "ext-json": "*",
@@ -4418,9 +4424,26 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Utopia\\Platform\\": "packages/platform/src/Platform"
+                    "Utopia\\Platform\\": "src/Platform"
                 }
-            }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Light and Fast Platform Library",
+            "keywords": [
+                "framework",
+                "php",
+                "platform",
+                "upf",
+                "utopia"
+            ],
+            "support": {
+                "issues": "https://github.com/utopia-php/platform/issues",
+                "source": "https://github.com/utopia-php/platform/tree/1.0.0-rc18"
+            },
+            "time": "2026-08-18T15:36:41+00:00"
         },
         {
             "name": "utopia-php/pools",
@@ -8533,8 +8556,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "utopia-php/http": 5,
-        "utopia-php/platform": 5
+        "utopia-php/http": 5
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
`utopia-php/platform` is declared through a hand-written `type: package` repository that points at a **branch**, under an invented version:

```json
"version": "1.0.999",
"source": { "reference": "cursor/multi-job-queue-platform-f0c8" }
```

Nothing tagged contained the combined worker initialisation that `app/worker.php` depends on — it passes `workers` and `jobs` to `Platform::init()`, which `platform/1.0.0-rc17` does not accept — so pinning to the newest tag was not an option. That left every build resolving a mutable branch reference: a force-push or a branch deletion breaks the build, with no integrity guarantee and no reproducibility.

## What changed upstream

The branch is **already merged into the monorepo `main`**, and `packages/platform` there is byte-identical to the pinned commit. What it adds over `rc17` is small and self-contained:

```
packages/platform/src/Platform/Platform.php     |  53 ++++++++--
packages/platform/tests/unit/InitWorkerTest.php | 130 ++++++++++++++++++
packages/platform/phpunit.xml                   |   3 +-
```

Since `main` already carried the code, it has been released as **`platform/1.0.0-rc18`**, tagged on `main` with all 21 CI checks green, following the convention in the monorepo's `CONTRIBUTING.md` (*"Releases are made by maintainers, by tagging the monorepo `<package>/<version>`"*) — the same way `rc15`, `rc16` and `rc17` were cut.

## This change

Drop the package repository block and depend on the tag:

```diff
-"utopia-php/platform": "^1.0@RC"      (+ 29 lines of hand-written repository)
+"utopia-php/platform": "1.0.0-rc18"
```

The lock now resolves a real dist zip at `aab0b18f26` instead of a branch. **Exactly one package changes:**

```
utopia-php/platform: 1.0.999 -> 1.0.0-rc18
total changed: 1
```

## Verification

Verified on `2.0.x`, which carries the same change:

- Image rebuilds; 26/26 services boot; `/v1/health/version` returns `2.0.0`
- **The combined worker still works** — the entire reason the branch was pinned: `Mode: combined — all queues in one process`, every queue registered with its per-queue coroutine cap, zero fatal or uncaught errors
- Async attribute creation returns `202` and the follow-up document writes succeed, so a worker genuinely consumed its queue
- Unit suite passes

## Test plan

- [x] `composer update utopia-php/platform` changes only that package in the lock
- [x] Production image builds; full stack boots healthy
- [x] Combined worker registers all queues; no fatal/uncaught errors
- [x] Queue consumption verified functionally, not just by boot
- [x] Unit suite passes

`utopia-php/http` still resolves to `2.0.0-rc23` via `^2.0@RC`. That is a tagged RC rather than a mutable reference, so it is a much weaker concern than this was, but worth a separate decision before a GA tag.
