### PR TITLE
fix(schedules): scope reads to the configured region

### DIFF
--- a/src/Appwrite/Schedule/Source/Database.php
+++ b/src/Appwrite/Schedule/Source/Database.php
@@ -104,12 +104,6 @@ abstract class Database implements Source, Changes
      */
     private function rows(?\DateTimeImmutable $since): iterable
     {
-        // Temporarly accepting both 'fra' and 'default'
-        $regions = [System::getEnv('_APP_REGION', 'default')];
-        if (!\in_array('default', $regions)) {
-            $regions[] = 'default';
-        }
-
         $limit = 10_000;
         $sum = $limit;
         $latest = null;
@@ -117,7 +111,7 @@ abstract class Database implements Source, Changes
         while ($sum === $limit) {
             $queries = [
                 Query::limit($limit),
-                Query::equal('region', $regions),
+                Query::equal('region', [System::getEnv('_APP_REGION', 'default')]),
                 Query::equal('resourceType', [$this->type()]),
             ];
 

--- a/tests/unit/Schedule/Source/DatabaseTest.php
+++ b/tests/unit/Schedule/Source/DatabaseTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Schedule\Source;
+
+use Appwrite\Schedule\Source\Messages;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Database;
+use Utopia\Database\Query;
+
+final class DatabaseTest extends TestCase
+{
+    #[DataProvider('regionProvider')]
+    public function testSnapshotReadsOnlyTheConfiguredRegion(?string $region, string $expected): void
+    {
+        $previous = \getenv('_APP_REGION');
+        $region === null ? \putenv('_APP_REGION') : \putenv("_APP_REGION={$region}");
+
+        try {
+            $database = $this->createMock(Database::class);
+            $database
+                ->expects($this->once())
+                ->method('find')
+                ->with('schedules', $this->callback(function (array $queries) use ($expected): bool {
+                    foreach ($queries as $query) {
+                        if ($query instanceof Query && $query->getAttribute() === 'region') {
+                            $this->assertSame([$expected], $query->getValues());
+
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }))
+                ->willReturn([]);
+
+            $source = new Messages($database, fn () => $database, fn () => false);
+
+            $this->assertSame([], \iterator_to_array($source->snapshot()));
+        } finally {
+            $previous === false ? \putenv('_APP_REGION') : \putenv("_APP_REGION={$previous}");
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string|null, string}>
+     */
+    public static function regionProvider(): iterable
+    {
+        yield 'self-hosted default' => [null, 'default'];
+        yield 'configured region' => ['tor', 'tor'];
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Scopes schedule reconciliation to the configured `_APP_REGION`. The previous temporary Cloud migration fallback added `default` to every regional query, so schedulers in regions such as `tor` also read schedules outside their region.

Self-hosted installations remain unchanged: when `_APP_REGION` is unset, `System::getEnv()` still falls back to `default`.

Adds a regression test covering both an unset region and a configured Cloud region through the schedule source public snapshot path.

## Test Plan

- `php vendor/bin/phpunit tests/unit/Schedule/Source/DatabaseTest.php`
- `composer lint src/Appwrite/Schedule/Source/Database.php`
- `composer lint tests/unit/Schedule/Source/DatabaseTest.php`
- `vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=1G src/Appwrite/Schedule/Source/Database.php tests/unit/Schedule/Source/DatabaseTest.php`

## Related PRs and Issues

- Follow-up to investigation of cross-region scheduler queries.

## Checklist

- [x] Have you read the contributing guidelines?
- [x] No API metadata changed.