### PR TITLE
Draw the fallback avatar with the heroicons user mark

### DIFF
--- a/src/Appwrite/AvatarPhotos/Providers/Fallback.php
+++ b/src/Appwrite/AvatarPhotos/Providers/Fallback.php
@@ -45,13 +45,21 @@ class Fallback extends Photo
 
     private function buildSvg(int $width, int $height): string
     {
+        // The person mark: heroicons 'user' solid (MIT), authored on a 24x24
+        // grid — https://heroicons.com. Scaled to just over half the avatar
+        // and centred, so it sits like an icon rather than filling the tile.
+        $box = \min($width, $height) * 0.6;
+        $scale = $box / 24;
+
+        $x = ($width - $box) / 2;
+        $y = ($height - $box) / 2;
+
+        $transform = \sprintf('translate(%.4F %.4F) scale(%.6F)', $x, $y, $scale);
+
         return <<<SVG
 <svg xmlns="http://www.w3.org/2000/svg" width="{$width}" height="{$height}" viewBox="0 0 {$width} {$height}">
   <rect width="{$width}" height="{$height}" fill="#FD366E"/>
-  <!-- Head -->
-  <circle cx="50%" cy="38%" r="22%" fill="rgba(255,255,255,0.85)"/>
-  <!-- Body / shoulder shape -->
-  <ellipse cx="50%" cy="90%" rx="35%" ry="30%" fill="rgba(255,255,255,0.85)"/>
+  <path transform="{$transform}" fill="rgba(255,255,255,0.85)" fill-rule="evenodd" clip-rule="evenodd" d="M7.5 6a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM3.751 20.105a8.25 8.25 0 0 1 16.498 0 .75.75 0 0 1-.437.695A18.683 18.683 0 0 1 12 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 0 1-.437-.695Z"/>
 </svg>
 SVG;
     }


### PR DESCRIPTION
## What does this PR do?

Replaces the static fallback avatar's hand-made figure (a `circle` head and an `ellipse` body) with the [heroicons](https://heroicons.com) **user solid** glyph (MIT), taken verbatim from `optimized/24/solid/user.svg`. The mark is scaled to just over half the tile and centred, keeping the `#FD366E` surface and the soft-white `rgba(255,255,255,0.85)` fill.

Follow-up to the photo resolver introduced in #13359 and simplified on main.

Rendered result (256×256):

- Head + rounded-shoulder silhouette, inset so corners stay surface-coloured — both the SVG string check and the PNG corner check in `assertPhotoFallback` hold unchanged.
- Percentage units are avoided for the mark (the path is authored on a 24×24 grid and placed with a computed `translate`/`scale`), so non-square sizes centre the glyph instead of distorting it — verified at 120×80.

## Test Plan

- `tests/unit/AvatarPhotos/` — 17 tests green.
- `tests/e2e/Services/Avatars/` — full suite, 46 tests / 923 assertions green.
- Rendered 256×256 and 120×80 outputs manually and inspected the rasterised result.

## Note for reviewers

While verifying, I found this container's ImageMagick security policy blocks SVG decoding entirely (`operation not authorized by the security policy 'SVG'`), so the Imagick rasterisation branch in `Fallback::get()` always throws and the endpoint serves raw SVG bytes in practice — on this stack the PNG path is dead code. The e2e helper already anticipates both encodings, and this PR keeps that structure untouched, but it may be worth deciding separately whether to draw the mark with Imagick primitives (works regardless of policy) or drop the rasterisation branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)