### PR TITLE
fix(tests): isolate parallel function archives

### DIFF
--- a/tests/e2e/Services/Functions/FunctionsBase.php
+++ b/tests/e2e/Services/Functions/FunctionsBase.php
@@ -258,15 +258,26 @@ trait FunctionsBase
     protected function packageFunction(string $function): CURLFile
     {
         $folderPath = realpath(__DIR__ . '/../../../resources/functions') . "/$function";
-        $tarPath = "$folderPath/code.tar.gz";
+        $tarPath = \sys_get_temp_dir() . '/appwrite-function-' . $function . '-' . \getmypid() . '-' . \uniqid('', true) . '.tar.gz';
 
-        Console::execute("cd $folderPath && tar --exclude code.tar.gz --exclude node_modules -czf code.tar.gz .", '', $this->stdout, $this->stderr);
+        Console::execute(
+            'tar --exclude code.tar.gz --exclude node_modules -czf ' . \escapeshellarg($tarPath) . ' -C ' . \escapeshellarg($folderPath) . ' .',
+            '',
+            $this->stdout,
+            $this->stderr
+        );
 
         if (filesize($tarPath) > 1024 * 1024 * 5) {
             throw new \Exception('Code package is too large. Use the chunked upload method instead.');
         }
 
-        return new CURLFile($tarPath, 'application/x-gzip', \basename($tarPath));
+        register_shutdown_function(static function () use ($tarPath) {
+            if (\is_file($tarPath)) {
+                @\unlink($tarPath);
+            }
+        });
+
+        return new CURLFile($tarPath, 'application/x-gzip', 'code.tar.gz');
     }
 
     protected function createDeployment(string $functionId, mixed $params = []): mixed


### PR DESCRIPTION
## What does this PR do?

Prevents parallel function E2E tests from sharing the same fixture-local `code.tar.gz`.

`packageFunction()` returned a `CURLFile` pointing at `tests/resources/functions/<fixture>/code.tar.gz`. Under ParaTest, another process could run `tar -czf` against that path before libcurl finished consuming it. Since `tar` truncates the file in place, deployments intermittently received an empty source archive.

The failure is visible in [this FunctionsSchedule job](https://github.com/appwrite/appwrite/actions/runs/33147999770/job/98773532040?pr=13399):

```text
pre-job artifact processing failed: archive source.tar.gz is empty
Build failed with exit code -1.
```

The job runs all four FunctionsSchedule methods with four ParaTest processes, and all four package the `basic` fixture concurrently.

Each call now creates an independently named archive in the system temporary directory, keeps the multipart filename as `code.tar.gz`, and removes the temporary file when its PHP test process shuts down. This follows the existing `packageSite()` pattern.

## How was it tested?

- `composer lint tests/e2e/Services/Functions/FunctionsBase.php`
- Recreated the failing CI setup locally with PostgreSQL, PHP 8.5.9, ParaTest 7.20.0, `--processes 4`, and `--functional`:

```text
OK (4 tests, 275 assertions)
```

- Stress-tested four concurrent archive writers against the old shared path: the path was observable at zero length and produced short reads.
- Repeated the same stress test with unique per-call archives: 974 valid archives, zero empty or invalid archives.
