### PR TITLE
Serve SVG files as attachment on the view endpoint

### DIFF
--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/View/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/View/Get.php
@@ -136,6 +136,13 @@ class Get extends Action
             $contentType = $file->getAttribute('mimeType');
         }
 
+        // SVG is an executable document, not a passive image: a browser that
+        // navigates to it will run any embedded script in this origin. Forcing
+        // a download means it is never rendered as a top-level document.
+        // Embedding through <img src> still works and is safe (browsers load
+        // SVG there in a restricted mode with no scripting).
+        $disposition = $contentType === 'image/svg+xml' ? 'attachment' : 'inline';
+
         $size = $file->getAttribute('sizeOriginal', 0);
 
         $rangeHeader = $request->getHeaderLine('range');
@@ -161,9 +168,9 @@ class Get extends Action
 
         $response
             ->setContentType($contentType)
-            ->addHeader('Content-Security-Policy', 'script-src none;')
+            ->addHeader('Content-Security-Policy', "script-src 'none';")
             ->addHeader('X-Content-Type-Options', 'nosniff')
-            ->addHeader('Content-Disposition', 'inline; filename="' . $file->getAttribute('name', '') . '"')
+            ->addHeader('Content-Disposition', $disposition . '; filename="' . $file->getAttribute('name', '') . '"')
             ->addHeader('Cache-Control', 'private, max-age=3888000') // 45 days
             ->addHeader('X-Peak', \memory_get_peak_usage())
         ;

--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -513,12 +513,14 @@ trait StorageBase
         $bucketId = $bucket['body']['$id'];
 
         $cases = [
-            ['source' => 'logo.svg', 'mimeType' => 'image/svg+xml', 'contentType' => 'image/svg+xml'],
-            ['source' => 'logo.png', 'mimeType' => 'image/png', 'contentType' => 'image/png'],
-            ['source' => 'document.pdf', 'mimeType' => 'application/pdf', 'contentType' => 'application/pdf'],
+            // SVG is executable in a browser, so it is served as a download
+            // (attachment) and never rendered as a top-level document.
+            ['source' => 'logo.svg', 'mimeType' => 'image/svg+xml', 'contentType' => 'image/svg+xml', 'disposition' => 'attachment'],
+            ['source' => 'logo.png', 'mimeType' => 'image/png', 'contentType' => 'image/png', 'disposition' => 'inline'],
+            ['source' => 'document.pdf', 'mimeType' => 'application/pdf', 'contentType' => 'application/pdf', 'disposition' => 'inline'],
             // HTML is not in the storage-mimes allowlist on purpose: rendering
             // user uploads as HTML on the API origin would allow stored XSS.
-            ['source' => 'page.html', 'mimeType' => 'text/html', 'contentType' => 'text/plain'],
+            ['source' => 'page.html', 'mimeType' => 'text/html', 'contentType' => 'text/plain', 'disposition' => 'inline'],
         ];
 
         foreach ($cases as $case) {
@@ -543,8 +545,9 @@ trait StorageBase
 
             $this->assertEquals(200, $view['headers']['status-code'], $case['source']);
             $this->assertEquals($case['contentType'], $view['headers']['content-type'], $case['source']);
-            $this->assertEquals('script-src none;', $view['headers']['content-security-policy'], $case['source']);
+            $this->assertEquals("script-src 'none';", $view['headers']['content-security-policy'], $case['source']);
             $this->assertEquals('nosniff', $view['headers']['x-content-type-options'], $case['source']);
+            $this->assertStringStartsWith($case['disposition'] . ';', $view['headers']['content-disposition'], $case['source']);
             $this->assertEquals(\file_get_contents($source), $view['body'], $case['source']);
         }
     }
@@ -1093,6 +1096,51 @@ trait StorageBase
         $this->assertEquals(400, $preview['headers']['status-code']);
         $this->assertEquals(Exception::STORAGE_IMAGE_RESOLUTION_EXCEEDED, $preview['body']['type']);
         $this->assertStringContainsString('60000x1', $preview['body']['message']);
+    }
+
+    public function testFileViewSvgIsNotExecutable(): void
+    {
+        $bucket = $this->client->call(Client::METHOD_POST, '/storage/buckets', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'bucketId' => ID::unique(),
+            'name' => 'SVG View Safety',
+            'permissions' => [
+                Permission::read(Role::any()),
+                Permission::create(Role::any()),
+            ],
+        ]);
+        $this->assertEquals(201, $bucket['headers']['status-code']);
+        $bucketId = $bucket['body']['$id'];
+
+        // A hostile SVG carrying <script>, onload, onclick, and a javascript: href.
+        $file = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', array_merge([
+            'content-type' => 'multipart/form-data',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'fileId' => ID::unique(),
+            'file' => new CURLFile(realpath(__DIR__ . '/../../../resources/script.svg'), 'image/svg+xml', 'script.svg'),
+            'permissions' => [
+                Permission::read(Role::any()),
+            ],
+        ]);
+        $this->assertEquals(201, $file['headers']['status-code']);
+        $this->assertEquals('image/svg+xml', $file['body']['mimeType']);
+
+        $view = $this->client->call(Client::METHOD_GET, '/storage/buckets/' . $bucketId . '/files/' . $file['body']['$id'] . '/view', array_merge([
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        /**
+         * Test for SUCCESS - the browser is never allowed to execute the SVG:
+         * it is served as a download, not rendered as a top-level document.
+         */
+        $this->assertEquals(200, $view['headers']['status-code']);
+        $this->assertStringStartsWith('attachment;', $view['headers']['content-disposition']);
+        $this->assertEquals("script-src 'none';", $view['headers']['content-security-policy']);
+        $this->assertEquals('nosniff', $view['headers']['x-content-type-options']);
     }
 
     public function testFilePreviewCache(): void

--- a/tests/resources/script.svg
+++ b/tests/resources/script.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="120" height="120" viewBox="0 0 120 120" onload="alert(document.domain)">
+    <script>alert(document.cookie);</script>
+    <rect width="120" height="120" rx="16" fill="#FD366E" onclick="alert(1)"/>
+    <a xlink:href="javascript:alert(1)">
+        <circle cx="60" cy="60" r="30" fill="#FFFFFF"/>
+    </a>
+</svg>


### PR DESCRIPTION
## What does this PR do?

Fixes a reported stored-XSS vector in the storage view endpoint. `GET /v1/storage/buckets/:bucketId/files/:fileId/view` served uploaded SVG files inline with `Content-Type: image/svg+xml`, so navigating a browser to the file URL rendered the SVG as a top-level document and executed any embedded `<script>`, event handlers, or `javascript:` hrefs on the API origin.

Changes:
- SVG (`image/svg+xml`) is now served with `Content-Disposition: attachment` instead of `inline`, so the browser downloads it and never renders it as a document. Embedding via `<img src>` keeps working — browsers load SVG images with scripting disabled, which is the safe mode.
- Fixed the `Content-Security-Policy` header on the endpoint: `script-src none;` is invalid CSP (`'none'` must be quoted), so the existing header never blocked anything. Now sends `script-src 'none';`.

No changes to `/preview`: SVG is not in the preview inputs allowlist, so SVGs already resolve to the placeholder file icon there and never reach the image pipeline.

## Test Plan

- Added `testFileViewSvgIsNotExecutable`: uploads a hostile SVG (`<script>`, `onload`, `onclick`, `javascript:` href) and asserts `/view` responds with `Content-Disposition: attachment`, valid `script-src 'none';` CSP, and `nosniff`.
- Extended the existing view content-type test to assert the disposition per mime type (SVG → attachment, png/pdf/html → inline) and the corrected CSP header.

## Related PRs and Issues

None.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

🤖 Generated with [Claude Code](https://claude.com/claude-code)