### PR TITLE
perf(realtime): single Swoole worker, encode the document once per event, meter outbound bytes

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -351,7 +351,7 @@ return [
             ],
             [
                 'name' => '_APP_WORKER_PER_CORE',
-                'description' => 'Internal Worker per core for the API, Realtime and Executor containers. Can be configured to optimize performance.',
+                'description' => 'Internal Worker per core for the API and Executor containers. Can be configured to optimize performance. Realtime ignores this and runs a single worker per container; use _APP_WORKERS_NUM to override.',
                 'introduction' => '0.13.0',
                 'default' => 6,
                 'required' => false,

--- a/app/realtime.php
+++ b/app/realtime.php
@@ -393,8 +393,13 @@ $stats->create();
 $containerId = uniqid();
 $statsDocument = null;
 
-$workerNumber = intval(System::getEnv('_APP_WORKERS_NUM', 0))
-    ?: intval(System::getEnv('_APP_CPU_NUM', swoole_cpu_num())) * intval(System::getEnv('_APP_WORKER_PER_CORE', 6));
+// Realtime is I/O bound: a single worker holding ~1200 websocket connections
+// measured 0.06-0.35 cores, so extra workers add forked interpreter copies (~84%
+// of a worker's footprint is fixed overhead, not connection state), duplicate the
+// firehose subscription so every worker json_decodes every event, and split the
+// accept distribution into a second, invisible balancing layer. Concurrency is the
+// deployment's job. `_APP_WORKERS_NUM` still overrides.
+$workerNumber = intval(System::getEnv('_APP_WORKERS_NUM', 0)) ?: 1;
 
 $adapter = new Adapter\Swoole(port: System::getEnv('PORT', 80));
 $adapter
@@ -788,19 +793,23 @@ $server->onWorkerStart(function (int $workerId) use ($server, $register, $stats,
                 $total = 0;
                 $outboundBytes = 0;
 
-                // One frame per connection. `subscriptions` carries that connection's
+                // One frame per connection: `subscriptions` carries that connection's
                 // matched subscription IDs, and those are ID::unique() per connection
                 // (see the subscribe handler), so no two connections can ever share a
-                // frame. The grouping this replaces keyed on exactly those IDs, so it
-                // never collapsed -- it always built one group of one.
-                foreach ($receivers as $id => $matched) {
-                    $data = $event['data'];
-                    $data['subscriptions'] = array_keys($matched);
+                // frame. (The grouping this replaced keyed on exactly those IDs and so
+                // never collapsed -- it always built one group of one.)
+                //
+                // `subscriptions` is the only part that varies, and it is small, so the
+                // document is serialised once per event rather than once per subscriber.
+                // This loop's json_encode was 26% of realtime's on-CPU work during a
+                // fan-out burst, against 2.8% at rest.
+                $data = $event['data'];
+                unset($data['subscriptions']);
+                $tail = $data === [] ? '' : ',' . substr(json_encode($data), 1, -1);
 
-                    $payloadJson = json_encode([
-                        'type' => 'event',
-                        'data' => $data
-                    ]);
+                foreach ($receivers as $id => $matched) {
+                    $payloadJson = '{"type":"event","data":{"subscriptions":'
+                        . json_encode(array_keys($matched)) . $tail . '}}';
 
                     $server->send([$id], $payloadJson);
 

--- a/app/realtime.php
+++ b/app/realtime.php
@@ -545,6 +545,10 @@ $server->onWorkerStart(function (int $workerId) use ($server, $register, $stats,
     $register->set('telemetry.connectionCounter', fn () => $telemetry->createUpDownCounter('realtime.server.open_connections'));
     $register->set('telemetry.connectionCreatedCounter', fn () => $telemetry->createCounter('realtime.server.connection.created'));
     $register->set('telemetry.messageSentCounter', fn () => $telemetry->createCounter('realtime.server.message.sent'));
+    // Fan-out cost is driven by bytes, not message count: one large document to many
+    // subscribers allocates far more than many small ones. Without this, a burst that
+    // moves hundreds of MB is invisible next to a flat message rate.
+    $register->set('telemetry.outboundBytesCounter', fn () => $telemetry->createCounter('realtime.server.outbound_bytes', 'By'));
     $register->set('telemetry.deliveryDelayHistogram', fn () => $telemetry->createHistogram(
         name: 'realtime.server.delivery_delay',
         unit: 'ms',
@@ -639,18 +643,11 @@ $server->onWorkerStart(function (int $workerId) use ($server, $register, $stats,
 
             $subscribers = $realtime->getSubscribers($event);
 
-            $groups = [];
             foreach ($subscribers as $id => $matched) {
-                $key = implode(',', array_keys($matched));
-                $groups[$key]['ids'][] = $id;
-                $groups[$key]['subscriptions'] = array_keys($matched);
-            }
-
-            foreach ($groups as $group) {
                 $data = $event['data'];
-                $data['subscriptions'] = $group['subscriptions'];
+                $data['subscriptions'] = array_keys($matched);
 
-                $server->send($group['ids'], json_encode([
+                $server->send([$id], json_encode([
                     'type' => 'event',
                     'data' => $data
                 ]));
@@ -788,35 +785,32 @@ $server->onWorkerStart(function (int $workerId) use ($server, $register, $stats,
                     Console::log("[Debug][Worker {$workerId}] Event: " . $payload);
                 }
 
-                // Group connections by matched subscription IDs for batch sending
-                $groups = [];
-                foreach ($receivers as $id => $matched) {
-                    $key = implode(',', array_keys($matched));
-                    $groups[$key]['ids'][] = $id;
-                    $groups[$key]['subscriptions'] = array_keys($matched);
-                }
-
                 $total = 0;
                 $outboundBytes = 0;
 
-                foreach ($groups as $group) {
+                // One frame per connection. `subscriptions` carries that connection's
+                // matched subscription IDs, and those are ID::unique() per connection
+                // (see the subscribe handler), so no two connections can ever share a
+                // frame. The grouping this replaces keyed on exactly those IDs, so it
+                // never collapsed -- it always built one group of one.
+                foreach ($receivers as $id => $matched) {
                     $data = $event['data'];
-                    $data['subscriptions'] = $group['subscriptions'];
+                    $data['subscriptions'] = array_keys($matched);
 
                     $payloadJson = json_encode([
                         'type' => 'event',
                         'data' => $data
                     ]);
 
-                    $server->send($group['ids'], $payloadJson);
+                    $server->send([$id], $payloadJson);
 
-                    $count = count($group['ids']);
-                    $total += $count;
-                    $outboundBytes += strlen($payloadJson) * $count;
+                    $total++;
+                    $outboundBytes += strlen($payloadJson);
                 }
 
                 if ($total > 0) {
                     $register->get('telemetry.messageSentCounter')->add($total);
+                    $register->get('telemetry.outboundBytesCounter')->add($outboundBytes);
                     $stats->incr($event['project'], 'messages', $total);
                     $updatedAt = $event['data']['payload']['$updatedAt'] ?? null;
                     if (\is_string($updatedAt)) {

--- a/app/realtime.php
+++ b/app/realtime.php
@@ -839,15 +839,12 @@ $server->onWorkerStart(function (int $workerId) use ($server, $register, $stats,
                     $projectId = $event['project'] ?? null;
 
                     if (!empty($projectId)) {
-                        $metrics = [
+                        // Reached only when $total > 0, and every frame carries the
+                        // literal envelope, so outbound bytes are always non-zero.
+                        triggerStats([
                             METRIC_REALTIME_CONNECTIONS_MESSAGES_SENT => $total,
-                        ];
-
-                        if ($outboundBytes > 0) {
-                            $metrics[METRIC_REALTIME_OUTBOUND] = $outboundBytes;
-                        }
-
-                        triggerStats($metrics, $projectId);
+                            METRIC_REALTIME_OUTBOUND => $outboundBytes,
+                        ], $projectId);
                     }
 
                 }


### PR DESCRIPTION
From an Appwrite Cloud realtime OOMKill investigation (fra1; OnCall #1098, #1175 and a third
kill at 15:32Z). Four changes, all evidenced below.

## 1. Realtime runs one Swoole worker per container

Was `_APP_CPU_NUM × _APP_WORKER_PER_CORE` (6). `_APP_WORKERS_NUM` still overrides.

Measured on fra1 production. Per-worker connection counts and `smaps_rollup` sampled at the
same instant, paired sorted-to-sorted (which *overstates* per-connection cost):

| connections | private | PSS |
|---|---|---|
| 51 | 41.1 MiB | 50.8 MiB |
| 93 | 41.3 MiB | 50.7 MiB |
| 116 | 43.4 MiB | 52.8 MiB |
| 170 | 49.6 MiB | 62.7 MiB |

Fit: **~37 MiB fixed per worker, ~71 KiB per connection.** At ~110 connections/worker that
makes ~84% of each worker's footprint duplicated interpreter, opcache COW breakage and
allocator arena — not connection state.

- **CPU never justified six.** A 60s profile at 199 Hz across master + 6 workers put real PHP
  work at **2.35%** of samples; the rest was `Swoole\Server::start` in epoll. Whole-container
  usage was 0.24–0.34 cores. After the change, one worker carrying *more* connections used
  0.06–0.10 cores.
- **Each worker duplicated the firehose.** Every worker subscribes to the Redis `realtime`
  channel and `json_decode`s every event — 27% of all real work at rest. Six workers meant 6×
  the decode for identical output.
- **Workers were a second, invisible balancing layer.** Inside one container, connections per
  worker ran **51 → 170** on Swoole's accept distribution, underneath the pod-level skew.

After rollout in fra1: container memory **325/679/725 MiB → ~185 MiB**, CPU 0.24–0.34 → 0.06–0.10
cores, connections per container even to ±3%, and per-worker skew gone by construction.

## 2. The document is serialised once per event, not once per subscriber

Every connection needs its own frame because `subscriptions` carries that connection's matched
subscription IDs. But that array is small, so the rest of the frame is now encoded once and
reused.

A 199 Hz profile captured **during a live growth event** (container RSS 578 → 667 MB across the
45s window):

| | at rest | during the burst |
|---|---|---|
| real work (non-idle samples) | 2.35% | **12.4%** |
| `json_encode` | 2.8% | **25.8%** |
| `json_decode` | 27.2% | 14.6% |
| `getSubscribers` | 3.4% | 9.2% |

**257 of 285 `json_encode` samples** sat on one stack: the pubsub callback at `realtime.php:679`
→ `json_encode`. That is this loop.

Frames are unchanged apart from key order (`subscriptions` moves first; JSON object order is
not significant). 36 comparisons across unicode escaping, slashes, empty `data`, nested
empties, a pre-set `subscriptions` key and a blob containing quotes and backslashes all decode
identically.

## 3. The fan-out grouping was dead code

It grouped receivers by their matched subscription IDs so one frame could serve many
connections — but those IDs are `ID::unique()` per subscription, so no two connections can
share a key. It always built one group of one. Replaced with a direct loop; verified
`old_groups == conns` at 1/5/100/1000 connections and 1–3 subscriptions each, with identical
frames, totals and byte counts, plus a control showing collapse requires repeated IDs.

## 4. Outbound bytes are metered

`realtime.server.message.sent` counted messages; nothing counted bytes, and bytes are what a
fan-out costs. During the incident three containers stepped **+18 / +78 / +226 MiB
simultaneously** at a message rate of **21/s** — below a 74/s peak 70 minutes earlier that cost
nothing. Meanwhile `dragonfly_net_output_bytes_total` on the pubsub instance went **1.2 → 4.05
MB/s**. Adds `realtime.server.outbound_bytes` (unit `By`).

## What is deliberately NOT changed

`Utopia\WebSocket\Adapter\Swoole::send()` spawns a coroutine per connection
(utopia-php/websocket#3, 2021). It is tempting to blame it, and I did — but there is no
evidence for it. In the production image (PHP 8.5.9, Swoole 6.2.2, Alpine), fanning distinct
frames to 1,000 connections that never read:

| variant | RSS delta |
|---|---|
| coroutine per connection (current) | +416 kB / +2,320 kB¹ |
| one coroutine per event | +2,340 kB¹ |
| fully synchronous, no coroutine | +2,320 kB¹ |
| decode + fan-out | +2,324 kB¹ |
| decode only | +2,196 kB¹ |

¹ THP `always`; the first figure is THP `madvise`. 977 MB fanned out, 20,000/20,000 pushes ok,
`coroutine_peak_num=2`. Raising the payload to 500 KB per frame changed nothing. All variants
are indistinguishable, so the adapter is not touched.

**The memory mechanism is still unidentified.** It is anonymous in-process memory
(`container_memory_cache` flat at 38.5 MB across a step while `container_memory_rss` went
170 → 396 MB), it is not transparent huge pages (`AnonHugePages` was 18 MB of 501 MB anonymous
on the growing container), and no synthetic reproduction has produced more than ~2 MB. The
remaining hypothesis is allocator fragmentation under heterogeneous allocation sizes against
long-lived state, which a uniform-size harness cannot reproduce. Cloud keeps a 1 GiB limit
for headroom until it is understood; these changes lower the baseline and the per-event work
but should not be described as fixing the OOM.

## Testing

`app/realtime.php` is a Swoole bootstrap with no unit coverage; this path runs only under
`tests/e2e/Services/Realtime/*`, which needs a live stack. The frame-equivalence and
grouping checks above stand in for it, and the `subscriptions` assertions in
`RealtimeCustomClientQueryTest` / `...WithMessage` still cover the contract end-to-end in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)