### PR TITLE
fix(health): require certificate domain

### DIFF
--- a/src/Appwrite/Platform/Modules/Health/Http/Health/Certificate/Get.php
+++ b/src/Appwrite/Platform/Modules/Health/Http/Health/Certificate/Get.php
@@ -30,7 +30,7 @@ class Get extends Action
             ->desc('Get the SSL certificate for a domain')
             ->groups(['api', 'health'])
             ->label('scope', 'health.read')
-            ->param('domain', null, new Multiple([new AnyOf([new URL(), new Domain()]), new PublicDomain()]), Multiple::TYPE_STRING, 'Domain name', example: 'example.com')
+            ->param('domain', '', new Multiple([new AnyOf([new URL(), new Domain()]), new PublicDomain()], Multiple::TYPE_STRING), 'Domain name', example: 'example.com')
             ->inject('response')
             ->callback($this->action(...));
     }

--- a/tests/e2e/Services/Health/CertificateTest.php
+++ b/tests/e2e/Services/Health/CertificateTest.php
@@ -18,6 +18,9 @@ final class CertificateTest extends HealthBase
         $this->assertCertificateFailure('doesnotexist.com', 404);
         $this->assertCertificateFailure('www.google.com/usr/src/local', 400);
         $this->assertCertificateFailure('', 400);
+
+        $response = $this->callGet('/health/certificate');
+        $this->assertEquals(400, $response['headers']['status-code']);
     }
 
     private function assertCertificate(string $domain, string $expectedName, string $expectedSN): void


### PR DESCRIPTION
## What does this PR do?

Fixes `GET /v1/health/certificate` returning a 500 response when `domain` is omitted.

`Multiple::TYPE_STRING` was passed as the parameter description instead of to the `Multiple` validator constructor. That shifted `"Domain name"` into the optional argument, making `domain` optional with a `null` default. The request then reached the typed action as `null` and raised a `TypeError`.

The validator type is now passed to `Multiple`, the parameter uses an empty-string default, and the endpoint returns the expected 400 validation response when `domain` is absent. This also restores `Domain name` as the generated parameter description instead of `string`.

## How was it tested?

- Added an E2E regression for a request without `domain`.
- Ran `tests/e2e/Services/Health/CertificateTest.php`:

```text
OK (1 test, 28 assertions)
```

- Pint passes for both changed files.
