### PR TITLE
feat: ship DocumentsDB and VectorsDB off by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,6 +520,8 @@ jobs:
           _APP_DATABASE_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'database_db_main' || '' }}
           _APP_DATABASE_DOCUMENTSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'documentsdb_db_main' || '' }}
           _APP_DATABASE_VECTORSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'vectorsdb_db_main' || '' }}
+          _APP_DOCUMENTSDB: enabled
+          _APP_VECTORSDB: enabled
         run: docker compose up -d --quiet-pull --wait
 
       - name: Wait for Open Runtimes
@@ -638,6 +640,8 @@ jobs:
           _APP_DATABASE_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'database_db_main' || '' }}
           _APP_DATABASE_DOCUMENTSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'documentsdb_db_main' || '' }}
           _APP_DATABASE_VECTORSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'vectorsdb_db_main' || '' }}
+          _APP_DOCUMENTSDB: enabled
+          _APP_VECTORSDB: enabled
         run: |
           if [ "${{ matrix.config.wait }}" = "clamav" ]; then
             docker compose up -d --quiet-pull --wait --wait-timeout 780

--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -616,6 +616,24 @@ return [
                 'question' => '',
                 'filter' => ''
             ],
+            [
+                'name' => '_APP_DOCUMENTSDB',
+                'description' => 'Enables the DocumentsDB API, which runs on MongoDB. The installer does not deploy MongoDB, so provision one and point the _APP_DB_*_DOCUMENTSDB variables at it before enabling this; until then the /v1/documentsdb routes return a service disabled error. Default value is: disabled.',
+                'introduction' => '2.0.0',
+                'default' => 'disabled',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
+            [
+                'name' => '_APP_VECTORSDB',
+                'description' => 'Enables the VectorsDB API, which runs on PostgreSQL. The installer does not deploy a PostgreSQL for it, so provision one and point the _APP_DB_*_VECTORSDB variables at it before enabling this; until then the /v1/vectorsdb routes return a service disabled error. Default value is: disabled.',
+                'introduction' => '2.0.0',
+                'default' => 'disabled',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
         ],
     ],
     [

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -461,6 +461,22 @@ Http::init()
         if (! empty($method)) {
             $namespace = \strtolower($method->getNamespace());
 
+            // DocumentsDB runs only on MongoDB and VectorsDB only on PostgreSQL, while an
+            // installation deploys just the engine backing the platform, so neither is on
+            // until an operator provisions that engine and says so. Closed to everyone --
+            // keys and privileged roles included -- rather than answering and then failing
+            // on the first write with the reason only in the logs.
+            $products = [
+                'documentsdb' => '_APP_DOCUMENTSDB',
+                'vectorsdb' => '_APP_VECTORSDB',
+            ];
+            if (
+                isset($products[$namespace])
+                && System::getEnv($products[$namespace], 'disabled') !== 'enabled'
+            ) {
+                throw new Exception(Exception::GENERAL_SERVICE_DISABLED);
+            }
+
             if (
                 array_key_exists($namespace, $project->getAttribute('services', []))
                 && ! $project->getAttribute('services', [])[$namespace]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -245,6 +245,8 @@ services:
       - _APP_GEO_SECRET
       - _APP_GEO_ENDPOINT
       - _APP_LIMIT_DATABASE_BATCH
+      - _APP_DOCUMENTSDB
+      - _APP_VECTORSDB
   appwrite-console:
     logging:
       driver: json-file
@@ -338,6 +340,8 @@ services:
       - _APP_LOGGING_CONFIG_REALTIME
       - _APP_DATABASE_SHARED_TABLES
       - _APP_LIMIT_DATABASE_BATCH
+      - _APP_DOCUMENTSDB
+      - _APP_VECTORSDB
       - _APP_POOL_ADAPTER=swoole
 
   appwrite-worker:
@@ -501,6 +505,8 @@ services:
       - _APP_MAINTENANCE_RETENTION_AUDIT
       - _APP_MAINTENANCE_RETENTION_AUDIT_CONSOLE
       - _APP_LIMIT_DATABASE_BATCH
+      - _APP_DOCUMENTSDB
+      - _APP_VECTORSDB
 
   appwrite-task-scheduler:
     entrypoint: schedule
@@ -757,6 +763,8 @@ services:
       - _APP_QUEUE_NAME
       - _APP_DATABASE_SHARED_TABLES
       - _APP_LIMIT_DATABASE_BATCH
+      - _APP_DOCUMENTSDB
+      - _APP_VECTORSDB
   appwrite-worker-builds:
     profiles:
       - separate


### PR DESCRIPTION
DocumentsDB and VectorsDB are unusable on a stock installation, so they now ship off and say so, instead of accepting a request and failing on the first write.

## What happens today

DocumentsDB runs only on MongoDB and VectorsDB only on PostgreSQL, but an installation deploys a single engine — the one chosen for the platform. A default install has neither engine behind those products:

```
POST /v1/documentsdb            201    database created
POST /v1/documentsdb/:id/collections
                                500    general_server_error
```

Nothing in the response says MongoDB is absent; the cause is only in the container logs. A MariaDB platform loses both products the same way.

## The change

Both products are off unless `_APP_DOCUMENTSDB` or `_APP_VECTORSDB` is set to `enabled`, and until then their routes return `general_service_disabled` — to API keys and privileged roles too, since there is no engine to reach either way. The check sits with the existing per-project service gate in `app/controllers/shared/api.php`, before scope validation, so a disabled product reads the same as one a project has turned off.

Enabling one is an operator decision that comes with provisioning work: deploy the engine and point the matching `_APP_DB_*_DOCUMENTSDB` / `_APP_DB_*_VECTORSDB` variables at it. The installer neither asks nor deploys an engine for a product — the variables are documented in `app/config/variables.php` and that is the whole surface.

CI sets both to `enabled`, so the existing DocumentsDB and VectorsDB e2e suites keep running against the MongoDB the matrix already provisions.

This supersedes #13382, which offered the choice through the CLI and web installers and had the compose generator deploy an engine per enabled product. That is a lot of surface for products that are not ready to be turned on, so it is closed in favour of this.

## Verification

Against a running stack with the change mounted, using a project API key holding every database scope:

| Request | Default | `_APP_DOCUMENTSDB=enabled` `_APP_VECTORSDB=enabled` |
|---|---|---|
| `GET /v1/documentsdb` | 403 `general_service_disabled` | 200 |
| `POST /v1/documentsdb` | 403 `general_service_disabled` | — |
| `GET /v1/vectorsdb` | 403 `general_service_disabled` | 200 |
| `POST /v1/vectorsdb` | 403 `general_service_disabled` | — |
| `POST /v1/tablesdb` (control) | 201 | 201 |
| `GET /v1/databases` (control) | 200 | 200 |

Also confirmed the gate fires ahead of scope validation: an unauthenticated call gets `general_service_disabled` rather than `general_unauthorized_scope`.

## Test plan

- [x] Pint PSR-12 passes
- [x] `docker compose config` validates
- [x] Disabled by default for keys and privileged roles, with the controls unaffected
- [x] Both products reachable again once the variables are set
- [ ] CI e2e stays green with the variables set in the workflow

## Note

`/v1/embeddings/text` is a separate service (`embeddings`) backed by the embedding container rather than a database engine, so it is left alone.

2.0.x carries a partial version of #13382 already (`e92e56d274`, the CLI installer half). A follow-up strips the prompts and the compose generator's per-product engine selection there and brings it in line with this.
