### PR TITLE
revert: drop the installer choice for the database products (2.0.x)

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -616,24 +616,6 @@ return [
                 'question' => '',
                 'filter' => ''
             ],
-            [
-                'name' => '_APP_DOCUMENTSDB',
-                'description' => 'Enables the DocumentsDB API. It runs on MongoDB, so the installation needs a reachable MongoDB while this is enabled. Set to disabled to leave MongoDB out; the /v1/documentsdb routes then return a service disabled error. Default value is: enabled.',
-                'introduction' => '2.0.0',
-                'default' => 'enabled',
-                'required' => false,
-                'question' => 'Enable DocumentsDB? It requires MongoDB (Y/n)',
-                'filter' => ''
-            ],
-            [
-                'name' => '_APP_VECTORSDB',
-                'description' => 'Enables the VectorsDB API. It runs on PostgreSQL, so the installation needs a reachable PostgreSQL while this is enabled. Set to disabled to leave PostgreSQL out; the /v1/vectorsdb routes then return a service disabled error. Default value is: enabled.',
-                'introduction' => '2.0.0',
-                'default' => 'enabled',
-                'required' => false,
-                'question' => 'Enable VectorsDB? It requires PostgreSQL (Y/n)',
-                'filter' => ''
-            ],
         ],
     ],
     [

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -461,19 +461,6 @@ Http::init()
         if (! empty($method)) {
             $namespace = \strtolower($method->getNamespace());
 
-            // An operator turns a database product off when its engine is not deployed,
-            // so the route is unavailable to everyone, keys and privileged roles included.
-            $productToggles = [
-                'documentsdb' => '_APP_DOCUMENTSDB',
-                'vectorsdb' => '_APP_VECTORSDB',
-            ];
-            if (
-                isset($productToggles[$namespace])
-                && System::getEnv($productToggles[$namespace], 'enabled') !== 'enabled'
-            ) {
-                throw new Exception(Exception::GENERAL_SERVICE_DISABLED);
-            }
-
             if (
                 array_key_exists($namespace, $project->getAttribute('services', []))
                 && ! $project->getAttribute('services', [])[$namespace]

--- a/app/views/install/installer.phtml
+++ b/app/views/install/installer.phtml
@@ -9,8 +9,6 @@ $defaultAppDomain = $vars['_APP_DOMAIN']['default'] ?? 'localhost';
 $defaultAppDomain = ($defaultAppDomain === 'traefik') ? 'localhost' : $defaultAppDomain;
 $defaultEmailCertificates ??= '';
 $defaultForceHttps ??= ($vars['_APP_OPTIONS_FORCE_HTTPS']['default'] ?? 'disabled') === 'enabled';
-$defaultDocumentsDB ??= ($vars['_APP_DOCUMENTSDB']['default'] ?? 'enabled') !== 'disabled';
-$defaultVectorsDB ??= ($vars['_APP_VECTORSDB']['default'] ?? 'enabled') !== 'disabled';
 $defaultDatabase = $vars['_APP_DB_ADAPTER']['default'] ?? 'postgresql';
 $enabledDatabases ??= ['postgresql', 'mariadb', 'mongodb'];
 $isLocalInstall ??= false;
@@ -67,8 +65,6 @@ $installerVersion = @filemtime(__DIR__ . '/installer/js/installer.js') ?: time()
     data-default-app-domain="<?php echo htmlspecialchars((string) $defaultAppDomain, ENT_QUOTES, 'UTF-8'); ?>"
     data-default-email-certificates="<?php echo htmlspecialchars((string) $defaultEmailCertificates, ENT_QUOTES, 'UTF-8'); ?>"
     data-default-force-https="<?php echo $defaultForceHttps ? 'true' : 'false'; ?>"
-    data-default-documentsdb="<?php echo $defaultDocumentsDB ? 'true' : 'false'; ?>"
-    data-default-vectorsdb="<?php echo $defaultVectorsDB ? 'true' : 'false'; ?>"
     data-default-secret-key=""
     data-default-assistant-openai-key=""
     data-default-database="<?php echo htmlspecialchars((string) $defaultDatabase, ENT_QUOTES, 'UTF-8'); ?>"

--- a/app/views/install/installer/js/modules/progress.js
+++ b/app/views/install/installer/js/modules/progress.js
@@ -369,8 +369,6 @@
             httpsPort: normalizedHttpsPort,
             database: formState?.database || 'postgresql',
             topology: formState?.topology || 'combined',
-            documentsDB: formState?.documentsDB !== false,
-            vectorsDB: formState?.vectorsDB !== false,
             appDomain: normalizedDomain,
             emailCertificates: normalizedEmail,
             forceHttps: formState?.forceHttps === true,

--- a/app/views/install/installer/js/modules/state.js
+++ b/app/views/install/installer/js/modules/state.js
@@ -20,8 +20,6 @@
         opensslKey: null,
         assistantOpenAIKey: null,
         topology: 'combined',
-        documentsDB: null,
-        vectorsDB: null,
         accountEmail: null,
         accountPassword: null
     };
@@ -49,8 +47,6 @@
         setStateIfEmpty('httpsPort', data.defaultHttpsPort);
         setStateIfEmpty('emailCertificates', data.defaultEmailCertificates);
         setStateIfEmpty('forceHttps', data.defaultForceHttps === 'true');
-        setStateIfEmpty('documentsDB', data.defaultDocumentsdb !== 'false');
-        setStateIfEmpty('vectorsDB', data.defaultVectorsdb !== 'false');
         setStateIfEmpty('opensslKey', data.defaultSecretKey);
         setStateIfEmpty('assistantOpenAIKey', data.defaultAssistantOpenaiKey);
         if (data.lockedDatabase) {

--- a/app/views/install/installer/js/modules/ui.js
+++ b/app/views/install/installer/js/modules/ui.js
@@ -265,18 +265,6 @@
             httpsBadge.classList.add(forceHttps ? 'badge-success' : 'badge-neutral');
         }
 
-        const productBadges = [
-            ['[data-review-documentsdb-badge]', formState?.documentsDB !== false],
-            ['[data-review-vectorsdb-badge]', formState?.vectorsDB !== false],
-        ];
-        productBadges.forEach(([selector, enabled]) => {
-            const badge = root.querySelector(selector);
-            if (!badge) return;
-            badge.textContent = enabled ? 'Enabled' : 'Disabled';
-            badge.classList.remove('badge-success', 'badge-neutral');
-            badge.classList.add(enabled ? 'badge-success' : 'badge-neutral');
-        });
-
         const assistantBadge = root.querySelector('[data-review-assistant-badge]');
         if (assistantBadge) {
             const hasAssistantKey = Boolean((formState?.assistantOpenAIKey || '').trim());

--- a/app/views/install/installer/js/steps.js
+++ b/app/views/install/installer/js/steps.js
@@ -122,8 +122,6 @@
         State.setStateIfEmpty?.('httpsPort', root.querySelector('#https-port')?.value);
         State.setStateIfEmpty?.('emailCertificates', root.querySelector('#ssl-email')?.value);
         State.setStateIfEmpty?.('forceHttps', root.querySelector('#force-https')?.checked);
-        State.setStateIfEmpty?.('documentsDB', root.querySelector('#documentsdb')?.checked);
-        State.setStateIfEmpty?.('vectorsDB', root.querySelector('#vectorsdb')?.checked);
         State.setStateIfEmpty?.('assistantOpenAIKey', root.querySelector('#assistant-openai-key')?.value);
     };
 
@@ -143,16 +141,6 @@
         const forceHttps = root.querySelector('#force-https');
         if (forceHttps && typeof formState.forceHttps === 'boolean') {
             forceHttps.checked = formState.forceHttps;
-        }
-
-        const documentsDB = root.querySelector('#documentsdb');
-        if (documentsDB && typeof formState.documentsDB === 'boolean') {
-            documentsDB.checked = formState.documentsDB;
-        }
-
-        const vectorsDB = root.querySelector('#vectorsdb');
-        if (vectorsDB && typeof formState.vectorsDB === 'boolean') {
-            vectorsDB.checked = formState.vectorsDB;
         }
 
         const assistantKey = root.querySelector('#assistant-openai-key');
@@ -224,8 +212,6 @@
         bindInputToState(httpsPort, 'httpsPort');
         bindInputToState(sslEmail, 'emailCertificates');
         bindCheckboxToState(forceHttps, 'forceHttps');
-        bindCheckboxToState(root.querySelector('#documentsdb'), 'documentsDB');
-        bindCheckboxToState(root.querySelector('#vectorsdb'), 'vectorsDB');
         bindInputToState(assistantKey, 'assistantOpenAIKey');
 
         bindErrorClear?.(hostname);

--- a/app/views/install/installer/templates/steps/step-1.phtml
+++ b/app/views/install/installer/templates/steps/step-1.phtml
@@ -10,8 +10,6 @@ $defaultEmailCertificates ??= '';
 $defaultForceHttps ??= false;
 $defaultAssistantOpenAIKey ??= '';
 $defaultDatabase ??= 'postgresql';
-$defaultDocumentsDB ??= true;
-$defaultVectorsDB ??= true;
 $enabledDatabases ??= ['postgresql', 'mariadb', 'mongodb'];
 $selectedDatabase = $lockedDatabase ?: $defaultDatabase;
 $isDatabaseLocked = !empty($lockedDatabase);
@@ -108,32 +106,6 @@ $assistantOpenAIKeyValue = htmlspecialchars((string) $defaultAssistantOpenAIKey,
                     <?php } ?>
                 </div>
             </div>
-
-            <label class="toggle-option" for="documentsdb">
-                <span class="toggle-option-content">
-                    <span class="typography-text-m-500 text-neutral-primary">DocumentsDB</span>
-                    <span id="documentsdb-description" class="typography-text-xs-400 text-neutral-tertiary">Schemaless document API. Runs on MongoDB, which is deployed alongside your database when this is on.</span>
-                </span>
-                <span class="toggle-switch">
-                    <input type="checkbox" id="documentsdb" name="documentsDB" class="sr-only" aria-describedby="documentsdb-description" <?php echo $defaultDocumentsDB ? 'checked' : ''; ?>>
-                    <span class="toggle-switch-track" aria-hidden="true">
-                        <span class="toggle-switch-thumb"></span>
-                    </span>
-                </span>
-            </label>
-
-            <label class="toggle-option" for="vectorsdb">
-                <span class="toggle-option-content">
-                    <span class="typography-text-m-500 text-neutral-primary">VectorsDB</span>
-                    <span id="vectorsdb-description" class="typography-text-xs-400 text-neutral-tertiary">Vector search API. Runs on PostgreSQL, which is deployed alongside your database when this is on.</span>
-                </span>
-                <span class="toggle-switch">
-                    <input type="checkbox" id="vectorsdb" name="vectorsDB" class="sr-only" aria-describedby="vectorsdb-description" <?php echo $defaultVectorsDB ? 'checked' : ''; ?>>
-                    <span class="toggle-switch-track" aria-hidden="true">
-                        <span class="toggle-switch-thumb"></span>
-                    </span>
-                </span>
-            </label>
 
             <div class="accordion">
                 <button

--- a/app/views/install/installer/templates/steps/step-4.phtml
+++ b/app/views/install/installer/templates/steps/step-4.phtml
@@ -67,14 +67,6 @@ $badgeClass = $defaultSecretKey !== '' ? 'badge-success' : 'badge-warning';
                         <span class="badge badge-neutral typography-text-xs-400" data-review-assistant-badge>Disabled</span>
                         <div class="review-label typography-text-xs-400 text-neutral-tertiary">Appwrite Assistant</div>
                     </div>
-                    <div class="review-row">
-                        <span class="badge badge-success typography-text-xs-400" data-review-documentsdb-badge>Enabled</span>
-                        <div class="review-label typography-text-xs-400 text-neutral-tertiary">DocumentsDB</div>
-                    </div>
-                    <div class="review-row">
-                        <span class="badge badge-success typography-text-xs-400" data-review-vectorsdb-badge>Enabled</span>
-                        <div class="review-label typography-text-xs-400 text-neutral-tertiary">VectorsDB</div>
-                    </div>
                     <?php if (!$isUpgrade) { ?>
                     <div class="review-row">
                         <span class="badge <?php echo $badgeClass; ?> typography-text-xs-400" data-review-badge>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -245,8 +245,6 @@ services:
       - _APP_GEO_SECRET
       - _APP_GEO_ENDPOINT
       - _APP_LIMIT_DATABASE_BATCH
-      - _APP_DOCUMENTSDB
-      - _APP_VECTORSDB
   appwrite-console:
     logging:
       driver: json-file
@@ -340,8 +338,6 @@ services:
       - _APP_LOGGING_CONFIG_REALTIME
       - _APP_DATABASE_SHARED_TABLES
       - _APP_LIMIT_DATABASE_BATCH
-      - _APP_DOCUMENTSDB
-      - _APP_VECTORSDB
       - _APP_POOL_ADAPTER=swoole
 
   appwrite-worker:
@@ -505,8 +501,6 @@ services:
       - _APP_MAINTENANCE_RETENTION_AUDIT
       - _APP_MAINTENANCE_RETENTION_AUDIT_CONSOLE
       - _APP_LIMIT_DATABASE_BATCH
-      - _APP_DOCUMENTSDB
-      - _APP_VECTORSDB
 
   appwrite-task-scheduler:
     entrypoint: schedule
@@ -763,8 +757,6 @@ services:
       - _APP_QUEUE_NAME
       - _APP_DATABASE_SHARED_TABLES
       - _APP_LIMIT_DATABASE_BATCH
-      - _APP_DOCUMENTSDB
-      - _APP_VECTORSDB
   appwrite-worker-builds:
     profiles:
       - separate

--- a/src/Appwrite/Docker/Compose/Generator.php
+++ b/src/Appwrite/Docker/Compose/Generator.php
@@ -25,17 +25,6 @@ class Generator
         ],
     ];
 
-    /**
-     * Engine each specialised database product runs on. DocumentsDB only runs on
-     * MongoDB and VectorsDB only on PostgreSQL, so an enabled product needs its
-     * engine even when a different one backs the platform. A disabled product
-     * leaves its engine out, keeping the installation to what it actually uses.
-     */
-    private const array PRODUCT_BACKING_SERVICES = [
-        'enableDocumentsDB' => 'mongodb',
-        'enableVectorsDB' => 'postgresql',
-    ];
-
     private const array OPTIONAL_SERVICES = [
         'enableAssistant' => 'appwrite-assistant',
     ];
@@ -71,8 +60,6 @@ class Generator
         'database' => 'postgresql',
         'hostPath' => '',
         'enableAssistant' => false,
-        'enableDocumentsDB' => true,
-        'enableVectorsDB' => true,
         'topology' => 'combined',
     ];
 
@@ -172,23 +159,8 @@ class Generator
     }
 
     /**
-     * Engines the enabled database products need, on top of the platform engine.
-     *
-     * @return array<int, string>
+     * @return string[]
      */
-    private function getRequiredBackingServices(): array
-    {
-        $services = [];
-
-        foreach (self::PRODUCT_BACKING_SERVICES as $param => $service) {
-            if (!empty($this->params[$param])) {
-                $services[] = $service;
-            }
-        }
-
-        return $services;
-    }
-
     private function getSelectableServices(): array
     {
         $services = [];
@@ -208,15 +180,9 @@ class Generator
     {
         foreach (self::SELECTABLE_SERVICE_GROUPS as $param => $config) {
             foreach ($config['services'] as $service) {
-                if ($service === $this->params[$param]) {
-                    continue;
+                if ($service !== $this->params[$param]) {
+                    unset($services[$service]);
                 }
-
-                if (\in_array($service, $this->getRequiredBackingServices(), true)) {
-                    continue;
-                }
-
-                unset($services[$service]);
             }
         }
 
@@ -282,10 +248,6 @@ class Generator
         foreach (self::SELECTABLE_VOLUME_GROUPS as $param => $groups) {
             foreach ($groups as $service => $names) {
                 if ($service === $this->params[$param]) {
-                    continue;
-                }
-
-                if (\in_array($service, $this->getRequiredBackingServices(), true)) {
                     continue;
                 }
 

--- a/src/Appwrite/Platform/Installer/Http/Installer/Install.php
+++ b/src/Appwrite/Platform/Installer/Http/Installer/Install.php
@@ -43,8 +43,6 @@ class Install extends Action
             ->param('accountPassword', '', new Password(allowEmpty: true), 'Account password', true)
             ->param('database', '', new WhiteList(['postgresql', 'mariadb', 'mongodb']), 'Database adapter', true)
             ->param('topology', 'combined', new WhiteList(['combined', 'separate']), 'Worker and scheduler topology', true)
-            ->param('documentsDB', true, new \Utopia\Validator\Boolean(true), 'Deploy DocumentsDB and the MongoDB it runs on', true)
-            ->param('vectorsDB', true, new \Utopia\Validator\Boolean(true), 'Deploy VectorsDB and the PostgreSQL it runs on', true)
             ->param('installId', '', new Text(64, 0), 'Installation ID', true)
             ->param('retryStep', null, new Nullable(new WhiteList([
                 Server::STEP_CONFIG_FILES,
@@ -76,8 +74,6 @@ class Install extends Action
         string $accountPassword,
         string $database,
         string $topology,
-        bool $documentsDB,
-        bool $vectorsDB,
         string $installId,
         ?string $retryStep,
         bool $migrate,
@@ -237,8 +233,6 @@ class Install extends Action
                 '_APP_EMAIL_CERTIFICATES' => $emailCertificates,
                 '_APP_DB_ADAPTER' => $lockedDatabase ?? ($database ?: 'postgresql'),
                 '_APP_ASSISTANT_OPENAI_API_KEY' => $assistantOpenAIKey,
-                '_APP_DOCUMENTSDB' => $documentsDB ? 'enabled' : 'disabled',
-                '_APP_VECTORSDB' => $vectorsDB ? 'enabled' : 'disabled',
             ];
 
             $previousHadError = is_array($existing) && isset($existing['error']);

--- a/src/Appwrite/Platform/Installer/Http/Installer/View.php
+++ b/src/Appwrite/Platform/Installer/Http/Installer/View.php
@@ -50,8 +50,6 @@ class View extends Action
 
         $defaultEmailCertificates = $vars['_APP_EMAIL_CERTIFICATES']['default'] ?? '';
         $defaultForceHttps = ($vars['_APP_OPTIONS_FORCE_HTTPS']['default'] ?? 'disabled') === 'enabled';
-        $defaultDocumentsDB = ($vars['_APP_DOCUMENTSDB']['default'] ?? 'enabled') !== 'disabled';
-        $defaultVectorsDB = ($vars['_APP_VECTORSDB']['default'] ?? 'enabled') !== 'disabled';
         if ($isLocalInstall && empty($defaultEmailCertificates)) {
             $defaultEmailCertificates = 'walterobrien@example.com';
         }

--- a/src/Appwrite/Platform/Tasks/Install.php
+++ b/src/Appwrite/Platform/Tasks/Install.php
@@ -259,33 +259,6 @@ class Install extends Action
             $enableAssistant = true;
         }
 
-        // DocumentsDB runs on MongoDB and VectorsDB on PostgreSQL. Turning one off keeps
-        // its engine out of the installation, so only deploy what is actually used.
-        $products = [
-            'enableDocumentsDB' => ['var' => '_APP_DOCUMENTSDB', 'label' => 'DocumentsDB', 'engine' => 'MongoDB'],
-            'enableVectorsDB' => ['var' => '_APP_VECTORSDB', 'label' => 'VectorsDB', 'engine' => 'PostgreSQL'],
-        ];
-        $enabledProducts = [];
-        foreach ($products as $param => $product) {
-            // On an upgrade the existing .env has already seeded the default; on a fresh
-            // install the environment is how a scripted run states its choice.
-            $current = $existingInstallation
-                ? ($vars[$product['var']]['default'] ?? 'enabled') !== 'disabled'
-                : System::getEnv($product['var'], 'enabled') !== 'disabled';
-
-            if ($interactive === 'Y' && Console::isInteractive()) {
-                $answer = Console::confirm(
-                    "Enable {$product['label']}? It requires {$product['engine']} (Y/n)"
-                    . ($existingInstallation ? ($current ? ' [Currently enabled]' : ' [Currently disabled]') : '')
-                );
-                $enabledProducts[$param] = empty($answer) ? $current : \strtolower($answer) === 'y';
-            } else {
-                $enabledProducts[$param] = $current;
-            }
-
-            $vars[$product['var']]['default'] = $enabledProducts[$param] ? 'enabled' : 'disabled';
-        }
-
         if (empty($httpPort)) {
             $httpPort = Console::confirm('Choose your server HTTP port: (default: ' . $defaultHttpPort . ')');
             $httpPort = ($httpPort) ?: $defaultHttpPort;
@@ -660,8 +633,6 @@ class Install extends Action
             'database' => $database,
             'hostPath' => $this->hostPath,
             'enableAssistant' => $enableAssistant,
-            'enableDocumentsDB' => ($input['_APP_DOCUMENTSDB'] ?? 'enabled') !== 'disabled',
-            'enableVectorsDB' => ($input['_APP_VECTORSDB'] ?? 'enabled') !== 'disabled',
             'topology' => $this->topology,
         ]);
 
@@ -719,12 +690,7 @@ class Install extends Action
                 $this->updateProgress($progress, InstallerServer::STEP_CONFIG_FILES, InstallerServer::STATUS_COMPLETED, $messages);
             }
 
-            // DocumentsDB runs on MongoDB, so the service, and its bind-mounted support
-            // files, can be present even when another engine backs the platform.
-            $needsMongo = $database === 'mongodb'
-                || ($input['_APP_DOCUMENTSDB'] ?? 'enabled') !== 'disabled';
-
-            if ($needsMongo && !$useExistingConfig && $startIndex <= 1) {
+            if ($database === 'mongodb' && !$useExistingConfig && $startIndex <= 1) {
                 $this->copyMongoFilesIfNeeded();
             }
 

--- a/tests/unit/Docker/Compose/GeneratorTest.php
+++ b/tests/unit/Docker/Compose/GeneratorTest.php
@@ -25,8 +25,6 @@ final class GeneratorTest extends TestCase
         $compose = $this->render([
             'database' => 'mariadb',
             'enableAssistant' => false,
-            'enableDocumentsDB' => false,
-            'enableVectorsDB' => false,
         ]);
 
         $this->assertArrayHasKey('mariadb', $compose['services']);
@@ -39,10 +37,7 @@ final class GeneratorTest extends TestCase
 
     public function testDefaultsToPostgreSQL(): void
     {
-        $compose = $this->render([
-            'enableDocumentsDB' => false,
-            'enableVectorsDB' => false,
-        ]);
+        $compose = $this->render();
 
         $this->assertArrayHasKey('postgresql', $compose['services']);
         $this->assertArrayNotHasKey('mongodb', $compose['services']);
@@ -50,64 +45,6 @@ final class GeneratorTest extends TestCase
         $this->assertArrayHasKey('appwrite-postgresql', $compose['volumes']);
         $this->assertArrayNotHasKey('appwrite-mongodb', $compose['volumes']);
         $this->assertArrayNotHasKey('appwrite-mariadb', $compose['volumes']);
-    }
-
-    public function testEnabledProductsAddTheirEngine(): void
-    {
-        $compose = $this->render([
-            'database' => 'mariadb',
-            'enableDocumentsDB' => true,
-            'enableVectorsDB' => true,
-        ]);
-
-        $this->assertArrayHasKey('mariadb', $compose['services']);
-        $this->assertArrayHasKey('mongodb', $compose['services'], 'DocumentsDB runs on MongoDB');
-        $this->assertArrayHasKey('postgresql', $compose['services'], 'VectorsDB runs on PostgreSQL');
-        $this->assertArrayHasKey('appwrite-mongodb', $compose['volumes']);
-        $this->assertArrayHasKey('appwrite-postgresql', $compose['volumes']);
-    }
-
-    public function testDisabledProductDropsItsEngine(): void
-    {
-        $compose = $this->render([
-            'database' => 'postgresql',
-            'enableDocumentsDB' => false,
-            'enableVectorsDB' => true,
-        ]);
-
-        $this->assertArrayNotHasKey('mongodb', $compose['services']);
-        $this->assertArrayNotHasKey('appwrite-mongodb', $compose['volumes']);
-        $this->assertArrayHasKey('postgresql', $compose['services'], 'still the platform engine');
-    }
-
-    public function testProductReusesThePlatformEngine(): void
-    {
-        $compose = $this->render([
-            'database' => 'mongodb',
-            'enableDocumentsDB' => true,
-            'enableVectorsDB' => false,
-        ]);
-
-        $engines = \array_intersect(
-            ['postgresql', 'mariadb', 'mongodb'],
-            \array_keys($compose['services'])
-        );
-
-        $this->assertSame(['mongodb'], \array_values($engines), 'DocumentsDB reuses MongoDB rather than adding a second engine');
-        $this->assertArrayNotHasKey('postgresql', $compose['services']);
-    }
-
-    public function testPlatformEngineSurvivesItsProductBeingDisabled(): void
-    {
-        $compose = $this->render([
-            'database' => 'mongodb',
-            'enableDocumentsDB' => false,
-            'enableVectorsDB' => false,
-        ]);
-
-        $this->assertArrayHasKey('mongodb', $compose['services'], 'selected as the platform engine');
-        $this->assertArrayHasKey('appwrite-mongodb', $compose['volumes']);
-        $this->assertArrayNotHasKey('postgresql', $compose['services']);
     }
 
     public function testTogglesAssistantService(): void


### PR DESCRIPTION
Removes the DocumentsDB and VectorsDB installer choice from 2.0.x, so this branch stops carrying database-product changes that main does not have.

## Why

DocumentsDB runs only on MongoDB and VectorsDB only on PostgreSQL, while an installation deploys a single engine — the one chosen for the platform. A default install has neither engine behind those products, so creating a database returns 201 and the first write fails with a bare server error, the cause only in the container logs.

2.0.x answered that by asking which products to deploy, in both the CLI and the web installer, and having the compose generator add an engine per enabled product. That is a lot of surface for products that are not ready to be turned on from a stock installation.

## What this reverts

| Commit | What it added |
|---|---|
| `e92e56d274` | CLI prompts, per-product engine selection in the compose generator |
| `de7f2585e9` | Generator tests for a product reusing the platform engine |
| `87c3467b23` | The web installer step and its state, progress and review wiring |
| `90b4058db1` | Copying the MongoDB support files whenever DocumentsDB needed them |

Afterwards 2.0.x matches main across `api.php`, `variables.php`, both installers and the compose generator — nothing about these products is left ahead of main, so #13379 no longer shows any of it.

## What replaces it

#13411, against main: both products off unless `_APP_DOCUMENTSDB` or `_APP_VECTORSDB` says otherwise, with their routes returning `general_service_disabled` until then. That is deliberately not cherry-picked here — it belongs on main and reaches this branch through the usual sync, which keeps 2.0.x from drifting ahead again.

## Test plan

- [x] Pint PSR-12 passes
- [x] PHPStan level 4 passes on the reverted files
- [x] `tests/unit/Docker` and `tests/unit/Platform` pass (293 tests)
- [x] `docker compose config` validates
- [x] No `_APP_DOCUMENTSDB` / `_APP_VECTORSDB` / `enableDocumentsDB` / `enableVectorsDB` left ahead of main
- [x] No trace of the choice left in either installer or the compose generator
