### PR TITLE
chore: bump orchestrator to 1.8.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1650,7 +1650,7 @@ services:
     # One image carrying every orchestrator control plane. Appwrite drives the
     # jobs plane today; the per-plane images exist for Kubernetes, where each
     # scales, fails and gets RBAC on its own.
-    image: ghcr.io/open-runtimes/orchestrator/orchestrator:1.8.0
+    image: ghcr.io/open-runtimes/orchestrator/orchestrator:1.8.2
     restart: unless-stopped
     user: root
     networks:
@@ -1664,9 +1664,6 @@ services:
       - ORCHESTRATOR_NETWORK=appwrite
       - DOCKER_NETWORK=appwrite
       - ARTIFACT_ENDPOINT=http://orchestrator:8080
-      # Sidecars ship with the service and move with it, so they share its tag.
-      - JOB_SIDECAR_IMAGE=ghcr.io/open-runtimes/orchestrator/job-sidecar:1.8.0
-      - WORKLOAD_SIDECAR_IMAGE=ghcr.io/open-runtimes/orchestrator/workload-sidecar:1.8.0
 
   mariadb:
     image: mariadb:10.11


### PR DESCRIPTION
## Summary

- bump the all-in-one orchestrator image from 1.8.0 to 1.8.2
- remove the redundant job/workload sidecar overrides

Release orchestrator images now select sidecars matching their embedded release version by default. Removing the explicit overrides keeps the service and sidecars in lockstep without repeating the version in three places.

The PHP runtime SDK is already on the latest 0.13.0 release, so no Composer lock change is needed.

## Validation

- verified the published orchestrator 1.8.2 amd64 and arm64 manifests
- `docker compose config --quiet`
- Prettier check for `docker-compose.yml`
