### PR TITLE
chore: bump orchestrator to 1.8.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1651,7 +1651,7 @@ services:
     # One image carrying every orchestrator control plane. Appwrite drives the
     # jobs plane today; the per-plane images exist for Kubernetes, where each
     # scales, fails and gets RBAC on its own.
-    image: ghcr.io/open-runtimes/orchestrator/orchestrator:1.8.2
+    image: ghcr.io/open-runtimes/orchestrator/orchestrator:1.8.3
     restart: unless-stopped
     user: root
     networks:


### PR DESCRIPTION
Bumps the Docker Compose orchestrator image to 1.8.3.

This release restores generic archive symlink preservation while retaining write-through traversal protection.

Release: https://github.com/open-runtimes/orchestrator/releases/tag/v1.8.3
Upstream fix: https://github.com/open-runtimes/orchestrator/pull/91

Validation:
- docker compose config --quiet