### PR TITLE
fix(proxy): store rule domains in canonical lowercase form

### DIFF
--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/API/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/API/Create.php
@@ -87,6 +87,11 @@ class Create extends Action
         Authorization $authorization,
         Bus $bus,
     ) {
+        // DNS is case-insensitive, and the rule ID below is derived from the
+        // lowercased domain. Store the same canonical form so the row matches
+        // its own ID and downstream certificate providers.
+        $domain = \strtolower($domain);
+
         $this->validateDomainRestrictions($domain, $platform);
 
         // TODO: (@Meldiron) Remove after 1.7.x migration

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Function/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Function/Create.php
@@ -99,6 +99,11 @@ class Create extends Action
         Bus $bus,
     ) {
 
+        // DNS is case-insensitive, and the rule ID below is derived from the
+        // lowercased domain. Store the same canonical form so the row matches
+        // its own ID and downstream certificate providers.
+        $domain = \strtolower($domain);
+
         $this->validateDomainRestrictions($domain, $platform);
 
         $function = $dbForProject->getDocument('functions', $functionId);

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Redirect/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Redirect/Create.php
@@ -116,6 +116,11 @@ class Create extends Action
         Bus $bus,
     ) {
 
+        // DNS is case-insensitive, and the rule ID below is derived from the
+        // lowercased domain. Store the same canonical form so the row matches
+        // its own ID and downstream certificate providers.
+        $domain = \strtolower($domain);
+
         $this->validateDomainRestrictions($domain, $platform);
 
         $collection = match ($resourceType) {

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Site/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Site/Create.php
@@ -99,6 +99,11 @@ class Create extends Action
         Bus $bus,
     ) {
 
+        // DNS is case-insensitive, and the rule ID below is derived from the
+        // lowercased domain. Store the same canonical form so the row matches
+        // its own ID and downstream certificate providers.
+        $domain = \strtolower($domain);
+
         $this->validateDomainRestrictions($domain, $platform);
 
         $site = $dbForProject->getDocument('sites', $siteId);

--- a/tests/e2e/Services/Proxy/ProxyBase.php
+++ b/tests/e2e/Services/Proxy/ProxyBase.php
@@ -205,6 +205,27 @@ trait ProxyBase
         $this->assertEquals(400, $rule['headers']['status-code']);
     }
 
+    public function testCreateAPIRuleFoldsDomainCase(): void
+    {
+        $domain = \uniqid() . '-Case.Custom.LOCALHOST';
+        $canonical = \strtolower($domain);
+
+        $rule = $this->createAPIRule($domain);
+        $this->assertEquals(201, $rule['headers']['status-code'], \json_encode($rule));
+        $this->assertEquals($canonical, $rule['body']['domain']);
+
+        // Re-read, so this pins what was persisted rather than how the create
+        // response was shaped. The stored value is what the delete path and the
+        // certificate providers are handed.
+        $fetched = $this->getRule($rule['body']['$id']);
+        $this->assertEquals(200, $fetched['headers']['status-code']);
+        $this->assertEquals($canonical, $fetched['body']['domain']);
+
+        // Deleting a mixed-case rule is the path that broke: a non-canonical
+        // stored domain must not stop the rule from being removed.
+        $this->cleanupRule($rule['body']['$id']);
+    }
+
     public function testCreateRedirectRule(): void
     {
         $domain = \uniqid() . '-redirect.custom.localhost';


### PR DESCRIPTION
## Summary

The four rule create actions validate the domain with `Utopia\Validator\Domain`, which does not constrain case, then persist the value verbatim — while deriving the rule ID from `md5(\strtolower($domain))`:

```php
$ruleId = System::getEnv('_APP_RULES_FORMAT') === 'md5' ? md5(\strtolower($domain)) : ID::unique();
...
'domain' => $domain,        // raw case
```

So a rule created for `MyApp.Example.COM` stores a domain that does not match the form its own ID was built from. The codebase already treats domains as case-insensitive for identity; storage should match.

## Why it matters

`Utopia\Cdn\Domain::validate()` treats a non-lowercase domain as malformed. On Appwrite Cloud 1.45.22 this made deleting such a rule throw and strand the certificate row it was about to remove.

Fixed properly in utopia-php/cdn#11 (fold case rather than reject). This PR is the write-side half: stop creating rows that are inconsistent with their own ID in the first place.

## Changes

- Normalize `$domain` to lowercase in `Rules/{API,Function,Redirect,Site}/Create.php`, before restriction checks and ID derivation
- `strtolower` is left in the ID expression: it guards an irreversible derivation, so a single source of truth is not worth the risk of silent ID churn if the normalization ever moves

## Tests

`ProxyBase::testCreateAPIRuleFoldsDomainCase` creates a rule with a mixed-case domain and asserts the **persisted** value is canonical by re-reading it, not just the create response. It then deletes the rule, which is the path that broke in production.

Not covered here: existing mixed-case rows. They keep working once utopia-php/cdn#11 lands, and MySQL's default collation is case-insensitive so exact-match lookups still resolve — a backfill would be consistency cleanup, not a fix, so I have not written one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)