### PR TITLE
Fix empty map and nullable response models

### DIFF
--- a/src/Appwrite/Utopia/Response/Model/FrameworkAdapter.php
+++ b/src/Appwrite/Utopia/Response/Model/FrameworkAdapter.php
@@ -39,6 +39,7 @@ class FrameworkAdapter extends Model
                 'description' => 'Name of fallback file to use instead of 404 page. If null, Appwrite 404 page will be displayed.',
                 'default' => null,
                 'example' => 'index.html',
+                'required' => false,
             ])
         ;
     }

--- a/src/Appwrite/Utopia/Response/Model/Project.php
+++ b/src/Appwrite/Utopia/Response/Model/Project.php
@@ -156,8 +156,8 @@ class Project extends Model
             ->addRule('onboarding', [
                 'type' => self::TYPE_JSON,
                 'description' => 'Stage progress (completed or skipped) with timestamps and actor types, keyed by stage id.',
-                'default' => [],
-                'example' => [],
+                'default' => new \stdClass(),
+                'example' => new \stdClass(),
             ])
 
             // Resource: Auth methods
@@ -241,6 +241,11 @@ class Project extends Model
         $this->expandAuthMethods($document);
         $this->expandConsoleAccessedAt($document);
         $document->setAttribute('wafEnabled', (bool) $document->getAttribute('wafEnabled', false));
+
+        $onboarding = $document->getAttribute('onboarding', []);
+        if (\is_array($onboarding) && empty($onboarding)) {
+            $document->setAttribute('onboarding', new \stdClass());
+        }
 
         return $document;
     }

--- a/src/Appwrite/Utopia/Response/Model/Provider.php
+++ b/src/Appwrite/Utopia/Response/Model/Provider.php
@@ -4,6 +4,7 @@ namespace Appwrite\Utopia\Response\Model;
 
 use Appwrite\Utopia\Response;
 use Appwrite\Utopia\Response\Model;
+use Utopia\Database\Document;
 
 class Provider extends Model
 {
@@ -55,7 +56,7 @@ class Provider extends Model
             ->addRule('credentials', [
                 'type' => self::TYPE_JSON,
                 'description' => 'Provider credentials.',
-                'default' => [],
+                'default' => new \stdClass(),
                 'example' => [
                     'key' => '123456789'
                 ],
@@ -63,12 +64,29 @@ class Provider extends Model
             ->addRule('options', [
                 'type' => self::TYPE_JSON,
                 'description' => 'Provider options.',
-                'default' => [],
+                'default' => new \stdClass(),
                 'required' => false,
                 'example' => [
                     'from' => 'sender-email@mydomain'
                 ],
             ]);
+    }
+
+    /**
+     * Process Document before returning it to the client
+     *
+     * @return Document
+     */
+    public function filter(Document $document): Document
+    {
+        foreach (['credentials', 'options'] as $attribute) {
+            $value = $document->getAttribute($attribute);
+            if (\is_array($value) && empty($value)) {
+                $document->setAttribute($attribute, new \stdClass());
+            }
+        }
+
+        return $document;
     }
 
     /**

--- a/src/Appwrite/Utopia/Response/Model/TemplateFramework.php
+++ b/src/Appwrite/Utopia/Response/Model/TemplateFramework.php
@@ -63,6 +63,7 @@ class TemplateFramework extends Model
                 'description' => 'Fallback file for SPA. Only relevant for static serve runtime.',
                 'default' => null,
                 'example' => 'index.html',
+                'required' => false,
             ])
         ;
     }

--- a/src/Appwrite/Utopia/Response/Model/TemplateSite.php
+++ b/src/Appwrite/Utopia/Response/Model/TemplateSite.php
@@ -33,6 +33,7 @@ class TemplateSite extends Model
                 'description' => 'URL hosting a template demo.',
                 'default' => '',
                 'example' => 'https://nextjs-starter.appwrite.network/',
+                'required' => false,
             ])
             ->addRule('screenshotDark', [
                 'type' => self::TYPE_STRING,

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -23,6 +23,7 @@ use Appwrite\Utopia\Response\Model as ResponseModel;
 use Appwrite\Utopia\Response\Model\AttributeLine;
 use Appwrite\Utopia\Response\Model\Error as ErrorModel;
 use Appwrite\Utopia\Response\Model\ErrorDev;
+use Appwrite\Utopia\Response\Model\FrameworkAdapter;
 use Appwrite\Utopia\Response\Model\HealthStatus;
 use Appwrite\Utopia\Response\Model\Metric;
 use Appwrite\Utopia\Response\Model\Migration;
@@ -36,6 +37,10 @@ use Appwrite\Utopia\Response\Model\PlatformWindows;
 use Appwrite\Utopia\Response\Model\Preferences;
 use Appwrite\Utopia\Response\Model\Provider;
 use Appwrite\Utopia\Response\Model\Team;
+use Appwrite\Utopia\Response\Model\TemplateFramework;
+use Appwrite\Utopia\Response\Model\TemplateSite;
+use Appwrite\Utopia\Response\Model\TemplateVariable;
+use Appwrite\Utopia\Response\Model\UsageDataPoint;
 use Appwrite\Utopia\Response\Model\UsageProject;
 use Appwrite\Utopia\Response\Model\User;
 use Appwrite\Utopia\Response\Model\Webhook;
@@ -1035,7 +1040,7 @@ final class FormatTest extends TestCase
         $this->assertSame('object', $openApiQuery['type']);
     }
 
-    public function testJsonModelRulesKeepAdditionalPropertiesAndSkipNullable(): void
+    public function testJsonAndNullableModelRulesEmitExpectedSchemas(): void
     {
         Method::$processed = [];
         Method::$errors = [];
@@ -1058,15 +1063,56 @@ final class FormatTest extends TestCase
 
         $models = [
             new Provider(),
+            new FrameworkAdapter(),
+            new TemplateFramework(),
+            new TemplateSite(),
+            new TemplateVariable(),
+            new UsageDataPoint(),
             new ErrorModel(),
         ];
+        $routes = [$route];
 
-        $openApi = (new OpenAPI3(new Container(), [], [$route], $models, [], 0, 'console'))->parse();
+        foreach ([
+            Response::MODEL_FRAMEWORK_ADAPTER,
+            Response::MODEL_TEMPLATE_FRAMEWORK,
+            Response::MODEL_TEMPLATE_SITE,
+            Response::MODEL_USAGE_DATA_POINT,
+        ] as $model) {
+            $routes[] = (new Route('GET', '/v1/tests/' . $model))
+                ->desc('Get test response model')
+                ->label('sdk', new Method(
+                    namespace: 'test',
+                    group: null,
+                    name: 'get' . \ucfirst($model),
+                    description: 'Get test response model.',
+                    auth: [],
+                    responses: [
+                        new SDKResponse(
+                            code: 200,
+                            model: $model,
+                        ),
+                    ],
+                ));
+        }
+
+        $openApi = (new OpenAPI3(new Container(), [], $routes, $models, [], 0, 'console'))->parse();
 
         $openApiOptions = $openApi['components']['schemas']['provider']['properties']['options'];
 
         $this->assertTrue($openApiOptions['additionalProperties']);
         $this->assertArrayNotHasKey('nullable', $openApiOptions);
+
+        foreach ([
+            Response::MODEL_FRAMEWORK_ADAPTER => 'fallbackFile',
+            Response::MODEL_TEMPLATE_FRAMEWORK => 'fallbackFile',
+            Response::MODEL_TEMPLATE_SITE => 'demoUrl',
+            Response::MODEL_USAGE_DATA_POINT => 'time',
+        ] as $model => $property) {
+            $schema = $openApi['components']['schemas'][$model];
+
+            $this->assertTrue($schema['properties'][$property]['nullable']);
+            $this->assertNotContains($property, $schema['required']);
+        }
     }
 
     public function testQueriesSubclassesEmitArrayOfStrings(): void

--- a/tests/unit/Utopia/ResponseTest.php
+++ b/tests/unit/Utopia/ResponseTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Utopia;
 use Appwrite\Models\Project as GeneratedProject;
 use Appwrite\Utopia\Response;
 use Appwrite\Utopia\Response\Model\Project as ProjectModel;
+use Appwrite\Utopia\Response\Model\Provider as ProviderModel;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
@@ -115,6 +116,7 @@ final class ResponseTest extends TestCase
     public function testProjectResponseCanHydrateGeneratedSdkProjectWithoutOAuth2Fields(): void
     {
         $this->response->setModel(new ProjectModel());
+        $this->response->setModel(new ProviderModel());
 
         $project = $this->response->output(new Document([
             '$id' => 'project',
@@ -127,7 +129,28 @@ final class ResponseTest extends TestCase
 
         $project['wafEnabled'] = false;
 
-        $generated = GeneratedProject::from($project);
+        $provider = $this->response->output(new Document([
+            'credentials' => [],
+            'options' => [],
+        ]), Response::MODEL_PROVIDER);
+        $populatedProvider = $this->response->output(new Document([
+            'credentials' => ['key' => 'secret'],
+            'options' => ['from' => 'sender@example.com'],
+        ]), Response::MODEL_PROVIDER);
+
+        $this->assertInstanceOf(\stdClass::class, $project['onboarding']);
+        $this->assertInstanceOf(\stdClass::class, $provider['credentials']);
+        $this->assertInstanceOf(\stdClass::class, $provider['options']);
+        $this->assertSame('{}', \json_encode($project['onboarding']));
+        $this->assertSame('{}', \json_encode($provider['credentials']));
+        $this->assertSame('{}', \json_encode($provider['options']));
+        $this->assertSame(['key' => 'secret'], $populatedProvider['credentials']);
+        $this->assertSame(['from' => 'sender@example.com'], $populatedProvider['options']);
+
+        // Match the JSON round trip performed by SDK clients. Empty objects on
+        // the wire decode to associative arrays in the generated PHP SDK.
+        $decoded = \json_decode(\json_encode($project, JSON_THROW_ON_ERROR), true, flags: JSON_THROW_ON_ERROR);
+        $generated = GeneratedProject::from($decoded);
 
         foreach ([
             'oAuth2ServerEnabled',


### PR DESCRIPTION
## What does this PR do?

Aligns response payloads and generated OpenAPI schemas for object-like and nullable fields.

- serializes empty `Project.onboarding` values as `{}` instead of `[]`
- serializes empty messaging provider `credentials` and `options` as `{}` instead of `[]`
- preserves populated map values unchanged
- marks framework/template fields optional where production responses can return `null` or omit them:
  - `FrameworkAdapter.fallbackFile`
  - `TemplateFramework.fallbackFile`
  - `TemplateSite.demoUrl`
- adds an OpenAPI regression assertion for the existing optional `UsageDataPoint.time` contract

These mismatches caused generated SDK response hydration failures because object schemas received arrays and nullable/omitted values were generated as required strings.

## How was this tested?

Existing unit coverage was extended with assertions; no new test files or standalone test cases were added.

- `composer lint` on all changed files
- `php vendor/bin/phpunit tests/unit/Utopia/ResponseTest.php`
- `php vendor/bin/phpunit tests/unit/SDK/Specification/FormatTest.php`
- targeted PHPStan analysis of all changed files with a 1 GB memory limit

The existing response test now verifies empty maps encode as `{}`, populated maps are preserved, and generated SDK hydration still works. The existing specification test now verifies optional response fields are nullable and excluded from each schema's required list.
