### PR TITLE
Normalize execution header response values

### DIFF
--- a/src/Appwrite/Utopia/Response/Model/Execution.php
+++ b/src/Appwrite/Utopia/Response/Model/Execution.php
@@ -5,6 +5,7 @@ namespace Appwrite\Utopia\Response\Model;
 use Appwrite\Utopia\Response;
 use Appwrite\Utopia\Response\Model;
 use Utopia\Database\DateTime;
+use Utopia\Database\Document;
 use Utopia\Database\Helpers\Role;
 
 class Execution extends Model
@@ -135,6 +136,38 @@ class Execution extends Model
                 'example' => self::TYPE_DATETIME_EXAMPLE,
             ])
         ;
+    }
+
+    /**
+     * Normalize HTTP header values to the public string contract.
+     */
+    public function filter(Document $document): Document
+    {
+        foreach (['requestHeaders', 'responseHeaders'] as $attribute) {
+            $headers = $document->getAttribute($attribute, []);
+            if (!\is_array($headers)) {
+                continue;
+            }
+
+            foreach ($headers as $index => $header) {
+                if ($header instanceof Document) {
+                    $value = $header->getAttribute('value');
+                    if (\is_array($value)) {
+                        $header->setAttribute('value', \implode(', ', $value));
+                    }
+                    continue;
+                }
+
+                if (\is_array($header) && \is_array($header['value'] ?? null)) {
+                    $header['value'] = \implode(', ', $header['value']);
+                    $headers[$index] = $header;
+                }
+            }
+
+            $document->setAttribute($attribute, $headers);
+        }
+
+        return $document;
     }
 
     /**

--- a/tests/unit/Utopia/Response/Model/ExecutionTest.php
+++ b/tests/unit/Utopia/Response/Model/ExecutionTest.php
@@ -15,10 +15,24 @@ final class ExecutionTest extends TestCase
         $execution = (new Execution())->filter(new Document([
             'resourceType' => 'sites',
             'resourceId' => 'site-id',
+            'requestHeaders' => [
+                ['name' => 'host', 'value' => ['example.com']],
+                ['name' => 'user-agent', 'value' => ['Agent/1.0', 'Agent/2.0']],
+                ['name' => 'content-type', 'value' => 'application/json'],
+            ],
+            'responseHeaders' => [
+                new Document(['name' => 'content-length', 'value' => ['42']]),
+            ],
         ]));
 
         $this->assertSame('site-id', $execution->getAttribute('resourceId'));
         $this->assertSame('sites', $execution->getAttribute('resourceType'));
+        $this->assertSame([
+            ['name' => 'host', 'value' => 'example.com'],
+            ['name' => 'user-agent', 'value' => 'Agent/1.0, Agent/2.0'],
+            ['name' => 'content-type', 'value' => 'application/json'],
+        ], $execution->getAttribute('requestHeaders'));
+        $this->assertSame('42', $execution->getAttribute('responseHeaders')[0]->getAttribute('value'));
     }
 
     public function testResourceIdentityIsRequired(): void


### PR DESCRIPTION
## What does this PR do?

Normalizes execution request and response header values to the public response model's string contract.

HTTP and runtime clients can represent header values as arrays, including one-element arrays. Those values were passed through unchanged, producing payloads such as:

```json
{"name":"host","value":["example.com"]}
```

The generated SDK model declares `Headers.value` as a string, so strict SDKs failed to deserialize execution responses. The execution response filter now joins array values with `, ` while preserving values that are already strings. Handling this at the response-model boundary covers functions, sites, synchronous/asynchronous executions, and Cloud regional records that use the inherited model.

Existing `ExecutionTest` coverage was extended with assertions for array and string request headers plus `Document` response headers. The regression assertion was observed failing with the production change reverted.

## How was this tested?

- `composer lint src/Appwrite/Utopia/Response/Model/Execution.php tests/unit/Utopia/Response/Model/ExecutionTest.php`
- `php vendor/bin/phpunit tests/unit/Utopia/Response/Model/ExecutionTest.php`
- targeted PHPStan analysis with a 1 GB memory limit
