### PR TITLE
fix(installer): keep the topology the operator picked

### DIFF
--- a/app/views/install/installer/js/modules/state.js
+++ b/app/views/install/installer/js/modules/state.js
@@ -19,7 +19,7 @@
         forceHttps: null,
         opensslKey: null,
         assistantOpenAIKey: null,
-        topology: 'combined',
+        topology: null,
         accountEmail: null,
         accountPassword: null
     };
@@ -53,7 +53,7 @@
             formState.database = data.lockedDatabase;
         }
         if (data.topology === 'combined' || data.topology === 'separate') {
-            formState.topology = data.topology;
+            setStateIfEmpty('topology', data.topology);
         }
         if (!isUpgradeMode?.()) {
             setStateIfEmpty('database', data.defaultDatabase);


### PR DESCRIPTION
Choosing **Separate** in the web installer silently installed **Combined**.

## What happens

Step 1 → Advanced settings → Workers and schedulers offers Combined and Separate. The radio, the card highlight and `formState.topology` all update correctly on click:

![topology choice](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/03-topology-separate-selected-0a1d9af0.png)

But the install request sends `combined` anyway:

```json
{"topology":"combined","database":"postgresql", ...}
```

and the generated `docker-compose.yml` has one worker and one scheduler rather than a container per queue:

```
appwrite-worker:            appwrite-task-scheduler:
appwrite-task-maintenance:  appwrite-task-interval:
```

15 containers start instead of 32. Nothing reports that the choice was dropped, and the review step does not list the topology, so there is nowhere to catch it before installing.

## Cause

`applyBodyDefaults()` runs on every step render — five call sites in `steps.js`, one in `progress.js` — and assigned the topology unconditionally:

```js
if (data.topology === 'combined' || data.topology === 'separate') {
    formState.topology = data.topology;   // clobbers the choice
}
```

`data.topology` is `<body data-topology>`, which the server renders once with the starting value. So moving from step 1 to step 2 put it straight back to `combined`. Every neighbouring field uses `setStateIfEmpty` and is unaffected; `database` looks similar but is guarded by `data.lockedDatabase`, which is only set on upgrade, where locking is the intent.

## Fix

Seed it like every other field:

```js
setStateIfEmpty('topology', data.topology);
```

`formState.topology` starts as `null` rather than `'combined'` so that seed can land — `setStateIfEmpty` only fills what is empty, and `'combined'` never was. The payload already falls back to `'combined'`, and `applyStep1State` guards on truthiness, so an unseeded value keeps the server-rendered radio.

## Verification

Same flow, before and after, driven with Playwright against `appwrite/appwrite:2.0.0`:

| | Before | After |
|---|---|---|
| `formState.topology` after clicking Separate | `separate` | `separate` |
| …after moving to step 2 | **`combined`** | `separate` |
| `topology` in the `/install` body | **`combined`** | `separate` |
| worker/scheduler services generated | 4 | 23 |
| containers running | 15 | 32 |

After the fix every per-queue worker runs, including the three stats services:

```
appwrite-worker-builds        appwrite-worker-databases    appwrite-worker-deletes
appwrite-worker-executions    appwrite-worker-functions    appwrite-worker-jobs
appwrite-worker-mails         appwrite-worker-messaging    appwrite-worker-migrations
appwrite-worker-notifications appwrite-worker-screenshots  appwrite-worker-webhooks
appwrite-worker-certificates  appwrite-worker-stats-usage  appwrite-worker-stats-resources
appwrite-task-scheduler-functions  appwrite-task-scheduler-executions
appwrite-task-scheduler-messages   appwrite-task-stats-resources
```

and the install completes to a working console:

![console after separate install](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/06-separate-install-console-1117d40d.png)

Reproduced three times before the fix — via a label click, a scripted `.click()`, and a label click after a settle delay — so it was not a race.

## Test plan

- [x] Choice survives step navigation
- [x] `separate` reaches the server in the install payload
- [x] Generated compose contains the per-queue services
- [x] All 32 containers start and the console is reachable
- [x] Combined (the default) still installs 15 containers as before

## Note

Separate topology is offered in the web installer and via the CLI `--topology` flag; only the web path was affected. This is present in the released `2.0.0` image, which is what the testing above ran against.

Worth a follow-up: the review step lists hostname, database, ports, SSL email, Assistant and secret key but not the topology, which is why this was invisible right up to the finished install.

![review step omits topology](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/04-review-omits-topology-a4393e9c.png)
