### PR TITLE
chore(deps): bump utopia-php/cdn to 0.0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "utopia-php/auth": "^0.10",
         "utopia-php/balancer": "0.4.*",
         "utopia-php/cache": "^5.0.0",
-        "utopia-php/cdn": "^0.0.7",
+        "utopia-php/cdn": "^0.0.8",
         "utopia-php/cli": "^0.24",
         "utopia-php/compression": "0.1.*",
         "utopia-php/config": "1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ccc304661866171cf625e0df17950e5f",
+    "content-hash": "8421ff4db771a69dea3af12a11983553",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3253,16 +3253,16 @@
         },
         {
             "name": "utopia-php/cdn",
-            "version": "0.0.7",
+            "version": "0.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/cdn.git",
-                "reference": "e7fb311371462a6e67380cb03d1bdcc1698ba670"
+                "reference": "320ef34c4b16b321345cc5d96e51b528c6254a41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/cdn/zipball/e7fb311371462a6e67380cb03d1bdcc1698ba670",
-                "reference": "e7fb311371462a6e67380cb03d1bdcc1698ba670",
+                "url": "https://api.github.com/repos/utopia-php/cdn/zipball/320ef34c4b16b321345cc5d96e51b528c6254a41",
+                "reference": "320ef34c4b16b321345cc5d96e51b528c6254a41",
                 "shasum": ""
             },
             "require": {
@@ -3322,10 +3322,10 @@
                 "utopia-php"
             ],
             "support": {
-                "source": "https://github.com/utopia-php/cdn/tree/0.0.7",
+                "source": "https://github.com/utopia-php/cdn/tree/0.0.8",
                 "issues": "https://github.com/utopia-php/cdn/issues"
             },
-            "time": "2026-08-28T13:19:44+00:00"
+            "time": "2026-08-29T11:50:39+00:00"
         },
         {
             "name": "utopia-php/circuit-breaker",


### PR DESCRIPTION
## Summary

Bumps `utopia-php/cdn` from 0.0.7 to 0.0.8, picking up utopia-php/cdn#11 — `Domain::validate()` now folds domain case instead of rejecting non-lowercase input, and `Proxy` normalizes once at each entry point so the canonical domain reaches both the `appDomain` routing check and the providers.

## Why this repo first

Composer treats `^0.0.7` on a `0.0.x` version as `>=0.0.7 <0.0.8`, so this constraint pins downstream consumers too. Appwrite Cloud cannot move to 0.0.8 while `server-ce` holds `^0.0.7`:

```
Problem 2
  - appwrite/server-ce dev-main requires utopia-php/cdn ^0.0.7 -> found
    utopia-php/cdn[0.0.7] but it conflicts with your root composer.json require (^0.0.8).
```

## Context

Appwrite Cloud 1.45.22 hit `InvalidArgumentException: Domain must be a lowercase hostname...` deleting proxy rules whose stored domain was not canonical, which aborted the job before the certificate row was removed. Fixed at the root in utopia-php/cdn#11, on the write side in #13417.

Lock diff is limited to `utopia-php/cdn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)