### PR TITLE
fix(e2e): stop testProjectVariableInFunction failing on a node-22 cold start

### DIFF
--- a/tests/e2e/Services/Project/VariablesCustomServerTest.php
+++ b/tests/e2e/Services/Project/VariablesCustomServerTest.php
@@ -49,7 +49,10 @@ final class VariablesCustomServerTest extends Scope
             'runtime' => 'node-22',
             'entrypoint' => 'index.js',
             'execute' => ['any'],
-            'timeout' => 15,
+            // Timeout is a single budget covering container prepare, launch,
+            // cold start and the handler, so a loaded runner can spend it all
+            // before the function runs.
+            'timeout' => 60,
             'commands' => 'echo $GLOBAL_VARIABLE',
         ]);
 


### PR DESCRIPTION
## What

Raises the function `timeout` in `VariablesCustomServerTest::testProjectVariableInFunction` from 15s to 60s. Nothing else changes; all four assertions are untouched.

## Why

`testProjectVariableInFunction` fails roughly 20% of the time in `appwrite-labs/cloud` CI, in the `Tests / CE / E2E / Project (dedicated)` job. It fails on `main` and on unrelated branches, so it is not caused by any one change.

The failure is always the same assertion, at `VariablesCustomServerTest.php:119`:

```
1) Tests\E2E\Services\Project\VariablesCustomServerTest::testProjectVariableInFunction
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'completed'
+'failed'
```

### The mechanism

The test creates its function with `'timeout' => 15` and then executes it synchronously. That timeout is not a budget for the handler alone. It is a single end-to-end budget that the executor spends before the function ever runs.

In `open-runtimes/executor`, `src/Executor/Runner/Docker.php` charges three separate waits against it and decrements the remainder after each one:

```php
// prepare the container
if (\microtime(true) - $prepareStart >= $timeout) {
    throw new ExecutorException(ExecutorException::RUNTIME_TIMEOUT);
}
...
$timeout -= (\microtime(true) - $prepareStart);   // launch is charged next
...
$timeout -= (\microtime(true) - $launchStart);    // cold start is charged next
...
// Wait for cold-start to finish (app listening on port)
if (\microtime(true) - $pingStart >= $timeout) {
    throw new ExecutorException(ExecutorException::RUNTIME_TIMEOUT);
}
...
$timeout -= (\microtime(true) - $pingStart);      // only this is left for the handler
```

That `$timeout` is the function's own value, passed from `Executions/Create.php` as `timeout: $function->getAttribute('timeout', 0)` and bound by the executor route at `app/controllers.php:159`.

When a node-22 container cold start on a contended runner outlasts the budget, the executor raises `RUNTIME_TIMEOUT` and returns a 500. Appwrite then classifies the execution with `$status = $executionResponse['statusCode'] >= 500 ? 'failed' : 'completed';`, so the assertion sees `failed`.

The executor log from a failing run, at the exact moment the test ends:

```
2026-08-29T18:26:31.353667633Z Timed out waiting for runtime.
2026-08-29T18:26:31.367447595Z http.request · 15.67s
  execution.status   failed
```

### Why 15s was never enough headroom

The budget was already nearly exhausted on the happy path. Comparing two runs of the same job:

| Run | Execution request | Budget used | Outcome |
|---|---|---|---|
| Passing | 13.76s | 92% of 15s | `completed` |
| Failing | 15.67s | over | `failed`, `RUNTIME_TIMEOUT` |

A passing run left 1.24s of margin. The test was sitting on a cliff edge, which is what produces an intermittent failure rate rather than a consistent one.

## What this change actually buys, and the real ceiling

Worth being precise, because the function `timeout` is not the only bound in play.

`Executions/Create.php` also passes `requestTimeout: 30` to the executor client, and that becomes `CURLOPT_TIMEOUT` on the caller's side:

```php
$executionResponse = $executor->createExecution(
    timeout: $function->getAttribute('timeout', 0),
    ...
    requestTimeout: 30
);
```

So raising the function timeout to 60 does **not** give the execution 60 seconds. It removes the function timeout as the binding constraint and leaves the caller's 30s request timeout as the real ceiling. In effect the budget moves from 15s to 30s, and the measured 13.76s happy path goes from consuming 92% of its budget to about 46%.

That is the intended and sufficient outcome here, given the cold starts actually observed sit in the 13 to 16 second range. It is a doubling of headroom, not a quadrupling.

If this test ever flakes again past 30s, the knob to look at is `requestTimeout` in `Executions/Create.php`, not this line. Past that bound the failure mode changes: the client raises `ExecutorTimeout`, `Create.php` converts it to `AppwriteException::FUNCTION_SYNCHRONOUS_TIMEOUT`, and the test would fail on the `assertSame(201, ...)` status-code assertion rather than on `'completed'`.

## Why 60 rather than 30

Any value at or above 30 makes the client request timeout the binding constraint, so 30 and 60 behave identically at the outer bound. 60 is preferred because the executor decrements the budget stage by stage: with `timeout => 30` and a 25s cold start, the handler inherits only the 5s remainder, whereas 60 leaves the handler a comfortable share of whatever the 30s ceiling permits.

It also matches existing precedent rather than introducing a new number. `setupDeployedFunction` in `tests/e2e/Services/Functions/FunctionsCustomServerTest.php` uses `'timeout' => 60` for the same cold-start reason. 60 is well inside the permitted range: the parameter validates against `Range(1, _APP_FUNCTIONS_TIMEOUT)`, and `_APP_FUNCTIONS_TIMEOUT` is 900 in `.env`.

Note that `15` was never a deliberate choice for this test. It is the API's own default for the parameter, so the line was restating the default rather than requesting a tight budget.

## Scope

`VariablesCustomServerTest.php` is the only file in the whole `Project` E2E directory that creates a function, sets a `timeout`, or runs a synchronous execution, so this one line covers the affected job. Verified with:

```
git grep -n "'timeout' =>"        tests/e2e/Services/Project   # 1 hit, this line
git grep -n "METHOD_POST, '/functions'" tests/e2e/Services/Project   # 1 hit, this test
git grep -n "'async' => false"    tests/e2e/Services/Project   # 1 hit, this test
```

The sibling `testProjectVariableInSite` in the same file is unaffected: it deploys a site, which takes no `timeout` parameter.

The tight timeouts elsewhere in `tests/e2e/Services/Functions/` are deliberately left alone. Some are load-bearing for what they assert, such as `'timeout' => 5, // Should timeout after 5 seconds`, and there is no observed failure evidence for that job.

## Assertions

Unchanged. The test still proves the execution completed and that the project variable reached the runtime with the right value:

```php
$this->assertSame(201, $execution['headers']['status-code']);
$this->assertSame('completed', $execution['body']['status']);
$this->assertSame(200, $execution['body']['responseStatusCode']);
$output = json_decode($execution['body']['responseBody'], true);
$this->assertSame('Project Variable Value', $output['GLOBAL_VARIABLE']);
```

Only the budget the function is given to reach that point changes.

## Verification

The red is observed rather than inferred: the assertion diff and the corresponding `Timed out waiting for runtime.` executor line above are both taken from real failing cloud CI jobs, on two different branches.

Because the trigger is runner contention, a local green run would not prove much on its own; the test already passes about 80% of the time. The argument for the fix is the mechanism plus the 1.24s margin measured on a passing run, both shown above. `pint` passes on the changed file.

CI on this PR is green across all 44 checks. One unrelated Realtime flake (`RealtimeConsoleClientTest::testDeleteIndexCollectionsAPI`) failed on the first attempt and passed on re-run; it is in a different job that runs only `tests/e2e/Services/Realtime`, which cannot load the file changed here.

## Downstream

`appwrite-labs/cloud` vendors this suite and pins `appwrite/server-ce` at `main-dev`, currently locked to `9d34ee5`. It will need a `composer update appwrite/server-ce` lock refresh to pick this up. No version bump is required. That is not included here.

Separately, the same cloud `Project (dedicated)` job also fails intermittently on `Health\StorageTest::testStorage` ("140 is less than 100", a 100ms latency budget) under the same runner contention. That is a distinct defect, untouched here, and it will need its own fix before that job is reliably green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
