### PR TITLE
feat(stats-resources): span each scheduler cycle with its enqueue count

### DIFF
--- a/src/Appwrite/Platform/Tasks/StatsResources.php
+++ b/src/Appwrite/Platform/Tasks/StatsResources.php
@@ -48,10 +48,6 @@ class StatsResources extends Action
         $interval = max(1, (int) System::getEnv('_APP_STATS_RESOURCES_INTERVAL', 3600));
 
         Console::loop(function () use ($dbForPlatform, $publisherForStatsResources, $usageConnection): void {
-            // A healthy cycle used to print nothing at all, so "is the scheduler
-            // still seeing this region's projects?" had no answer -- the only way
-            // to tell a stalled scheduler from a stalled worker was to guess. One
-            // span per cycle carrying the enqueue count makes that queryable.
             Span::init('stats_resources_task');
             $projectsQueued = 0;
             $projectsFailed = 0;
@@ -86,12 +82,8 @@ class StatsResources extends Action
                     Query::equal('region', [System::getEnv('_APP_REGION', 'default')]),
                     Query::orderAsc('$sequence'), // accessedAt Can be updated during iteration
                 ], function ($project) use ($publisherForStatsResources, &$projectsQueued, &$projectsFailed): void {
-                    // enqueue() returns false when usage stats are disabled and
-                    // when publishing threw -- it swallows that to keep the loop
-                    // alive, reporting it only to Console. Counting those as
-                    // queued would be worse than not counting at all: this number
-                    // is meant to be a trustworthy denominator for the worker's
-                    // completion count.
+                    // enqueue() swallows a publish failure, reporting it only to
+                    // Console and returning false — as it does when stats are off.
                     if ($publisherForStatsResources->enqueue(new StatsResourcesMessage(project: $project)) === false) {
                         $projectsFailed++;
                         return;
@@ -104,9 +96,7 @@ class StatsResources extends Action
                 Span::add('stats_resources_task.error', $th->getMessage());
                 Console::error('stats resources: cycle failed, retrying next interval: ' . $th->getMessage());
             } finally {
-                // Every exit path finishes the span, the early return above
-                // included: an unfinished span exports nothing, and a cycle that
-                // reports nothing is exactly the blind spot this closes.
+                // An unfinished span exports nothing, including the early return.
                 Span::add('stats_resources_task.projects_queued', $projectsQueued);
                 Span::add('stats_resources_task.projects_failed', $projectsFailed);
                 Span::current()?->finish();

--- a/src/Appwrite/Platform/Tasks/StatsResources.php
+++ b/src/Appwrite/Platform/Tasks/StatsResources.php
@@ -11,6 +11,7 @@ use Utopia\Console;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Query;
+use Utopia\Span\Span;
 use Utopia\System\System;
 
 class StatsResources extends Action
@@ -47,6 +48,13 @@ class StatsResources extends Action
         $interval = max(1, (int) System::getEnv('_APP_STATS_RESOURCES_INTERVAL', 3600));
 
         Console::loop(function () use ($dbForPlatform, $publisherForStatsResources, $usageConnection): void {
+            // A healthy cycle used to print nothing at all, so "is the scheduler
+            // still seeing this region's projects?" had no answer -- the only way
+            // to tell a stalled scheduler from a stalled worker was to guess. One
+            // span per cycle carrying the enqueue count makes that queryable.
+            Span::init('stats_resources_task');
+            $projectsQueued = 0;
+
             // Nothing here may end the loop. An exception escaping this closure
             // ends Console::loop, and the process then stays alive and idle: it
             // never exits, so restartPolicy never fires, and with no liveness
@@ -56,6 +64,7 @@ class StatsResources extends Action
             // Ready for weeks while queueing nothing.
             try {
                 if (!$usageConnection->isReady()) {
+                    Span::add('stats_resources_task.skipped', 'usage_schema_not_ready');
                     Console::error('stats resources: usage schema is not ready, skipping cycle');
                     return;
                 }
@@ -75,13 +84,23 @@ class StatsResources extends Action
                     Query::greaterThanEqual('accessedAt', DateTime::format($last24Hours)),
                     Query::equal('region', [System::getEnv('_APP_REGION', 'default')]),
                     Query::orderAsc('$sequence'), // accessedAt Can be updated during iteration
-                ], function ($project) use ($publisherForStatsResources): void {
+                ], function ($project) use ($publisherForStatsResources, &$projectsQueued): void {
                     $publisherForStatsResources->enqueue(new StatsResourcesMessage(project: $project));
+                    $projectsQueued++;
                 });
             } catch (\Throwable $th) {
                 // Cost a cycle, not the process: the next tick retries in full.
+                Span::add('stats_resources_task.error', $th->getMessage());
                 Console::error('stats resources: cycle failed, retrying next interval: ' . $th->getMessage());
+            } finally {
+                // Every exit path finishes the span, the early return above
+                // included: an unfinished span exports nothing, and a cycle that
+                // reports nothing is exactly the blind spot this closes.
+                Span::add('stats_resources_task.projects_queued', $projectsQueued);
+                Span::current()?->finish();
             }
-        }, $interval);
+        }, $interval, 0, function (\Throwable $th) {
+            Span::current()?->finish(error: $th);
+        });
     }
 }

--- a/src/Appwrite/Platform/Tasks/StatsResources.php
+++ b/src/Appwrite/Platform/Tasks/StatsResources.php
@@ -54,6 +54,7 @@ class StatsResources extends Action
             // span per cycle carrying the enqueue count makes that queryable.
             Span::init('stats_resources_task');
             $projectsQueued = 0;
+            $projectsFailed = 0;
 
             // Nothing here may end the loop. An exception escaping this closure
             // ends Console::loop, and the process then stays alive and idle: it
@@ -84,8 +85,18 @@ class StatsResources extends Action
                     Query::greaterThanEqual('accessedAt', DateTime::format($last24Hours)),
                     Query::equal('region', [System::getEnv('_APP_REGION', 'default')]),
                     Query::orderAsc('$sequence'), // accessedAt Can be updated during iteration
-                ], function ($project) use ($publisherForStatsResources, &$projectsQueued): void {
-                    $publisherForStatsResources->enqueue(new StatsResourcesMessage(project: $project));
+                ], function ($project) use ($publisherForStatsResources, &$projectsQueued, &$projectsFailed): void {
+                    // enqueue() returns false when usage stats are disabled and
+                    // when publishing threw -- it swallows that to keep the loop
+                    // alive, reporting it only to Console. Counting those as
+                    // queued would be worse than not counting at all: this number
+                    // is meant to be a trustworthy denominator for the worker's
+                    // completion count.
+                    if ($publisherForStatsResources->enqueue(new StatsResourcesMessage(project: $project)) === false) {
+                        $projectsFailed++;
+                        return;
+                    }
+
                     $projectsQueued++;
                 });
             } catch (\Throwable $th) {
@@ -97,6 +108,7 @@ class StatsResources extends Action
                 // included: an unfinished span exports nothing, and a cycle that
                 // reports nothing is exactly the blind spot this closes.
                 Span::add('stats_resources_task.projects_queued', $projectsQueued);
+                Span::add('stats_resources_task.projects_failed', $projectsFailed);
                 Span::current()?->finish();
             }
         }, $interval, 0, function (\Throwable $th) {


### PR DESCRIPTION
## What does this PR do?

The `stats-resources` scheduler logs nothing on its success path — no
per-project enqueue line, no cycle summary. A healthy pod produces no output at
all, so "is the task still seeing this region's projects?" has no answer. Across
production regions this task emits between 13 and 27 lines per 24 hours, and the
ones I sampled are pod churn and database reconnect notices; not one says
anything about scheduling. For comparison, `task-stats-edge` — the same
`Console::loop` shape, already spanned — emits around 1,400 per region over the
same window, one per cycle.

That was the expensive half of a recent incident (Linear DAT-1898): resource
gauges stopped arriving for one project, and there was no way to tell a
scheduler that had stopped enumerating from a worker that was dying on the job.
The worker only names a project once it *finishes*, so a job that keeps dying
leaves no trace either — both failures present as the same silence. The comment
already at the top of this loop records the previous time that silence cost
weeks: a single transient timeout ended scheduling for a whole region while the
pod kept reporting Ready.

`projects_queued` is also the denominator the worker side cannot produce for
itself. A container OOM kill is SIGKILL, so nothing exports from the worker at
all; the only way to notice a project the worker keeps dying on is to compare
what the scheduler queued against what the workers reported finishing.

This wraps the loop body in one span per cycle, following the same shape as the
stats-edge task:

- `stats_resources_task.projects_queued` — incremented in the `foreachDocument`
  enqueue callback, so every cycle states how many projects it handed to the
  worker. Only successful publishes count: the publisher returns `false` when
  `_APP_USAGE_STATS` is disabled and when publishing threw (it swallows the
  exception to keep the loop alive and reports it only to `Console`), and an
  inflated count would be worse than no count at all for a number meant to be a
  denominator.
- `stats_resources_task.projects_failed` — those `false` returns, so the publish
  failures that currently only reach `Console` become queryable alongside the
  successes.
- `stats_resources_task.skipped = usage_schema_not_ready` on the early return,
  so a skipped cycle is not mistaken for a cycle that legitimately queued zero
  projects.
- `stats_resources_task.error` on the caught cycle failure, which previously
  only reached `Console::error` — ingested, but as unstructured ANSI text that
  `| json` cannot parse into fields, so it cannot be filtered or aggregated on.

The span is finished in a `finally` rather than at the end of the closure: the
usage-schema early `return` would otherwise leave the span unfinished, and an
unfinished span exports nothing — the same blind spot again. `Console::loop`'s
fourth-argument error handler finishes the span for anything that escapes the
closure entirely.

Deliberately **not** included: `first_sequence` / `last_sequence` fields. They
only catch a cycle truncated at one end and would give false comfort about gaps
in the middle of the range.

Note this task is vendored into Appwrite Cloud, whose subclass only overrides
`disableSubqueries()` and adds no behaviour, so the change belongs here rather
than in a downstream `action()` override.

### What a person runs now

Per-cycle enqueue counts, per region:

```logql
{service_name="task-stats-resources"} | json
  | line_format "{{.cluster}} queued={{.stats_resources_task_projects_queued}}"
```

A scheduler that has stopped enumerating (queues nothing, repeatedly):

```logql
sum by (cluster) (
  sum_over_time(
    {service_name="task-stats-resources"} | json
      | unwrap stats_resources_task_projects_queued [1h]
  )
)
```

Cycles that skipped or failed rather than ran, or that could not publish:

```logql
{service_name="task-stats-resources"} | json
  | stats_resources_task_skipped != ""
    or stats_resources_task_error != ""
    or stats_resources_task_projects_failed != "0"
```

## Test Plan

Observability fields only; no behaviour change to scheduling. No unit test
covers this task, so the suite is run to show it is unaffected — the errors and
failures below are pre-existing on `main` in this environment (missing swoole /
redis / imagick / yaml / sockets / maxminddb extensions), and the counts are
**identical** with and without this change:

```
# this branch
$ php vendor/bin/phpunit --testsuite unit
Tests: 1088, Assertions: 5148, Errors: 67, Failures: 6, PHPUnit Warnings: 1, Deprecations: 1, PHPUnit Notices: 1, Skipped: 9.

# same run with src/Appwrite/Platform/Tasks/StatsResources.php reverted to origin/main
$ php vendor/bin/phpunit --testsuite unit
Tests: 1088, Assertions: 5148, Errors: 67, Failures: 6, PHPUnit Warnings: 1, Deprecations: 1, PHPUnit Notices: 1, Skipped: 9.

$ php vendor/bin/pint --test --config pint.json src/Appwrite/Platform/Tasks/StatsResources.php
{"tool":"pint","result":"passed"}

$ php vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=1G
 [OK] No errors
```

Manual verification after deploy: `{service_name="task-stats-resources"} | json`
should produce one line per interval per region carrying a non-zero
`stats_resources_task_projects_queued`, where it previously produced nothing.

Review follow-up: the enqueue counter originally incremented unconditionally.
`vendor/bin/phpstan` and `vendor/bin/pint` were re-run clean after that fix.

## Related PRs and Issues

- Linear DAT-1898 — the incident that exposed the blind spot.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
