### PR TITLE
feat(locale): add Sign Language (sgn) to languages list

### DIFF
--- a/app/config/locale/languages.php
+++ b/app/config/locale/languages.php
@@ -719,6 +719,11 @@ return [
         "nativeName" => "Sängö"
     ],
     [
+        "code" => "sgn",
+        "name" => "Sign Language",
+        "nativeName" => "Sign Language"
+    ],
+    [
         "code" => "sh",
         "name" => "Serbo-Croatian",
         "nativeName" => "Srpskohrvatski / Српскохрватски"

--- a/tests/e2e/Services/Locale/LocaleBase.php
+++ b/tests/e2e/Services/Locale/LocaleBase.php
@@ -205,15 +205,15 @@ trait LocaleBase
 
         $this->assertEquals($response['headers']['status-code'], 200);
         $this->assertIsArray($response['body']);
-        $this->assertEquals(186, $response['body']['total']);
+        $this->assertEquals(187, $response['body']['total']);
 
         $this->assertEquals($response['body']['languages'][0]['code'], 'aa');
         $this->assertEquals($response['body']['languages'][0]['name'], 'Afar');
         $this->assertEquals($response['body']['languages'][0]['nativeName'], 'Afar');
 
-        $this->assertEquals($response['body']['languages'][185]['code'], 'zu');
-        $this->assertEquals($response['body']['languages'][185]['name'], 'Zulu');
-        $this->assertEquals($response['body']['languages'][185]['nativeName'], 'isiZulu');
+        $this->assertEquals($response['body']['languages'][186]['code'], 'zu');
+        $this->assertEquals($response['body']['languages'][186]['name'], 'Zulu');
+        $this->assertEquals($response['body']['languages'][186]['nativeName'], 'isiZulu');
 
         /**
          * Test for FAILURE


### PR DESCRIPTION
## Summary
- Adds ISO 639-2 code `sgn` (Sign Language) to `app/config/locale/languages.php`
- Updates Locale e2e language total/index assertions

Fixes #8201

## Test plan
- [ ] `GET /locale/languages` includes `{ code: "sgn", name: "Sign Language" }`
- [ ] Locale language count assertions pass