### PR TITLE
fix(spec): emit object-typed validators as objects, not strings

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -731,9 +731,9 @@ class OpenAPI3 extends Format
                         $node['schema']['format'] = 'url';
                         $node['schema']['example'] = ($param['example'] ?? '') !== '' ? $param['example'] : 'https://example.com';
                         break;
-                    case \Utopia\Validator\JSON::class:
-                    case \Utopia\Validator\JSON\ObjectValidator::class:
                     case \Utopia\Validator\Assoc::class:
+                        // Assoc reports TYPE_ARRAY, so only an explicit case publishes
+                        // it as an object. TYPE_OBJECT is handled by the default.
                         $node['schema']['type'] = 'object';
                         $node['schema']['default'] = (empty($param['default'])) ? new \stdClass() : $param['default'];
                         $node['schema']['example'] = ($param['example'] ?? '') !== '' ? $param['example'] : '{}';
@@ -943,10 +943,6 @@ class OpenAPI3 extends Format
                         }
                         break;
                     default:
-                        // The cases above match on the concrete validator class, so a
-                        // validator that declares itself an object but is not listed
-                        // reaches here and would be published as a string. That is how
-                        // JSON\FCM narrowed serviceAccountJSON in every generated SDK.
                         if ($validator->getType() === Validator::TYPE_OBJECT) {
                             $node['schema']['type'] = 'object';
                             $node['schema']['default'] = empty($param['default']) ? new \stdClass() : $param['default'];

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -733,7 +733,6 @@ class OpenAPI3 extends Format
                         break;
                     case \Utopia\Validator\JSON::class:
                     case \Utopia\Validator\JSON\ObjectValidator::class:
-                    case \Utopia\Validator\JSON\FCM::class:
                     case \Utopia\Validator\Assoc::class:
                         $node['schema']['type'] = 'object';
                         $node['schema']['default'] = (empty($param['default'])) ? new \stdClass() : $param['default'];
@@ -944,6 +943,17 @@ class OpenAPI3 extends Format
                         }
                         break;
                     default:
+                        // The cases above match on the concrete validator class, so a
+                        // validator that declares itself an object but is not listed
+                        // reaches here and would be published as a string. That is how
+                        // JSON\FCM narrowed serviceAccountJSON in every generated SDK.
+                        if ($validator->getType() === Validator::TYPE_OBJECT) {
+                            $node['schema']['type'] = 'object';
+                            $node['schema']['default'] = empty($param['default']) ? new \stdClass() : $param['default'];
+                            $node['schema']['example'] = ($param['example'] ?? '') !== '' ? $param['example'] : '{}';
+                            break;
+                        }
+
                         $node['schema']['type'] = 'string';
                         if (($param['example'] ?? '') !== '') {
                             $node['schema']['example'] = $param['example'];

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -733,6 +733,7 @@ class OpenAPI3 extends Format
                         break;
                     case \Utopia\Validator\JSON::class:
                     case \Utopia\Validator\JSON\ObjectValidator::class:
+                    case \Utopia\Validator\JSON\FCM::class:
                     case \Utopia\Validator\Assoc::class:
                         $node['schema']['type'] = 'object';
                         $node['schema']['default'] = (empty($param['default'])) ? new \stdClass() : $param['default'];

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -54,6 +54,7 @@ use Utopia\Database\Validator\Spatial;
 use Utopia\DI\Container;
 use Utopia\Http\Route;
 use Utopia\Platform\Enum;
+use Utopia\Validator;
 use Utopia\Validator\AnyOf;
 use Utopia\Validator\ArrayList;
 use Utopia\Validator\Assoc;
@@ -68,6 +69,56 @@ use Utopia\Validator\Nullable;
 use Utopia\Validator\Range;
 use Utopia\Validator\Text;
 use Utopia\Validator\WhiteList;
+
+/**
+ * Stands in for a validator that reports an object but has no case of its own in
+ * the OpenAPI3 parameter switch, which is the shape that regressed.
+ */
+class UnlistedObjectValidator extends Validator
+{
+    public function getDescription(): string
+    {
+        return 'Value must be an object';
+    }
+
+    public function isArray(): bool
+    {
+        return false;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE_OBJECT;
+    }
+
+    public function isValid(mixed $value): bool
+    {
+        return \is_array($value) || $value instanceof \stdClass;
+    }
+}
+
+class UnlistedStringValidator extends Validator
+{
+    public function getDescription(): string
+    {
+        return 'Value must be a string';
+    }
+
+    public function isArray(): bool
+    {
+        return false;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE_STRING;
+    }
+
+    public function isValid(mixed $value): bool
+    {
+        return \is_string($value);
+    }
+}
 
 class TestFormat extends Format
 {
@@ -1041,7 +1092,7 @@ final class FormatTest extends TestCase
         $this->assertSame('object', $openApiQuery['type']);
     }
 
-    public function testObjectValidatorsOutsideTheSwitchAreNotEmittedAsStrings(): void
+    public function testObjectValidatorsWithoutTheirOwnCaseAreNotEmittedAsStrings(): void
     {
         Method::$processed = [];
         Method::$errors = [];
@@ -1057,13 +1108,18 @@ final class FormatTest extends TestCase
                 responses: [],
             ))
             ->param('serviceAccountJSON', null, new Nullable(new FCM()), 'FCM service account JSON.', true)
-            ->param('bareServiceAccountJSON', null, new FCM(), 'FCM service account JSON.', true);
+            ->param('bareServiceAccountJSON', null, new FCM(), 'FCM service account JSON.', true)
+            ->param('unlistedObject', null, new UnlistedObjectValidator(), 'An object validator with no case of its own.', true)
+            ->param('unlistedString', null, new UnlistedStringValidator(), 'A string validator with no case of its own.', true);
 
         $spec = (new OpenAPI3(new Container(), [], [$route], [], [], 0, 'console'))->parse();
         $properties = $spec['paths']['/tests/fcm']['post']['requestBody']['content']['application/json']['schema']['properties'];
 
         $this->assertSame('object', $properties['serviceAccountJSON']['type']);
         $this->assertSame('object', $properties['bareServiceAccountJSON']['type']);
+        $this->assertSame('object', $properties['unlistedObject']['type']);
+        $this->assertEquals(new \stdClass(), $properties['unlistedObject']['default']);
+        $this->assertSame('string', $properties['unlistedString']['type']);
     }
 
     public function testJsonAndNullableModelRulesEmitExpectedSchemas(): void

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -54,7 +54,6 @@ use Utopia\Database\Validator\Spatial;
 use Utopia\DI\Container;
 use Utopia\Http\Route;
 use Utopia\Platform\Enum;
-use Utopia\Validator;
 use Utopia\Validator\AnyOf;
 use Utopia\Validator\ArrayList;
 use Utopia\Validator\Assoc;
@@ -64,61 +63,10 @@ use Utopia\Validator\FloatValidator;
 use Utopia\Validator\HexColor;
 use Utopia\Validator\Integer as IntegerValidator;
 use Utopia\Validator\JSON;
-use Utopia\Validator\JSON\FCM;
 use Utopia\Validator\Nullable;
 use Utopia\Validator\Range;
 use Utopia\Validator\Text;
 use Utopia\Validator\WhiteList;
-
-/**
- * Stands in for a validator that reports an object but has no case of its own in
- * the OpenAPI3 parameter switch, which is the shape that regressed.
- */
-class UnlistedObjectValidator extends Validator
-{
-    public function getDescription(): string
-    {
-        return 'Value must be an object';
-    }
-
-    public function isArray(): bool
-    {
-        return false;
-    }
-
-    public function getType(): string
-    {
-        return self::TYPE_OBJECT;
-    }
-
-    public function isValid(mixed $value): bool
-    {
-        return \is_array($value) || $value instanceof \stdClass;
-    }
-}
-
-class UnlistedStringValidator extends Validator
-{
-    public function getDescription(): string
-    {
-        return 'Value must be a string';
-    }
-
-    public function isArray(): bool
-    {
-        return false;
-    }
-
-    public function getType(): string
-    {
-        return self::TYPE_STRING;
-    }
-
-    public function isValid(mixed $value): bool
-    {
-        return \is_string($value);
-    }
-}
 
 class TestFormat extends Format
 {
@@ -1090,36 +1038,6 @@ final class FormatTest extends TestCase
         $openApiQuery = $openApi['paths']['/tests/graphql']['post']['requestBody']['content']['application/json']['schema']['properties']['query'];
 
         $this->assertSame('object', $openApiQuery['type']);
-    }
-
-    public function testObjectValidatorsWithoutTheirOwnCaseAreNotEmittedAsStrings(): void
-    {
-        Method::$processed = [];
-        Method::$errors = [];
-
-        $route = (new Route('POST', '/v1/tests/fcm'))
-            ->desc('Create FCM provider')
-            ->label('sdk', new Method(
-                namespace: 'test',
-                group: null,
-                name: 'createFcmProvider',
-                description: 'Create FCM provider.',
-                auth: [],
-                responses: [],
-            ))
-            ->param('serviceAccountJSON', null, new Nullable(new FCM()), 'FCM service account JSON.', true)
-            ->param('bareServiceAccountJSON', null, new FCM(), 'FCM service account JSON.', true)
-            ->param('unlistedObject', null, new UnlistedObjectValidator(), 'An object validator with no case of its own.', true)
-            ->param('unlistedString', null, new UnlistedStringValidator(), 'A string validator with no case of its own.', true);
-
-        $spec = (new OpenAPI3(new Container(), [], [$route], [], [], 0, 'console'))->parse();
-        $properties = $spec['paths']['/tests/fcm']['post']['requestBody']['content']['application/json']['schema']['properties'];
-
-        $this->assertSame('object', $properties['serviceAccountJSON']['type']);
-        $this->assertSame('object', $properties['bareServiceAccountJSON']['type']);
-        $this->assertSame('object', $properties['unlistedObject']['type']);
-        $this->assertEquals(new \stdClass(), $properties['unlistedObject']['default']);
-        $this->assertSame('string', $properties['unlistedString']['type']);
     }
 
     public function testJsonAndNullableModelRulesEmitExpectedSchemas(): void

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -63,6 +63,7 @@ use Utopia\Validator\FloatValidator;
 use Utopia\Validator\HexColor;
 use Utopia\Validator\Integer as IntegerValidator;
 use Utopia\Validator\JSON;
+use Utopia\Validator\JSON\FCM;
 use Utopia\Validator\Nullable;
 use Utopia\Validator\Range;
 use Utopia\Validator\Text;
@@ -1038,6 +1039,31 @@ final class FormatTest extends TestCase
         $openApiQuery = $openApi['paths']['/tests/graphql']['post']['requestBody']['content']['application/json']['schema']['properties']['query'];
 
         $this->assertSame('object', $openApiQuery['type']);
+    }
+
+    public function testObjectValidatorsOutsideTheSwitchAreNotEmittedAsStrings(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route('POST', '/v1/tests/fcm'))
+            ->desc('Create FCM provider')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'createFcmProvider',
+                description: 'Create FCM provider.',
+                auth: [],
+                responses: [],
+            ))
+            ->param('serviceAccountJSON', null, new Nullable(new FCM()), 'FCM service account JSON.', true)
+            ->param('bareServiceAccountJSON', null, new FCM(), 'FCM service account JSON.', true);
+
+        $spec = (new OpenAPI3(new Container(), [], [$route], [], [], 0, 'console'))->parse();
+        $properties = $spec['paths']['/tests/fcm']['post']['requestBody']['content']['application/json']['schema']['properties'];
+
+        $this->assertSame('object', $properties['serviceAccountJSON']['type']);
+        $this->assertSame('object', $properties['bareServiceAccountJSON']['type']);
     }
 
     public function testJsonAndNullableModelRulesEmitExpectedSchemas(): void


### PR DESCRIPTION
`OpenAPI3::parseParams` switches on the concrete validator class, so a validator with no case of its own falls through to `default:` and is published as `type: string` — even when it reports `TYPE_OBJECT`.

`Utopia\Validator\JSON\FCM` is one such validator. Replacing the FCM params' plain `JSON` validator with the stricter `FCM` one was meant to tighten validation, and the endpoints still declare `array|string|\stdClass|null $serviceAccountJSON` and `json_decode` a string before use, so the object path is live. But the swap also narrowed the published type, so `serviceAccountJSON` became a string in every generated SDK. In Go that surfaced as `WithCreateFcmProviderServiceAccountJSON(v interface{})` turning into `(v string)` — a breaking signature change nobody asked for.

`default:` now honours the declared type and emits an object for `TYPE_OBJECT`, so the next object validator without a case of its own does not regress the same way. With that in place the `JSON` and `JSON\ObjectValidator` cases are redundant and come out — both report `TYPE_OBJECT`, so the default emits exactly what they did.

`Assoc` keeps its case: it reports `TYPE_ARRAY` but is published as an object on purpose, so only an explicit case gets it right.

## Blast radius

Regenerating all four 1.9.x specs against the full cloud route table changes exactly two parameters — `serviceAccountJSON` on `POST /messaging/providers/fcm` and `PATCH /messaging/providers/fcm/{providerId}` — from `string` back to `object`. The client and manager specs are byte-identical, and removing the two cases leaves the delta unchanged. Nothing else in the route table reaches `default:` with `TYPE_OBJECT`.

`FormatTest` passes (31 tests, 160 assertions) and Pint is clean.