### PR TITLE
fix: coordinate scheduled execution cancel with publish lock

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
@@ -68,6 +68,7 @@ class Delete extends Base
             ->inject('queueForEvents')
             ->inject('authorization')
             ->inject('bus')
+            ->inject('locks')
             ->callback($this->action(...));
     }
 
@@ -81,6 +82,7 @@ class Delete extends Base
         Event $queueForEvents,
         Authorization $authorization,
         Bus $bus,
+        callable $locks,
     ) {
         $function = $dbForProject->getDocument('functions', $functionId);
 
@@ -109,7 +111,7 @@ class Delete extends Base
                 throw new Exception(Exception::EXECUTION_NOT_FOUND);
             }
 
-            $cancelled = $authorization->skip(fn () => $this->cancelSchedule($dbForPlatform, $schedule->getId()));
+            $cancelled = $authorization->skip(fn () => $this->cancelSchedule($dbForPlatform, $locks, $schedule->getId()));
             if (!$cancelled) {
                 throw new Exception(Exception::EXECUTION_NOT_FOUND);
             }
@@ -180,7 +182,7 @@ class Delete extends Base
                 throw new Exception(Exception::EXECUTION_IN_PROGRESS);
             }
 
-            $cancelled = $authorization->skip(fn () => $this->cancelSchedule($dbForPlatform, $schedule->getId()));
+            $cancelled = $authorization->skip(fn () => $this->cancelSchedule($dbForPlatform, $locks, $schedule->getId()));
             if (!$cancelled) {
                 throw new Exception(Exception::EXECUTION_IN_PROGRESS);
             }
@@ -204,19 +206,29 @@ class Delete extends Base
         $response->noContent();
     }
 
-    private function cancelSchedule(Database $dbForPlatform, string $scheduleId): bool
+    /**
+     * @param callable(string, int, callable, float): mixed $locks
+     */
+    private function cancelSchedule(Database $dbForPlatform, callable $locks, string $scheduleId): bool
     {
-        return $dbForPlatform->withTransaction(function () use ($dbForPlatform, $scheduleId) {
-            $schedule = $dbForPlatform->getDocument('schedules', $scheduleId, forUpdate: true);
+        return $locks(
+            'lock:platform:schedules:' . $scheduleId,
+            30,
+            function () use ($dbForPlatform, $scheduleId): bool {
+                return $dbForPlatform->withTransaction(function () use ($dbForPlatform, $scheduleId) {
+                    $schedule = $dbForPlatform->getDocument('schedules', $scheduleId, forUpdate: true);
 
-            // active=false is the scheduler's durable claim. Cancellation
-            // loses once that claim is committed, even if queue publication
-            // succeeds and the scheduler later fails to remove the schedule.
-            if ($schedule->isEmpty() || !$schedule->getAttribute('active', false)) {
-                return false;
-            }
+                    // active=false is the scheduler's durable claim. Cancellation
+                    // loses once that claim is committed, even if queue publication
+                    // succeeds and the scheduler later fails to remove the schedule.
+                    if ($schedule->isEmpty() || !$schedule->getAttribute('active', false)) {
+                        return false;
+                    }
 
-            return $dbForPlatform->deleteDocument('schedules', $scheduleId);
-        });
+                    return $dbForPlatform->deleteDocument('schedules', $scheduleId);
+                });
+            },
+            10.0,
+        );
     }
 }

--- a/src/Appwrite/Platform/Workers/Functions.php
+++ b/src/Appwrite/Platform/Workers/Functions.php
@@ -305,69 +305,90 @@ class Functions extends Action
         }
     }
 
-    protected function enqueueScheduledExecution(Database $dbForPlatform, Document $project, Document $execution, string $functionId, callable $enqueue): bool
+    /**
+     * @param callable(string, int, callable, float): mixed|null $locks
+     */
+    protected function enqueueScheduledExecution(Database $dbForPlatform, Document $project, Document $execution, string $functionId, callable $enqueue, ?callable $locks = null): bool
     {
         $scheduleId = $execution->getAttribute('scheduleId', '');
-        $schedule = $dbForPlatform->withTransaction(function () use ($dbForPlatform, $scheduleId) {
-            $schedule = $dbForPlatform->getDocument('schedules', $scheduleId, forUpdate: true);
-
-            if ($schedule->isEmpty() || !$schedule->getAttribute('active', false)) {
-                return new Document();
-            }
-
-            $claimed = $dbForPlatform->updateDocument('schedules', $scheduleId, new Document([
-                'resourceUpdatedAt' => DateTime::now(),
-                'active' => false,
-            ]));
-
-            return $claimed->isEmpty() ? new Document() : $schedule;
-        });
-
-        if ($schedule->isEmpty()) {
-            return false;
+        $lock = $locks ?? $this->locks;
+        if (!is_callable($lock)) {
+            $lock = static function (string $key, int $ttl, callable $callback, float $timeout = 0.0): mixed {
+                return $callback();
+            };
         }
 
-        $data = $schedule->getAttribute('data', []);
-        $functionId = $data['functionId'] ?? $functionId;
+        return $lock(
+            'lock:platform:schedules:' . $scheduleId,
+            30,
+            function () use ($dbForPlatform, $project, $execution, $functionId, $enqueue, $scheduleId): bool {
+                $schedule = $dbForPlatform->withTransaction(function () use ($dbForPlatform, $scheduleId) {
+                    $schedule = $dbForPlatform->getDocument('schedules', $scheduleId, forUpdate: true);
 
-        if (empty($functionId)) {
-            Console::error("Missing functionId for scheduled execution {$execution->getId()}, skipping");
-            $dbForPlatform->deleteDocument('schedules', $scheduleId);
-            return false;
-        }
+                    if ($schedule->isEmpty() || !$schedule->getAttribute('active', false)) {
+                        return new Document();
+                    }
 
-        $published = false;
-        try {
-            $enqueue(new FunctionMessage(
-                project: $project,
-                userId: $data['userId'] ?? '',
-                functionId: $functionId,
-                execution: new Document(['$id' => $execution->getId()]),
-                type: 'schedule',
-                body: $data['body'] ?? '',
-                path: $data['path'] ?? '/',
-                headers: $data['headers'] ?? [],
-                method: $data['method'] ?? 'POST',
-            ));
-            $published = true;
+                    $claimed = $dbForPlatform->updateDocument('schedules', $scheduleId, new Document([
+                        'resourceUpdatedAt' => DateTime::now(),
+                        'active' => false,
+                    ]));
 
-            if (!$dbForPlatform->deleteDocument('schedules', $scheduleId)) {
-                throw new \RuntimeException('Failed to remove claimed execution schedule');
-            }
+                    return $claimed->isEmpty() ? new Document() : $schedule;
+                });
 
-            return true;
-        } catch (\Throwable $error) {
-            // A failed publish releases the claim for a later retry. Once the
-            // publish succeeds, keep the schedule inactive even if cleanup
-            // fails so another worker cannot publish it again.
-            if (!$published) {
-                $dbForPlatform->updateDocument('schedules', $scheduleId, new Document([
-                    'resourceUpdatedAt' => DateTime::now(),
-                    'active' => true,
-                ]));
-            }
-            throw $error;
-        }
+                if ($schedule->isEmpty()) {
+                    return false;
+                }
+
+                $data = $schedule->getAttribute('data', []);
+                $functionId = $data['functionId'] ?? $functionId;
+
+                if (empty($functionId)) {
+                    Console::error("Missing functionId for scheduled execution {$execution->getId()}, skipping");
+                    $dbForPlatform->deleteDocument('schedules', $scheduleId);
+                    return false;
+                }
+
+                $published = false;
+                try {
+                    $enqueue(new FunctionMessage(
+                        project: $project,
+                        userId: $data['userId'] ?? '',
+                        functionId: $functionId,
+                        execution: new Document(['$id' => $execution->getId()]),
+                        type: 'schedule',
+                        body: $data['body'] ?? '',
+                        path: $data['path'] ?? '/',
+                        headers: $data['headers'] ?? [],
+                        method: $data['method'] ?? 'POST',
+                    ));
+                    $published = true;
+
+                    if (!$dbForPlatform->deleteDocument('schedules', $scheduleId)) {
+                        throw new \RuntimeException('Failed to remove claimed execution schedule');
+                    }
+
+                    return true;
+                } catch (\Throwable $error) {
+                    // A failed publish releases the claim for a later retry. Once the
+                    // publish succeeds, keep the schedule inactive even if cleanup
+                    // fails so another worker cannot publish it again.
+                    // Cancellation shares lock:platform:schedules:{id}, so a cancel
+                    // that raced the publish runs only after this block releases
+                    // the lock (and can then delete a revived schedule, or no-op
+                    // if publish already succeeded and left active=false).
+                    if (!$published) {
+                        $dbForPlatform->updateDocument('schedules', $scheduleId, new Document([
+                            'resourceUpdatedAt' => DateTime::now(),
+                            'active' => true,
+                        ]));
+                    }
+                    throw $error;
+                }
+            },
+            10.0,
+        );
     }
 
     protected function updateProjectAccess(Document $project, Database $dbForPlatform): void

--- a/tests/unit/Platform/Workers/FunctionsTest.php
+++ b/tests/unit/Platform/Workers/FunctionsTest.php
@@ -163,6 +163,92 @@ final class FunctionsTest extends TestCase
         }
     }
 
+    public function testFailedPublishDoesNotReviveScheduleAfterConcurrentCancellation(): void
+    {
+        $store = new MemoryScheduleStore(new Document([
+            '$id' => 'schedule-id',
+            'active' => true,
+            'data' => ['functionId' => 'function-id'],
+        ]));
+        $locks = new QueueingLock();
+        $cancelled = false;
+
+        try {
+            $this->worker()->schedule(
+                $this->scheduleDatabase($store),
+                new Document(['$id' => 'project-id', 'accessedAt' => DateTime::now()]),
+                new Document(['$id' => 'execution-id', 'scheduleId' => 'schedule-id']),
+                'function-id',
+                function () use ($store, $locks, &$cancelled): void {
+                    $this->cancelSchedule($this->scheduleDatabase($store), $locks, 'schedule-id', $cancelled);
+                    throw new \RuntimeException('Queue unavailable');
+                },
+                $locks,
+            );
+        } catch (\RuntimeException $error) {
+            $this->assertSame('Queue unavailable', $error->getMessage());
+        }
+
+        $this->assertTrue($cancelled, 'Cancellation must succeed when publication was prevented');
+        $this->assertTrue($store->document->isEmpty(), 'Failed publication must not revive a cancelled schedule');
+    }
+
+    public function testCancellationLosesOncePublicationSucceedsEvenIfCleanupFails(): void
+    {
+        $store = new MemoryScheduleStore(new Document([
+            '$id' => 'schedule-id',
+            'active' => true,
+            'data' => ['functionId' => 'function-id'],
+        ]));
+        $store->failDeletes = true;
+        $locks = new QueueingLock();
+        $cancelled = false;
+
+        try {
+            $this->worker()->schedule(
+                $this->scheduleDatabase($store),
+                new Document(['$id' => 'project-id', 'accessedAt' => DateTime::now()]),
+                new Document(['$id' => 'execution-id', 'scheduleId' => 'schedule-id']),
+                'function-id',
+                function () use ($store, $locks, &$cancelled): void {
+                    $this->cancelSchedule($this->scheduleDatabase($store), $locks, 'schedule-id', $cancelled);
+                },
+                $locks,
+            );
+            $this->fail('Cleanup failure must surface after a successful publish');
+        } catch (\RuntimeException $error) {
+            $this->assertSame('Failed to remove claimed execution schedule', $error->getMessage());
+        }
+
+        $this->assertFalse($cancelled, '204 is not allowed after the function job is already queued');
+        $this->assertFalse($store->document->isEmpty());
+        $this->assertFalse($store->document->getAttribute('active'));
+    }
+
+    /**
+     * @param callable(string, int, callable, float): mixed $locks
+     */
+    private function cancelSchedule(Database $dbForPlatform, callable $locks, string $scheduleId, ?bool &$result = null): ?bool
+    {
+        return $locks(
+            'lock:platform:schedules:' . $scheduleId,
+            30,
+            function () use ($dbForPlatform, $scheduleId, &$result): bool {
+                $result = $dbForPlatform->withTransaction(function () use ($dbForPlatform, $scheduleId): bool {
+                    $schedule = $dbForPlatform->getDocument('schedules', $scheduleId, forUpdate: true);
+                    if ($schedule->isEmpty() || !$schedule->getAttribute('active', false)) {
+                        return false;
+                    }
+
+                    return $dbForPlatform->deleteDocument('schedules', $scheduleId);
+                });
+
+                return $result;
+            },
+            10.0,
+        );
+    }
+
     /**
      * @return \Iterator<string, array{array<string, string>, string, string}>
      */
@@ -185,19 +271,102 @@ final class FunctionsTest extends TestCase
     {
         return new TestFunctions();
     }
+
+    private function scheduleDatabase(MemoryScheduleStore $store): Database
+    {
+        $db = $this->createMock(Database::class);
+        $db->method('withTransaction')->willReturnCallback(fn (callable $callback): mixed => $callback());
+        $db->method('getDocument')->willReturnCallback(function (string $collection, string $id) use ($store): Document {
+            if ($store->document->isEmpty() || $store->document->getId() !== $id) {
+                return new Document();
+            }
+
+            return $store->document;
+        });
+        $db->method('updateDocument')->willReturnCallback(function (string $collection, string $id, Document $update) use ($store): Document {
+            if ($store->document->isEmpty() || $store->document->getId() !== $id) {
+                return new Document();
+            }
+
+            foreach ($update->getArrayCopy() as $key => $value) {
+                $store->document->setAttribute($key, $value);
+            }
+
+            return $store->document;
+        });
+        $db->method('deleteDocument')->willReturnCallback(function (string $collection, string $id) use ($store): bool {
+            if ($store->failDeletes || $store->document->isEmpty() || $store->document->getId() !== $id) {
+                return false;
+            }
+
+            $store->document = new Document();
+
+            return true;
+        });
+
+        return $db;
+    }
 }
 
 final class TestFunctions extends Functions
 {
     public int $projectAccessUpdates = 0;
 
-    public function schedule(Database $dbForPlatform, Document $project, Document $execution, string $functionId, callable $enqueue): bool
+    /**
+     * @param callable(string, int, callable, float): mixed|null $locks
+     */
+    public function schedule(Database $dbForPlatform, Document $project, Document $execution, string $functionId, callable $enqueue, ?callable $locks = null): bool
     {
-        return $this->enqueueScheduledExecution($dbForPlatform, $project, $execution, $functionId, $enqueue);
+        return $this->enqueueScheduledExecution($dbForPlatform, $project, $execution, $functionId, $enqueue, $locks);
     }
 
     protected function updateProjectAccess(Document $project, Database $dbForPlatform): void
     {
         $this->projectAccessUpdates++;
+    }
+}
+
+/**
+ * Single-thread stand-in for a blocking per-key lock: waiters run after release.
+ */
+final class QueueingLock
+{
+    /** @var array<string, bool> */
+    private array $held = [];
+
+    /** @var array<string, list<callable(): mixed>> */
+    private array $waiters = [];
+
+    public function __invoke(string $key, int $ttl, callable $callback, float $timeout = 0.0): mixed
+    {
+        if ($this->held[$key] ?? false) {
+            $result = null;
+            $this->waiters[$key][] = function () use ($callback, &$result): mixed {
+                return $result = $callback();
+            };
+
+            return $result;
+        }
+
+        $this->held[$key] = true;
+        try {
+            return $callback();
+        } finally {
+            $this->held[$key] = false;
+            $waiters = $this->waiters[$key] ?? [];
+            $this->waiters[$key] = [];
+            foreach ($waiters as $waiter) {
+                ($this)($key, $ttl, $waiter, $timeout);
+            }
+        }
+    }
+}
+
+final class MemoryScheduleStore
+{
+    public bool $failDeletes = false;
+
+    public function __construct(public Document $document)
+    {
     }
 }


### PR DESCRIPTION
## Summary
Scheduled execution cancellation raced with the functions worker claim/publish path: a failed publish could revive a schedule after cancel had already won, and a cancel after successful publish could still return 204 if cleanup failed.

This shares `lock:platform:schedules:{id}` across the worker's claim → publish → cleanup and the executions delete cancel path so those outcomes are linearizable.

## Test plan
- [x] `vendor/bin/phpunit tests/unit/Platform/Workers/FunctionsTest.php`
- [ ] Confirm cancel during publish failure leaves the schedule deleted
- [ ] Confirm cancel after successful publish is rejected when the schedule claim is inactive

Fixes #13249