### PR TITLE
chore: bump orchestrator to 1.9.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1667,7 +1667,7 @@ services:
     # One image carrying every orchestrator control plane. Appwrite drives the
     # jobs plane today; the per-plane images exist for Kubernetes, where each
     # scales, fails and gets RBAC on its own.
-    image: ghcr.io/open-runtimes/orchestrator/orchestrator:1.8.3
+    image: ghcr.io/open-runtimes/orchestrator/orchestrator:1.9.2
     restart: unless-stopped
     user: root
     networks:


### PR DESCRIPTION
Bumps the orchestrator control-plane image from 1.8.3 to [1.9.2](https://github.com/open-runtimes/orchestrator/releases/tag/v1.9.2), picking up the jobs-service lifecycle fix (open-runtimes/orchestrator#98): build pods that fail during init (before the worker container ever runs) now emit a failure callback with the culprit init container and exit code, instead of vanishing and leaving the deployment stuck in "building" until the watchdog timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)