### PR TITLE
fix(databases): list indexes by database and collection sequence, not id

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/XList.php
@@ -95,8 +95,8 @@ class XList extends Action
 
         \array_push(
             $queries,
-            Query::equal('databaseId', [$databaseId]),
-            Query::equal('collectionId', [$collectionId]),
+            Query::equal('databaseInternalId', [$database->getSequence()]),
+            Query::equal('collectionInternalId', [$collection->getSequence()]),
         );
 
         $cursor = Query::getCursorQueries($queries, false);

--- a/tests/unit/Platform/Modules/Databases/Http/IndexesListTest.php
+++ b/tests/unit/Platform/Modules/Databases/Http/IndexesListTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform\Modules\Databases\Http;
+
+use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Indexes\XList;
+use Appwrite\Utopia\Response;
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Query;
+use Utopia\Database\Validator\Authorization;
+
+require_once __DIR__ . '/../../../../../../app/init.php';
+require_once __DIR__ . '/../../../../../../src/Appwrite/Platform/Modules/Databases/Constants.php';
+
+final class IndexesListTest extends TestCase
+{
+    private const string DATABASE_ID = 'rv109a-vdb-ded';
+    private const string COLLECTION_ID = 'vectors';
+
+    /**
+     * Index metadata rows are keyed by the database and collection sequences, and a
+     * recreated database keeps its id while taking a new sequence. Listing by the id
+     * strings therefore surfaces every earlier incarnation's rows next to the live
+     * ones; a stale `processing` row from a torn-down incarnation then reads as an
+     * index that never became available (r30 PR-95 on rv109a-vdb-ded).
+     */
+    public function testListsOnlyTheLiveIncarnationOfARecreatedDatabase(): void
+    {
+        $database = new Document([
+            '$id' => self::DATABASE_ID,
+            '$sequence' => '148569',
+            'type' => DATABASE_TYPE_VECTORSDB,
+        ]);
+        $collection = new Document([
+            '$id' => self::COLLECTION_ID,
+            '$sequence' => '1',
+            'attributes' => [],
+            'indexes' => [],
+        ]);
+        $records = [
+            $this->index('148001', 'processing'),
+            $this->index('148569', 'available'),
+        ];
+
+        $matching = static fn (array $queries): array => \array_values(\array_filter(
+            $records,
+            static fn (Document $record): bool => self::satisfies($record, $queries),
+        ));
+
+        $dbForProject = $this->createStub(Database::class);
+        $dbForProject->method('getDocument')->willReturnCallback(
+            static fn (string $collectionId, string $id): Document => match ($collectionId) {
+                'databases' => $database,
+                'database_148569' => $collection,
+                default => new Document(),
+            }
+        );
+        $dbForProject->method('find')->willReturnCallback(
+            static fn (string $collectionId, array $queries): array => $matching($queries)
+        );
+        $dbForProject->method('count')->willReturnCallback(
+            static fn (string $collectionId, array $queries): int => \count($matching($queries))
+        );
+
+        $authorization = $this->createStub(Authorization::class);
+        $authorization->method('skip')->willReturnCallback(static fn (callable $callback): mixed => $callback());
+
+        $listed = null;
+        $response = $this->createMock(Response::class);
+        $response->expects($this->once())
+            ->method('dynamic')
+            ->willReturnCallback(static function (Document $document) use (&$listed): void {
+                $listed = $document;
+            });
+
+        (new XList())->action(self::DATABASE_ID, self::COLLECTION_ID, [], true, $response, $dbForProject, $authorization);
+
+        $this->assertInstanceOf(Document::class, $listed);
+        $this->assertSame(1, $listed->getAttribute('total'), 'total must count only the live incarnation');
+        $this->assertSame(
+            ['148569_1_idx_embeddings'],
+            \array_map(static fn (Document $index): string => $index->getId(), $listed->getAttribute('indexes')),
+            'a torn-down incarnation of the same database id must not be listed'
+        );
+    }
+
+    private function index(string $databaseSequence, string $status): Document
+    {
+        return new Document([
+            '$id' => $databaseSequence . '_1_idx_embeddings',
+            'key' => 'idx_embeddings',
+            'status' => $status,
+            'databaseInternalId' => $databaseSequence,
+            'databaseId' => self::DATABASE_ID,
+            'collectionInternalId' => '1',
+            'collectionId' => self::COLLECTION_ID,
+            'type' => 'hnsw_cosine',
+            'attributes' => ['embeddings'],
+        ]);
+    }
+
+    /**
+     * @param array<Query> $queries
+     */
+    private static function satisfies(Document $record, array $queries): bool
+    {
+        foreach ($queries as $query) {
+            if ($query->getMethod() !== Query::TYPE_EQUAL) {
+                continue;
+            }
+            if (!\in_array($record->getAttribute($query->getAttribute()), $query->getValues(), true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## The defect

`Databases\Collections\Indexes\XList` (inherited by the TablesDB, DocumentsDB and VectorsDB index lists) filtered the `indexes` metadata collection on the `databaseId` / `collectionId` **strings**:

```php
Query::equal('databaseId', [$databaseId]),
Query::equal('collectionId', [$collectionId]),
```

Every sibling path keys on the sequences instead: the attribute list, the cursor lookup three lines below in the same action, the create-time limit `count`, and the worker's delete cascade (`deleteByGroup('indexes', [databaseInternalId, collectionInternalId])`). A recreated database keeps its id but takes a new sequence, so whenever an earlier incarnation's index rows outlive it, the list returns them next to the live rows under the same `key`.

## How it surfaced

109-point GA campaign, r30 PR-95 (`rv109a-vdb-ded`, dedicated VectorsDB, cloud 1.45.40 / edge 0.14.4-db, fra):

- r28 and r29 left `idx_embeddings` rows at `processing`: the pool-identity denial fixed in cloud#5573 threw in the databases worker at `$getDatabasesDB($database)`, before `createIndex` could mark them `failed`, and the same denial stopped the delete-database job before its cascade reached them.
- r30 created the index cleanly (worker `createIndex` span 0.43s, row `available`), the similarity query returned the correct ranking, yet the list kept returning the stale `processing` rows alongside the live one and the row failed on "index never left processing" for a third round.
- PR-93 on the same prefix passed in r30 because the **attribute** list already filters on the sequences; only the index list leaked.

## The fix

Filter on `databaseInternalId` / `collectionInternalId`, which both metadata collections index via `_key_db_collection`.

## Regression test

`tests/unit/Platform/Modules/Databases/Http/IndexesListTest.php` drives the VectorsDB `XList` action against two `indexes` rows sharing the database/collection id strings but differing in sequence, with `find`/`count` evaluating the action's own `equal` queries. Watched red on the unfixed action (`total` 2, both rows listed), green after.

Refs: r30 PR-95, r28/r29 PR-95, cloud#5573.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
