### PR TITLE
refactor(queues): remove intermediate publisher resources

### DIFF
--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -109,20 +109,6 @@ $container->set('authorization', fn () => new Authorization(), []);
 
 $container->set('publisher', fn (Group $pools) => new BrokerPool(publisher: $pools->get('publisher')), ['pools']);
 
-$container->set('publisherDatabases', fn (Publisher $publisher) => $publisher, ['publisher']);
-
-$container->set('publisherFunctions', fn (Publisher $publisher) => $publisher, ['publisher']);
-
-$container->set('publisherMigrations', fn (Publisher $publisher) => $publisher, ['publisher']);
-
-$container->set('publisherMails', fn (Publisher $publisher) => $publisher, ['publisher']);
-
-$container->set('publisherDeletes', fn (Publisher $publisher) => $publisher, ['publisher']);
-
-$container->set('publisherMessaging', fn (Publisher $publisher) => $publisher, ['publisher']);
-
-$container->set('publisherWebhooks', fn (Publisher $publisher) => $publisher, ['publisher']);
-
 $container->set('publisherForAudits', fn (Publisher $publisher) => new AuditPublisher(
     $publisher,
     new Queue(System::getEnv('_APP_AUDITS_QUEUE_NAME', Event::AUDITS_QUEUE_NAME))
@@ -204,10 +190,10 @@ $container->set('publisherForJobs', fn (Publisher $publisher) => new JobsPublish
     new Queue(System::getEnv('_APP_JOBS_QUEUE_NAME', Event::JOBS_QUEUE_NAME))
 ), ['publisher']);
 
-$container->set('publisherForDatabase', fn (Publisher $publisherDatabases) => new DatabasePublisher(
-    $publisherDatabases,
+$container->set('publisherForDatabase', fn (Publisher $publisher) => new DatabasePublisher(
+    $publisher,
     new Queue(System::getEnv('_APP_DATABASE_QUEUE_NAME', Event::DATABASE_QUEUE_NAME))
-), ['publisherDatabases']);
+), ['publisher']);
 
 $container->set('publisherForDeletes', fn (Publisher $publisher) => new DeletePublisher(
     $publisher,

--- a/app/init/resources/request.php
+++ b/app/init/resources/request.php
@@ -672,7 +672,7 @@ return function (Container $context): void {
         return;
     }, ['user', 'store', 'proofForToken']);
 
-    $context->set('dbForProject', function (DatabaseFactory $databaseFactory, Database $dbForPlatform, Document $project, Response $response, Publisher $publisher, Publisher $publisherFunctions, Publisher $publisherWebhooks, Event $queueForEvents, FunctionPublisher $publisherForFunctions, Webhook $queueForWebhooks, Realtime $queueForRealtime, UsageContext $usage, Request $request) {
+    $context->set('dbForProject', function (DatabaseFactory $databaseFactory, Database $dbForPlatform, Document $project, Response $response, Publisher $publisher, Event $queueForEvents, FunctionPublisher $publisherForFunctions, Webhook $queueForWebhooks, Realtime $queueForRealtime, UsageContext $usage, Request $request) {
         if ($project->isEmpty() || $project->getId() === 'console') {
             return $dbForPlatform;
         }
@@ -796,7 +796,7 @@ return function (Container $context): void {
         // Clone the queues, to prevent events triggered by the database listener
         // from overwriting the events that are supposed to be triggered in the shutdown hook.
         $queueForEventsClone = new Event($publisher);
-        $queueForWebhooks = new Webhook($publisherWebhooks);
+        $queueForWebhooksClone = clone $queueForWebhooks;
         $queueForRealtime = new Realtime();
 
         $database
@@ -811,7 +811,7 @@ return function (Container $context): void {
                 $response,
                 $queueForEventsClone->from($queueForEvents),
                 $publisherForFunctions,
-                $queueForWebhooks->from($queueForEvents),
+                $queueForWebhooksClone->from($queueForEvents),
                 $queueForRealtime->from($queueForEvents)
             ))
             ->on(Database::EVENT_DOCUMENT_CREATE, 'purge-function-events-cache', fn ($event, $document) => $functionsEventsCacheListener($event, $document, $project, $database))
@@ -819,7 +819,7 @@ return function (Container $context): void {
             ->on(Database::EVENT_DOCUMENT_DELETE, 'purge-function-events-cache', fn ($event, $document) => $functionsEventsCacheListener($event, $document, $project, $database));
 
         return $database;
-    }, ['databaseFactory', 'dbForPlatform', 'project', 'response', 'publisher', 'publisherFunctions', 'publisherWebhooks', 'queueForEvents', 'publisherForFunctions', 'queueForWebhooks', 'queueForRealtime', 'usage', 'request']);
+    }, ['databaseFactory', 'dbForPlatform', 'project', 'response', 'publisher', 'queueForEvents', 'publisherForFunctions', 'queueForWebhooks', 'queueForRealtime', 'usage', 'request']);
 
     $context->set('schema', function ($utopia, $dbForProject, $authorization) {
 


### PR DESCRIPTION
## Summary

- remove the seven `publisherX` aliases that only returned the generic publisher
- have `publisherForDatabase` consume the generic publisher directly
- remove raw publisher dependencies from request-scoped database setup and clone the typed webhook queue instead

Companion Cloud cleanup: appwrite-labs/cloud#5607

## Validation

- `composer lint app/init/resources.php app/init/resources/request.php`
- `vendor/bin/phpstan analyse --memory-limit=2G -c phpstan.neon app/init/resources.php app/init/resources/request.php`
- `git diff --check`