### PR TITLE
chore: run the mails worker with 6 coroutines

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1145,7 +1145,7 @@ services:
     environment:
       - _APP_ENV
       - _APP_WORKERS_NUM=1
-      - _APP_WORKER_MAX_COROUTINES=1
+      - _APP_WORKER_MAX_COROUTINES=6
       - _APP_WORKER_PER_CORE
       - _APP_POOL_ADAPTER
       - _APP_OPENSSL_KEY_V1


### PR DESCRIPTION
Mails ran as one process with one coroutine, so every send blocked the next. Set `_APP_WORKER_MAX_COROUTINES=6`, matching the other workers.

The SMTP transport (utopia-php/smtp) uses PHP streams under `SWOOLE_HOOK_ALL`, and the shared cloud adapter opens and closes a client per send, so concurrent sends share nothing.

Context: cloud fra1 worker-mails OOMKill on 2026-09-02. Cloud moves from 6 processes to 1 process / 6 coroutines so total heap stays under the pod limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)