### PR TITLE
perf: cache geo and audit attribution lookups

### DIFF
--- a/src/Appwrite/Event/Message/Audit.php
+++ b/src/Appwrite/Event/Message/Audit.php
@@ -30,6 +30,8 @@ final class Audit extends Base
                 '$id' => $this->project->getId(),
                 '$sequence' => $this->project->getSequence(),
                 'database' => $this->project->getAttribute('database', ''),
+                'teamId' => $this->project->getAttribute('teamId', ''),
+                'teamInternalId' => $this->project->getAttribute('teamInternalId', ''),
             ],
             'user' => $this->user->getArrayCopy(),
             'impersonatorUser' => $this->impersonatorUser->getArrayCopy(),

--- a/src/Appwrite/Geo/Geo.php
+++ b/src/Appwrite/Geo/Geo.php
@@ -11,7 +11,7 @@ use Utopia\Locale\Locale;
 class Geo
 {
     public const CACHE_SIZE = 10_000;
-    public const CACHE_VALUE_SIZE = 512;
+    public const CACHE_VALUE_SIZE = 1024;
 
     public function __construct(
         private ?Client $client,
@@ -77,7 +77,8 @@ class Geo
             'weatherCode' => $record['weatherCode'] ?? null,
             'postalCode' => $record['postalCode'] ?? null,
             'city' => $record['city']['en'] ?? null,
-            'state' => $record['subdivision']['en'] ?? $record['subdivisions'][0]['en'] ?? null,
+            'state' => $record['subdivision']['en'] ?? $record['subdivisions'][0]['en'] ?? $record['subdivisions'][0]['names']['en'] ?? null,
+            'subdivisions' => $record['subdivisions'] ?? null,
             'autonomousSystemNumber' => $autonomousSystemNumber === null ? null : (string) $autonomousSystemNumber,
             'autonomousSystemOrganization' => $record['autonomousSystemOrganization'] ?? null,
             'connectionType' => $record['connection'] ?? null,

--- a/tests/unit/Geo/GeoTest.php
+++ b/tests/unit/Geo/GeoTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Geo;
+
+use Appwrite\Geo\Client;
+use Appwrite\Geo\Geo;
+use PHPUnit\Framework\TestCase;
+use Swoole\Table;
+use Utopia\Config\Config;
+use Utopia\Locale\Locale;
+
+final class GeoTest extends TestCase
+{
+    public function testCachePreservesPremiumGeoAttributes(): void
+    {
+        Config::setParam('locale-eu', []);
+        Config::setParam('locale-currencies', []);
+        Locale::setLanguageFromArray('en', []);
+
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('lookup')
+            ->with('203.0.113.10')
+            ->willReturn([
+                'countryCode' => 'DE',
+                'continentCode' => 'EU',
+                'city' => ['en' => 'Frankfurt'],
+                'subdivisions' => [
+                    ['iso_code' => 'HE', 'names' => ['en' => 'Hesse']],
+                ],
+                'isp' => 'Example ISP',
+            ]);
+
+        $cache = new Table(16);
+        $cache->column('value', Table::TYPE_STRING, Geo::CACHE_VALUE_SIZE);
+        $cache->create();
+
+        $geo = new Geo($client, new Locale('en'), $cache);
+        $geo->get('203.0.113.10');
+        $cached = $geo->get('203.0.113.10');
+
+        $this->assertSame('Frankfurt', $cached->getAttribute('city'));
+        $this->assertSame('Hesse', $cached->getAttribute('subdivisions')[0]['names']['en']);
+        $this->assertSame('Example ISP', $cached->getAttribute('isp'));
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Makes the existing Geo cache retain complete premium records, and adds the missing team attribution to audit queue messages.

- Raises the cached Geo record capacity from 512 to 1024 bytes and preserves the subdivision chain, so background consumers can reuse `Appwrite\Geo\Geo` without losing premium fields.
- Adds `teamId` and `teamInternalId` to the project snapshot already serialized into audit messages. Cloud audit consumers need these immutable attribution fields and can stop reloading the same project document for every audit.

Both changes remove per-message network work from the Cloud audits worker while preserving the data written to ClickHouse.

## Test plan

- Added a focused Geo cache test covering a cache hit and premium subdivision/ISP preservation.
- `php vendor/bin/phpunit tests/unit/Geo/GeoTest.php`
- `php vendor/bin/pint --test src/Appwrite/Geo/Geo.php src/Appwrite/Event/Message/Audit.php tests/unit/Geo/GeoTest.php`