### PR TITLE
test(vcs): expect the Gitea callback redirect in the project's region

### DIFF
--- a/tests/e2e/Scopes/ProjectCustom.php
+++ b/tests/e2e/Scopes/ProjectCustom.php
@@ -255,6 +255,7 @@ trait ProjectCustom
         return [
             '$id' => $project['body']['$id'],
             'name' => $project['body']['name'],
+            'region' => $project['body']['region'],
             'apiKey' => $key['body']['secret'],
             'webhookId' => $webhook['body']['$id'],
             'signatureKey' => $webhook['body']['secret'],

--- a/tests/e2e/Services/VCSGitea/VCSGiteaConsoleClientTest.php
+++ b/tests/e2e/Services/VCSGitea/VCSGiteaConsoleClientTest.php
@@ -124,7 +124,7 @@ final class VCSGiteaConsoleClientTest extends Scope
         /** @var array<string, string> $cookies */
         $cookies = [];
         $this->giteaCookies = $cookies;
-        $consoleUrl = 'http://localhost/console/project-default-' . $projectId . '/settings/git-installations';
+        $consoleUrl = $this->gitInstallationsUrl($projectId);
 
         $authorize = $this->client->call(Client::METHOD_GET, '/vcs/gitea/authorize', \array_merge([
             'x-appwrite-project' => $projectId,
@@ -376,7 +376,7 @@ final class VCSGiteaConsoleClientTest extends Scope
     public function testCreateInstallationWithTamperedState(): void
     {
         $projectId = $this->getProject()['$id'];
-        $consoleUrl = 'http://localhost/console/project-default-' . $projectId . '/settings/git-installations';
+        $consoleUrl = $this->gitInstallationsUrl($projectId);
 
         $state = \json_decode($this->buildGiteaState($projectId, $consoleUrl, $consoleUrl), true);
         $state['projectId'] = 'victim-project';
@@ -392,7 +392,7 @@ final class VCSGiteaConsoleClientTest extends Scope
     public function testCreateInstallationWithoutCode(): void
     {
         $projectId = $this->getProject()['$id'];
-        $consoleUrl = 'http://localhost/console/project-default-' . $projectId . '/settings/git-installations';
+        $consoleUrl = $this->gitInstallationsUrl($projectId);
 
         // Signed state, no code: the failure redirect carries the error as a query string
         $response = $this->callGiteaCallbackHelper([
@@ -415,7 +415,7 @@ final class VCSGiteaConsoleClientTest extends Scope
         ]);
 
         $this->assertEquals(301, $response['headers']['status-code']);
-        $this->assertStringStartsWith('http://localhost/console/project-default-' . $projectId . '/settings/git-installations?error=', (string) $response['headers']['location']);
+        $this->assertStringStartsWith($this->gitInstallationsUrl($projectId) . '?error=', (string) $response['headers']['location']);
     }
 
     public function testCreateInstallationWithInvalidState(): void
@@ -427,7 +427,7 @@ final class VCSGiteaConsoleClientTest extends Scope
 
     public function testCreateInstallationWithUnknownProject(): void
     {
-        $consoleUrl = 'http://localhost/console/project-default-missing/settings/git-installations';
+        $consoleUrl = $this->gitInstallationsUrl('missing');
 
         $response = $this->callGiteaCallbackHelper([
             'code' => 'unused',
@@ -441,7 +441,7 @@ final class VCSGiteaConsoleClientTest extends Scope
     public function testCreateInstallationWithLongState(): void
     {
         $projectId = $this->getProject()['$id'];
-        $consoleUrl = 'http://localhost/console/project-default-' . $projectId . '/settings/git-installations';
+        $consoleUrl = $this->gitInstallationsUrl($projectId);
 
         // Past the old 2048 cap: redirect URLs are not length-limited, so the
         // authorize endpoint can produce a state this size itself.
@@ -463,6 +463,18 @@ final class VCSGiteaConsoleClientTest extends Scope
         $installation = $this->createInstallationHelper(redirects: false);
 
         $this->assertNotEmpty($installation['$id']);
+    }
+
+    /**
+     * The callback builds its fallback redirect from the project's region, so the
+     * expected URL follows the region the scope's project was created in: Cloud
+     * CI creates projects in a region other than default.
+     */
+    private function gitInstallationsUrl(string $projectId): string
+    {
+        $region = $this->getProject()['region'];
+
+        return "http://localhost/console/project-{$region}-{$projectId}/settings/git-installations";
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

The Gitea callback tests added in #13426 hardcode `project-default-` in the expected redirect. The callback builds that URL from the project's region. In this repo's CI every project is created in `default`, so the tests pass. Appwrite Cloud runs the same suite with projects in another region, and `testCreateInstallationWithEmptyRedirects` and `testCreateInstallationWithoutRedirects` fail there on every run since the bump to e9b5b58282.

This exposes the created project's `region` from the `ProjectCustom` scope, next to its id and API key, and builds the six expected URLs from it through one helper. The test reads no environment variable. No production code changes.

## Test Plan

E2E only. Behaviour is unchanged when the scope's project is in `default`; under a Cloud region the expected URL now matches what the callback returns.

## Related PRs and Issues

- #13426 introduced the tests.
- Blocks appwrite-labs/cloud E2E `VCS and migrations` on main.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] Have you added tests for the change?
- [x] Did you run the linter?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQPB3JWhybuoo1gHhqDBLa