### PR TITLE
fix(usage): tag build and execution usage with the resource id

### DIFF
--- a/src/Appwrite/Bus/Listeners/Usage.php
+++ b/src/Appwrite/Bus/Listeners/Usage.php
@@ -65,6 +65,7 @@ class Usage extends Listener
 
         $context = (new Context())
             ->setResource(rtrim($resourceType, 's'))
+            ->setResourceId((string) $resource->getId())
             ->setResourceInternalId((string) $resourceInternalId)
             ->addMetric(METRIC_EXECUTIONS, 1)
             ->addMetric(str_replace(['{resourceType}'], [$resourceType], METRIC_RESOURCE_TYPE_EXECUTIONS), 1)

--- a/src/Appwrite/Usage/Build.php
+++ b/src/Appwrite/Usage/Build.php
@@ -39,11 +39,11 @@ final class Build
             $mbSeconds = 0;
         }
 
-        // Per-resource breakdown now travels as resource dimensions on the
-        // Context (resolved to resourceType + resourceId in the usage pipeline)
+        // Per-resource breakdown travels as resource dimensions on the Context
         // instead of per-{resourceInternalId} metric-name templates.
         $usage
             ->setResource(rtrim($resourceType, 's'))
+            ->setResourceId($resource->getId())
             ->setResourceInternalId((string) $resource->getSequence());
 
         switch ($deployment->getAttribute('status')) {


### PR DESCRIPTION
## Symptom

All build GB-hours collapse into a single row labelled **"Unknown"** in the console's usage breakdown, and the per-function GB-hours chart excludes build compute entirely.

Build usage rows land in ClickHouse with `resourceType` = `function`/`site` and a populated `resourceInternalId`, but an **empty `resourceId`**. The console groups the GB-hours breakdown by `resourceId`, so every build row falls into the same empty bucket. The per-resource chart filters on `resourceId` too, so build compute never matches a resource and drops out of that view altogether.

## Root cause

CLO-4383 specified that these emitters should save the public `id` rather than the internal one. That requirement was applied to the Cloud-side emitters only — the CE-side emitters were never updated.

The phase 2 usage migration compounded it: it dropped the per-`{resourceInternalId}` metric-name templates and replaced them with a `resourceId` **dimension** on the usage `Context` — a dimension that nothing on the CE path ever fills.

A comment in `Usage/Build.php` asserted the id was "resolved to resourceType + resourceId in the usage pipeline". No such resolution exists anywhere in the codebase; that claim is removed as part of this fix.

## The change

Two call sites, one line each:

- **`src/Appwrite/Usage/Build.php`** — set `resourceId` from the function/site document. This helper is shared by the executor `Builds` worker and the jobs-service `Jobs` worker, so it covers functions and sites on both paths. Cloud inherits it: its `Workers/Builds.php` and `Workers/Jobs.php` subclasses do not touch the usage `Context`.
- **`src/Appwrite/Bus/Listeners/Usage.php`** (`handleExecutionCompleted`) — same gap for executions. Cloud overrides this method entirely, so this is a self-hosted-only fix.

No constants, no Cloud changes, no refactoring.

## Scope

This is **forward-only** — it fixes rows written from here on. Existing history still has an empty `resourceId` and needs a separate backfill, deriving `resourceId` from the `resourceInternalId` already stored on those rows.

Fixes CLO-4794
https://linear.app/appwrite/issue/CLO-4794/build-usage-writes-no-resourceid-collapsing-all-build-gb-hours-into