### PR TITLE
feat(usage): expose the remaining Context dimension getters

### DIFF
--- a/src/Appwrite/Usage/Context.php
+++ b/src/Appwrite/Usage/Context.php
@@ -122,6 +122,11 @@ class Context
         return $this;
     }
 
+    public function getCountry(): string
+    {
+        return $this->country;
+    }
+
     public function setRegion(string $region): static
     {
         $this->region = $region;
@@ -152,10 +157,20 @@ class Context
         return $this;
     }
 
+    public function getHostname(): string
+    {
+        return $this->hostname;
+    }
+
     public function setUserAgent(string $userAgent): static
     {
         $this->userAgent = $userAgent;
         return $this;
+    }
+
+    public function getUserAgent(): string
+    {
+        return $this->userAgent;
     }
 
     public function setIp(string $ip): static
@@ -175,10 +190,20 @@ class Context
         return $this;
     }
 
+    public function getSdk(): string
+    {
+        return $this->sdk;
+    }
+
     public function setSdkVersion(string $sdkVersion): static
     {
         $this->sdkVersion = $sdkVersion;
         return $this;
+    }
+
+    public function getSdkVersion(): string
+    {
+        return $this->sdkVersion;
     }
 
     /**


### PR DESCRIPTION
## What

Adds the five missing dimension getters to `Appwrite\Usage\Context`: `getHostname()`, `getUserAgent()`, `getCountry()`, `getSdk()` and `getSdkVersion()`. The class already exposes `getService()`, `getResourceId()`, `getResourcePath()` and `getIp()`; these are the same shape, placed next to their corresponding setters.

Purely additive accessors. No behaviour change, no existing call site touched.

## Why

Cloud needs to read these off the request-scoped `Context` to tag synchronous SDK execution usage.

`POST /v1/functions/{functionId}/executions` currently records usage with empty `country`, `ip`, `hostname` and `userAgent` — and therefore empty `osName` / `clientType` / `clientName` / `deviceName`, which are derived from the user agent. Cloud's usage listener reads those dimensions off the dispatched event spec, but only the edge-region ingest builds a spec carrying them; the CE-side dispatch sites populate `$spec` from `Config::getParam('specifications')`, which holds only `slug`, `memory` and `cpus`.

The correct values are already resolved onto the request-scoped `Context` by an `Http::init()` hook that runs before the route action, so no new geo lookup is needed — Cloud just needs to be able to read them back out. That is the follow-up change; this PR is the accessor half.

Not a billing issue: `memory` and `cpus` are present, so mbSeconds and GB-hours are exact. What is degraded is the geo/client breakdown on `executions`, `executions.compute` and `executions.mbSeconds`.

CLO-4796: https://linear.app/appwrite/issue/CLO-4796/sync-sdk-executions-record-usage-with-no-country-ip-hostname-or-user

## Test plan

Trivial accessors returning already-tested properties; no unit test added.

- [x] `vendor/bin/pint --test --config pint.json src/Appwrite/Usage/Context.php` — passed
- [x] `vendor/bin/phpstan analyse -c phpstan.neon src/Appwrite/Usage/Context.php` — no errors
