### PR TITLE
Keep team total in sync with confirmed memberships

### DIFF
--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
@@ -303,12 +303,29 @@ class Create extends Action
             $invitedTime = DateTime::now();
 
             if ($isPrivilegedUser || $isAppUser) {
-                $membership = $authorization->skip(fn () => $dbForProject->updateDocument('memberships', $membership->getId(), new Document([
-                    'secret' => $secretHash,
-                    'invited' => $invitedTime,
-                    'joined' => DateTime::now(),
-                    'confirm' => true
-                ])));
+                $membership = $dbForProject->withTransaction(function () use ($dbForProject, $authorization, $membership, $team, $secretHash, $invitedTime) {
+                    // Re-read under a lock, a concurrent invite must not count the same member twice
+                    $current = $authorization->skip(fn () => $dbForProject->getDocument('memberships', $membership->getId(), forUpdate: true));
+
+                    if ($current->getAttribute('confirm') === true) {
+                        return new Document();
+                    }
+
+                    $confirmed = $authorization->skip(fn () => $dbForProject->updateDocument('memberships', $membership->getId(), new Document([
+                        'secret' => $secretHash,
+                        'invited' => $invitedTime,
+                        'joined' => DateTime::now(),
+                        'confirm' => true
+                    ])));
+
+                    $authorization->skip(fn () => $dbForProject->increaseDocumentAttribute('teams', $team->getId(), 'total', 1));
+
+                    return $confirmed;
+                });
+
+                if ($membership->isEmpty()) {
+                    throw new Exception(Exception::MEMBERSHIP_ALREADY_CONFIRMED);
+                }
             } else {
                 $membership = $dbForProject->updateDocument('memberships', $membership->getId(), new Document([
                     'secret' => $secretHash,

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Delete.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Delete.php
@@ -124,17 +124,17 @@ class Delete extends Action
 
         // This membership is primary for the team, update the primary to next member.
         if ($team->getAttribute('userInternalId') === $membership->getAttribute('userInternalId')) {
-            $membership = $dbForProject->findOne('memberships', [
+            $successor = $dbForProject->findOne('memberships', [
                 Query::equal('teamInternalId', [$team->getSequence()]),
                 Query::equal('confirm', [true]),
             ]);
 
-            if (!$membership->isEmpty()) {
-                $team->setAttribute('userId', $membership->getAttribute('userId'));
-                $team->setAttribute('userInternalId', $membership->getAttribute('userInternalId'));
+            if (!$successor->isEmpty()) {
+                $team->setAttribute('userId', $successor->getAttribute('userId'));
+                $team->setAttribute('userInternalId', $successor->getAttribute('userInternalId'));
                 $dbForProject->updateDocument('teams', $team->getId(), new Document([
-                    'userId' => $membership->getAttribute('userId'),
-                    'userInternalId' => $membership->getAttribute('userInternalId'),
+                    'userId' => $successor->getAttribute('userId'),
+                    'userInternalId' => $successor->getAttribute('userInternalId'),
                 ]));
             }
         }

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Status/Update.php
@@ -191,11 +191,26 @@ class Update extends Action
             ;
         }
 
-        $membership = $dbForProject->updateDocument('memberships', $membership->getId(), new Document(['joined' => $membership->getAttribute('joined'), 'confirm' => true]));
+        $membership = $dbForProject->withTransaction(function () use ($dbForProject, $authorization, $membership, $team) {
+            // Re-read under a lock, a concurrent accept of the same invite must not be counted twice
+            $current = $authorization->skip(fn () => $dbForProject->getDocument('memberships', $membership->getId(), forUpdate: true));
+
+            if ($current->getAttribute('confirm') === true) {
+                return new Document();
+            }
+
+            $confirmed = $dbForProject->updateDocument('memberships', $membership->getId(), new Document(['joined' => $membership->getAttribute('joined'), 'confirm' => true]));
+
+            $authorization->skip(fn () => $dbForProject->increaseDocumentAttribute('teams', $team->getId(), 'total', 1));
+
+            return $confirmed;
+        });
+
+        if ($membership->isEmpty()) {
+            throw new Exception(Exception::MEMBERSHIP_ALREADY_CONFIRMED);
+        }
 
         $dbForProject->purgeCachedDocument('users', $targetUser->getId());
-
-        $authorization->skip(fn () => $dbForProject->increaseDocumentAttribute('teams', $team->getId(), 'total', 1));
 
         $queueForEvents
             ->setParam('userId', $targetUser->getId())

--- a/src/Appwrite/Platform/Modules/Teams/Http/Teams/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Teams/Create.php
@@ -76,53 +76,57 @@ class Create extends Action
         $teamId = $teamId == 'unique()' ? ID::unique() : $teamId;
 
         try {
-            $team = $authorization->skip(fn () => $dbForProject->createDocument('teams', new Document([
-                '$id' => $teamId,
-                '$permissions' => [
-                    Permission::read(Role::team($teamId)),
-                    Permission::update(Role::team($teamId, 'owner')),
-                    Permission::delete(Role::team($teamId, 'owner')),
-                ],
-                'labels' => [],
-                'name' => $name,
-                'total' => ($isPrivilegedUser || $isAppUser) ? 0 : 1,
-                'prefs' => new \stdClass(),
-                'search' => implode(' ', [$teamId, $name]),
-            ])));
+            // The seeded total only holds if the owner membership lands with the team
+            $team = $dbForProject->withTransaction(function () use ($dbForProject, $authorization, $teamId, $name, $roles, $user, $isPrivilegedUser, $isAppUser) {
+                $team = $authorization->skip(fn () => $dbForProject->createDocument('teams', new Document([
+                    '$id' => $teamId,
+                    '$permissions' => [
+                        Permission::read(Role::team($teamId)),
+                        Permission::update(Role::team($teamId, 'owner')),
+                        Permission::delete(Role::team($teamId, 'owner')),
+                    ],
+                    'labels' => [],
+                    'name' => $name,
+                    'total' => ($isPrivilegedUser || $isAppUser) ? 0 : 1,
+                    'prefs' => new \stdClass(),
+                    'search' => implode(' ', [$teamId, $name]),
+                ])));
+
+                if (!$isPrivilegedUser && !$isAppUser) { // Don't add user on server mode
+                    if (!\in_array('owner', $roles)) {
+                        $roles[] = 'owner';
+                    }
+
+                    $membershipId = ID::unique();
+                    $dbForProject->createDocument('memberships', new Document([
+                        '$id' => $membershipId,
+                        '$permissions' => [
+                            Permission::read(Role::user($user->getId())),
+                            Permission::read(Role::team($team->getId())),
+                            Permission::update(Role::user($user->getId())),
+                            Permission::update(Role::team($team->getId(), 'owner')),
+                            Permission::delete(Role::user($user->getId())),
+                            Permission::delete(Role::team($team->getId(), 'owner')),
+                        ],
+                        'userId' => $user->getId(),
+                        'userInternalId' => $user->getSequence(),
+                        'teamId' => $team->getId(),
+                        'teamInternalId' => $team->getSequence(),
+                        'roles' => $roles,
+                        'invited' => DateTime::now(),
+                        'joined' => DateTime::now(),
+                        'confirm' => true,
+                        'secret' => '',
+                        'search' => implode(' ', [$membershipId, $user->getId()])
+                    ]));
+
+                    $dbForProject->purgeCachedDocument('users', $user->getId());
+                }
+
+                return $team;
+            });
         } catch (Duplicate $th) {
             throw new Exception(Exception::TEAM_ALREADY_EXISTS);
-        }
-
-        if (!$isPrivilegedUser && !$isAppUser) { // Don't add user on server mode
-            if (!\in_array('owner', $roles)) {
-                $roles[] = 'owner';
-            }
-
-            $membershipId = ID::unique();
-            $membership = new Document([
-                '$id' => $membershipId,
-                '$permissions' => [
-                    Permission::read(Role::user($user->getId())),
-                    Permission::read(Role::team($team->getId())),
-                    Permission::update(Role::user($user->getId())),
-                    Permission::update(Role::team($team->getId(), 'owner')),
-                    Permission::delete(Role::user($user->getId())),
-                    Permission::delete(Role::team($team->getId(), 'owner')),
-                ],
-                'userId' => $user->getId(),
-                'userInternalId' => $user->getSequence(),
-                'teamId' => $team->getId(),
-                'teamInternalId' => $team->getSequence(),
-                'roles' => $roles,
-                'invited' => DateTime::now(),
-                'joined' => DateTime::now(),
-                'confirm' => true,
-                'secret' => '',
-                'search' => implode(' ', [$membershipId, $user->getId()])
-            ]);
-
-            $membership = $dbForProject->createDocument('memberships', $membership);
-            $dbForProject->purgeCachedDocument('users', $user->getId());
         }
 
         $queueForEvents->setParam('teamId', $team->getId());

--- a/tests/e2e/Services/Teams/TeamsCustomClientTest.php
+++ b/tests/e2e/Services/Teams/TeamsCustomClientTest.php
@@ -165,4 +165,79 @@ final class TeamsCustomClientTest extends Scope
         ], $this->getHeaders()));
         $this->assertEquals(204, $response['headers']['status-code']);
     }
+
+    public function testCreateTeamMembershipConfirmsPendingInvite(): void
+    {
+        $teamData = $this->createTeamHelper();
+        $teamUid = $teamData['teamUid'];
+        $projectId = $this->getProject()['$id'];
+
+        $membershipData = $this->createPendingMembershipHelper($teamUid, $teamData['teamName']);
+
+        $team = $this->client->call(Client::METHOD_GET, '/teams/' . $teamUid, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+        ], $this->getHeaders()));
+
+        $this->assertEquals(200, $team['headers']['status-code']);
+        $this->assertEquals(1, $team['body']['total']); // A pending invite is not a member yet
+
+        /**
+         * Test for SUCCESS
+         * A server side invite confirms the pending membership, so it has to be counted
+         */
+        $response = $this->client->call(Client::METHOD_POST, '/teams/' . $teamUid . '/memberships', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'userId' => $membershipData['userUid'],
+            'roles' => ['developer'],
+            'url' => 'http://localhost:5000/join-us#title'
+        ]);
+
+        $this->assertEquals(201, $response['headers']['status-code']);
+        $this->assertEquals($membershipData['membershipUid'], $response['body']['$id']);
+        $this->assertTrue($response['body']['confirm']);
+
+        $team = $this->client->call(Client::METHOD_GET, '/teams/' . $teamUid, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+        ], $this->getHeaders()));
+
+        $this->assertEquals(200, $team['headers']['status-code']);
+        $this->assertEquals(2, $team['body']['total']);
+
+        $memberships = $this->client->call(Client::METHOD_GET, '/teams/' . $teamUid . '/memberships', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+        ], $this->getHeaders()));
+
+        $this->assertEquals(200, $memberships['headers']['status-code']);
+        $this->assertEquals($team['body']['total'], $memberships['body']['total']);
+
+        /**
+         * Test for FAILURE
+         * Re-inviting a confirmed member must not count them twice
+         */
+        $response = $this->client->call(Client::METHOD_POST, '/teams/' . $teamUid . '/memberships', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'userId' => $membershipData['userUid'],
+            'roles' => ['developer'],
+            'url' => 'http://localhost:5000/join-us#title'
+        ]);
+
+        $this->assertEquals(409, $response['headers']['status-code']);
+
+        $team = $this->client->call(Client::METHOD_GET, '/teams/' . $teamUid, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+        ], $this->getHeaders()));
+
+        $this->assertEquals(200, $team['headers']['status-code']);
+        $this->assertEquals(2, $team['body']['total']);
+    }
 }


### PR DESCRIPTION
## What does this PR do?

`teams.total` is meant to be the number of confirmed memberships, but four code paths could drift it away from the actual rows. This is user visible: a team can report `total = 2` while only one membership row exists for it.

**1. `Memberships/Delete.php` — the decrement read the wrong document.** The primary-transfer block reassigned `$membership` to the *successor* before the decrement:

```php
if ($team->getAttribute('userInternalId') === $membership->getAttribute('userInternalId')) {
    $membership = $dbForProject->findOne('memberships', [...]); // clobbered
}

if ($membership->getAttribute('confirm')) { // now the successor, not the deleted membership
```

When the only remaining member was still unconfirmed, `findOne` returned an empty document and the decrement was skipped entirely, leaving the team permanently over-counted. The same clobbering sent the successor's `membershipId` and document in the event payload. Renamed the lookup to `$successor`.

Note this branch only fires when `team.userInternalId` is set, which is a Cloud-only extension of the `teams` collection — it is unreachable in this repo, so it has no e2e coverage here.

**2. `Memberships/Create.php` — server-side confirm was never counted.** When a server/API-key caller invited a user who already had a pending membership, the row flipped to `confirm => true` but only the "new membership" branch incremented `total`. Under-counted, and a later delete then decremented it below the real count.

**3. `Status/Update.php` — invite accepts could double count.** The `confirm === true` guard ran ~70 lines before the increment, so two concurrent accepts of the same invite (double-clicked invite link, email prefetch, client retry) both passed the guard and both incremented. The flip and increment now share a transaction behind a `getDocument(..., forUpdate: true)` re-read; the loser gets `MEMBERSHIP_ALREADY_CONFIRMED` (409). Same treatment applied to the path in 2.

**4. `Teams/Create.php` — non-atomic seed.** `total => 1` was written, then the owner membership was created in a separate statement. A failure in between left a team counting a member that does not exist. Both writes now share a transaction.

The atomic `increaseDocumentAttribute` / `decreaseDocumentAttribute` primitives are kept rather than recomputing with `count()` on every write: they are already race-free (utopia runs them in a transaction with a locking read), whereas `count()` + `update` is a read-modify-write, `memberships` has no index on `confirm`, and the deletes worker calls the callback per deleted row, which would make bulk cleanup quadratic.

## Test Plan

Added `testCreateTeamMembershipConfirmsPendingInvite` to `tests/e2e/Services/Teams/TeamsCustomClientTest.php`: a client creates a team and a pending invite (`total` stays 1), a server-key invite confirms it (`total` must become 2 and match `GET /memberships` total), and re-inviting the confirmed member returns 409 without counting again.

Verified it is a real regression test — with the `Memberships/Create.php` fix reverted it fails on `Failed asserting that 1 matches expected 2`, and passes with the fix.

```
docker compose exec appwrite test tests/e2e/Services/Teams
OK (46 tests, 1057 assertions)
```

`composer lint` and `composer analyze` are clean on `src/Appwrite/Platform/Modules/Teams/`.

Not covered by tests: 1 is unreachable in this repo (see above), 3 is a concurrency window, and 4 needs an induced write failure.

## Related PRs and Issues

- (none)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? — no metadata changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)