### PR TITLE
fix: let the build job deliver its output to the builds device

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -933,7 +933,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_DEVICE',
-                'description' => 'Select the default storage device. Supported adapters are \'local\', \'s3\', \'dospaces\', \'backblaze\', \'linode\', and \'wasabi\'. Remote adapters use _APP_STORAGE_S3_* configuration. Their deprecated provider-specific variables remain available as fallbacks for backward compatibility, but Open Runtimes Orchestrator does not support those fallback variables.',
+                'description' => 'Select the default storage device. Supported adapters are \'local\', \'s3\', \'dospaces\', \'backblaze\', \'linode\', and \'wasabi\'. Configure object storage with _APP_STORAGE_S3_* variables. Deprecated provider-specific variables remain available as fallbacks for backward compatibility, but Open Runtimes Orchestrator does not support those fallback variables.',
                 'introduction' => '0.13.0',
                 'default' => 'local',
                 'required' => false,

--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -933,7 +933,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_DEVICE',
-                'description' => 'Select default storage device. The default value is \'local\'. List of supported adapters are \'local\', \'s3\', \'dospaces\', \'backblaze\', \'linode\' and \'wasabi\'.',
+                'description' => 'Select the default storage device. Supported adapters are \'local\', \'s3\', \'dospaces\', \'backblaze\', \'linode\', and \'wasabi\'. Remote adapters use _APP_STORAGE_S3_* configuration. Their deprecated provider-specific variables remain available as fallbacks for backward compatibility, but Open Runtimes Orchestrator does not support those fallback variables.',
                 'introduction' => '0.13.0',
                 'default' => 'local',
                 'required' => false,
@@ -981,7 +981,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_DO_SPACES_ACCESS_KEY',
-                'description' => 'DigitalOcean spaces access key. Required when the storage adapter is set to DOSpaces. You can get your access key from your DigitalOcean console.',
+                'description' => 'Deprecated. DigitalOcean Spaces access key retained for backward compatibility. Use _APP_STORAGE_S3_ACCESS_KEY instead; Open Runtimes Orchestrator does not support this provider-specific variable.',
                 'introduction' => '0.13.0',
                 'default' => '',
                 'required' => false,
@@ -989,7 +989,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_DO_SPACES_SECRET',
-                'description' => 'DigitalOcean spaces secret key. Required when the storage adapter is set to DOSpaces. You can get your secret key from your DigitalOcean console.',
+                'description' => 'Deprecated. DigitalOcean Spaces secret key retained for backward compatibility. Use _APP_STORAGE_S3_SECRET instead; Open Runtimes Orchestrator does not support this provider-specific variable.',
                 'introduction' => '0.13.0',
                 'default' => '',
                 'required' => false,
@@ -997,7 +997,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_DO_SPACES_REGION',
-                'description' => 'DigitalOcean spaces region. Required when storage adapter is set to DOSpaces. You can find your region info for your space from DigitalOcean console.',
+                'description' => 'Deprecated. DigitalOcean Spaces region retained for backward compatibility. Use _APP_STORAGE_S3_REGION instead; Open Runtimes Orchestrator does not support this provider-specific variable.',
                 'introduction' => '0.13.0',
                 'default' => 'us-east-1',
                 'required' => false,
@@ -1005,7 +1005,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_DO_SPACES_BUCKET',
-                'description' => 'DigitalOcean spaces bucket. Required when storage adapter is set to DOSpaces. You can create spaces in your DigitalOcean console.',
+                'description' => 'Deprecated. DigitalOcean Spaces bucket retained for backward compatibility. Use _APP_STORAGE_S3_BUCKET instead; Open Runtimes Orchestrator does not support this provider-specific variable.',
                 'introduction' => '0.13.0',
                 'default' => '',
                 'required' => false,
@@ -1013,7 +1013,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_BACKBLAZE_ACCESS_KEY',
-                'description' => 'Backblaze access key. Required when the storage adapter is set to Backblaze. Your Backblaze keyID will be your access key. You can get your keyID from your Backblaze console.',
+                'description' => 'Deprecated. Backblaze access key retained for backward compatibility. Use _APP_STORAGE_S3_ACCESS_KEY instead; Open Runtimes Orchestrator does not support this provider-specific variable.',
                 'introduction' => '0.14.2',
                 'default' => '',
                 'required' => false,
@@ -1021,7 +1021,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_BACKBLAZE_SECRET',
-                'description' => 'Backblaze secret key. Required when the storage adapter is set to Backblaze. Your Backblaze applicationKey will be your secret key. You can get your applicationKey from your Backblaze console.',
+                'description' => 'Deprecated. Backblaze secret key retained for backward compatibility. Use _APP_STORAGE_S3_SECRET instead; Open Runtimes Orchestrator does not support this provider-specific variable.',
                 'introduction' => '0.14.2',
                 'default' => '',
                 'required' => false,
@@ -1029,7 +1029,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_BACKBLAZE_REGION',
-                'description' => 'Backblaze region. Required when storage adapter is set to Backblaze. You can find your region info from your Backblaze console.',
+                'description' => 'Deprecated. Backblaze region retained for backward compatibility. Use _APP_STORAGE_S3_REGION instead; Open Runtimes Orchestrator does not support this provider-specific variable.',
                 'introduction' => '0.14.2',
                 'default' => 'us-west-004',
                 'required' => false,
@@ -1037,7 +1037,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_BACKBLAZE_BUCKET',
-                'description' => 'Backblaze bucket. Required when storage adapter is set to Backblaze. You can create your bucket from your Backblaze console.',
+                'description' => 'Deprecated. Backblaze bucket retained for backward compatibility. Use _APP_STORAGE_S3_BUCKET instead; Open Runtimes Orchestrator does not support this provider-specific variable.',
                 'introduction' => '0.14.2',
                 'default' => '',
                 'required' => false,
@@ -1045,7 +1045,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_LINODE_ACCESS_KEY',
-                'description' => 'Linode object storage access key. Required when the storage adapter is set to Linode. You can get your access key from your Linode console.',
+                'description' => 'Deprecated. Linode Object Storage access key retained for backward compatibility. Use _APP_STORAGE_S3_ACCESS_KEY instead; Open Runtimes Orchestrator does not support this provider-specific variable.',
                 'introduction' => '0.14.2',
                 'default' => '',
                 'required' => false,
@@ -1053,7 +1053,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_LINODE_SECRET',
-                'description' => 'Linode object storage secret key. Required when the storage adapter is set to Linode. You can get your secret key from your Linode console.',
+                'description' => 'Deprecated. Linode Object Storage secret key retained for backward compatibility. Use _APP_STORAGE_S3_SECRET instead; Open Runtimes Orchestrator does not support this provider-specific variable.',
                 'introduction' => '0.14.2',
                 'default' => '',
                 'required' => false,
@@ -1061,7 +1061,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_LINODE_REGION',
-                'description' => 'Linode object storage region. Required when storage adapter is set to Linode. You can find your region info from your Linode console.',
+                'description' => 'Deprecated. Linode Object Storage region retained for backward compatibility. Use _APP_STORAGE_S3_REGION instead; Open Runtimes Orchestrator does not support this provider-specific variable.',
                 'introduction' => '0.14.2',
                 'default' => 'eu-central-1',
                 'required' => false,
@@ -1069,7 +1069,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_LINODE_BUCKET',
-                'description' => 'Linode object storage bucket. Required when storage adapter is set to Linode. You can create buckets in your Linode console.',
+                'description' => 'Deprecated. Linode Object Storage bucket retained for backward compatibility. Use _APP_STORAGE_S3_BUCKET instead; Open Runtimes Orchestrator does not support this provider-specific variable.',
                 'introduction' => '0.14.2',
                 'default' => '',
                 'required' => false,
@@ -1077,7 +1077,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_WASABI_ACCESS_KEY',
-                'description' => 'Wasabi access key. Required when the storage adapter is set to Wasabi. You can get your access key from your Wasabi console.',
+                'description' => 'Deprecated. Wasabi access key retained for backward compatibility. Use _APP_STORAGE_S3_ACCESS_KEY instead; Open Runtimes Orchestrator does not support this provider-specific variable.',
                 'introduction' => '0.14.2',
                 'default' => '',
                 'required' => false,
@@ -1085,7 +1085,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_WASABI_SECRET',
-                'description' => 'Wasabi secret key. Required when the storage adapter is set to Wasabi. You can get your secret key from your Wasabi console.',
+                'description' => 'Deprecated. Wasabi secret key retained for backward compatibility. Use _APP_STORAGE_S3_SECRET instead; Open Runtimes Orchestrator does not support this provider-specific variable.',
                 'introduction' => '0.14.2',
                 'default' => '',
                 'required' => false,
@@ -1093,7 +1093,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_WASABI_REGION',
-                'description' => 'Wasabi region. Required when storage adapter is set to Wasabi. You can find your region info from your Wasabi console.',
+                'description' => 'Deprecated. Wasabi region retained for backward compatibility. Use _APP_STORAGE_S3_REGION instead; Open Runtimes Orchestrator does not support this provider-specific variable.',
                 'introduction' => '0.14.2',
                 'default' => 'eu-central-1',
                 'required' => false,
@@ -1101,7 +1101,7 @@ return [
             ],
             [
                 'name' => '_APP_STORAGE_WASABI_BUCKET',
-                'description' => 'Wasabi bucket. Required when storage adapter is set to Wasabi. You can create buckets in your Wasabi console.',
+                'description' => 'Deprecated. Wasabi bucket retained for backward compatibility. Use _APP_STORAGE_S3_BUCKET instead; Open Runtimes Orchestrator does not support this provider-specific variable.',
                 'introduction' => '0.14.2',
                 'default' => '',
                 'required' => false,

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -287,7 +287,18 @@ $container->set('deviceForLocal', fn (Telemetry $telemetry) => new Device\Teleme
 
 function getDevice(string $root, string $connection = ''): Device
 {
-    $connection = ! empty($connection) ? $connection : System::getEnv('_APP_CONNECTIONS_STORAGE', '');
+    $configuredDevice = DeviceType::tryFrom(strtolower(System::getEnv('_APP_STORAGE_DEVICE', DeviceType::Local->value))) ?? DeviceType::Local;
+    $s3AccessKey = System::getEnv('_APP_STORAGE_S3_ACCESS_KEY', '');
+    $s3AccessSecret = System::getEnv('_APP_STORAGE_S3_SECRET', '');
+    $s3Region = System::getEnv('_APP_STORAGE_S3_REGION', '');
+    $s3Bucket = System::getEnv('_APP_STORAGE_S3_BUCKET', '');
+    $hasS3Configuration = $s3AccessKey !== '' && $s3AccessSecret !== '' && $s3Bucket !== '';
+
+    // An explicit connection remains authoritative. Otherwise the generic S3
+    // configuration takes precedence and the legacy internal DSN is a fallback.
+    if ($connection === '' && (! \in_array($configuredDevice, [DeviceType::S3, DeviceType::AwsS3], true) || ! $hasS3Configuration)) {
+        $connection = System::getEnv('_APP_CONNECTIONS_STORAGE', '');
+    }
 
     $device = DeviceType::Local;
     $accessKey = '';
@@ -307,20 +318,27 @@ function getDevice(string $root, string $connection = ''): Device
             Console::warning($e->getMessage() . 'Invalid DSN. Defaulting to Local device.');
         }
     } else {
-        $device = DeviceType::tryFrom(strtolower(System::getEnv('_APP_STORAGE_DEVICE', DeviceType::Local->value))) ?? DeviceType::Local;
+        $device = $configuredDevice;
         $prefix = match ($device) {
-            DeviceType::S3, DeviceType::AwsS3 => 'S3',
+            DeviceType::S3, DeviceType::AwsS3 => null,
             DeviceType::DoSpaces => 'DO_SPACES',
             DeviceType::Backblaze => 'BACKBLAZE',
             DeviceType::Linode => 'LINODE',
             DeviceType::Wasabi => 'WASABI',
             DeviceType::Local => null,
         };
-        if ($prefix !== null) {
-            $accessKey = System::getEnv("_APP_STORAGE_{$prefix}_ACCESS_KEY", '');
-            $accessSecret = System::getEnv("_APP_STORAGE_{$prefix}_SECRET", '');
-            $region = System::getEnv("_APP_STORAGE_{$prefix}_REGION", '');
-            $bucket = System::getEnv("_APP_STORAGE_{$prefix}_BUCKET", '');
+        if ($device !== DeviceType::Local) {
+            if ($prefix === null || $hasS3Configuration) {
+                $accessKey = $s3AccessKey;
+                $accessSecret = $s3AccessSecret;
+                $region = $s3Region;
+                $bucket = $s3Bucket;
+            } else {
+                $accessKey = System::getEnv("_APP_STORAGE_{$prefix}_ACCESS_KEY", '');
+                $accessSecret = System::getEnv("_APP_STORAGE_{$prefix}_SECRET", '');
+                $region = System::getEnv("_APP_STORAGE_{$prefix}_REGION", '');
+                $bucket = System::getEnv("_APP_STORAGE_{$prefix}_BUCKET", '');
+            }
         }
     }
 

--- a/app/init/resources/request.php
+++ b/app/init/resources/request.php
@@ -213,15 +213,9 @@ return function (Container $context): void {
     ), ['publisher']);
     // Builds a Deployments bound to a given project — webhook handlers resolve
     // their tenant projects mid-request, after this container is initialized.
-    $context->set('deploymentsFactory', function (Jobs $jobs, array $platform, Telemetry $telemetry) {
-        return fn (Database $dbForProject, Document $project): Deployments => new Deployments(
-            $jobs,
-            $dbForProject,
-            $project,
-            $platform,
-            new Device\Telemetry($telemetry, getDevice(APP_STORAGE_BUILDS . '/app-' . $project->getId())),
-        );
-    }, ['jobs', 'platform', 'telemetry']);
+    $context->set('deploymentsFactory', function (Jobs $jobs, array $platform) {
+        return fn (Database $dbForProject, Document $project): Deployments => new Deployments($jobs, $dbForProject, $project, $platform);
+    }, ['jobs', 'platform']);
     $context->set('deployments', fn (callable $deploymentsFactory, Database $dbForProject, Document $project) => $deploymentsFactory($dbForProject, $project), ['deploymentsFactory', 'dbForProject', 'project']);
     $context->set('eventProcessor', fn () => new EventProcessor(), []);
     $context->set('databaseFactory', fn (Group $pools, Cache $cache, Authorization $authorization) => new DatabaseFactory(

--- a/app/init/worker/message.php
+++ b/app/init/worker/message.php
@@ -24,7 +24,6 @@ use Utopia\Queue\Publisher;
 use Utopia\Queue\Queue;
 use Utopia\Registry\Registry;
 use Utopia\Span\Span;
-use Utopia\Storage\Device;
 use Utopia\Storage\Device\Telemetry as TelemetryDevice;
 use Utopia\System\System;
 use Utopia\Telemetry\Adapter as Telemetry;
@@ -191,9 +190,9 @@ return function (Container $container): void {
 
     // Only the Builds worker uses this, handing template-into-repo pushes to
     // the jobs-service.
-    $container->set('deployments', function (Jobs $jobs, Database $dbForProject, Document $project, array $platform, Device $deviceForBuilds) {
-        return new Deployments($jobs, $dbForProject, $project, $platform, $deviceForBuilds);
-    }, ['jobs', 'dbForProject', 'project', 'platform', 'deviceForBuilds']);
+    $container->set('deployments', function (Jobs $jobs, Database $dbForProject, Document $project, array $platform) {
+        return new Deployments($jobs, $dbForProject, $project, $platform);
+    }, ['jobs', 'dbForProject', 'project', 'platform']);
 
     $container->set('logError', function (Registry $register, Document $project) {
         return function (Throwable $error, string $namespace, string $action, ?array $extras = null) use ($register, $project) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1707,6 +1707,13 @@ services:
       - ORCHESTRATOR_NETWORK=appwrite
       - DOCKER_NETWORK=appwrite
       - ARTIFACT_ENDPOINT=http://orchestrator:8080
+      # Signs the s3:// build artifacts Appwrite submits when the builds
+      # device is not local (see Deployments::storage()); forwarded into
+      # the sidecar that runs them. Empty on the local device.
+      - S3_ENDPOINT=${_APP_STORAGE_S3_ENDPOINT:-}
+      - S3_REGION=${_APP_STORAGE_S3_REGION:-us-east-1}
+      - S3_ACCESS_KEY_ID=${_APP_STORAGE_S3_ACCESS_KEY:-}
+      - S3_SECRET_ACCESS_KEY=${_APP_STORAGE_S3_SECRET:-}
 
   mariadb:
     image: mariadb:10.11

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1707,9 +1707,6 @@ services:
       - ORCHESTRATOR_NETWORK=appwrite
       - DOCKER_NETWORK=appwrite
       - ARTIFACT_ENDPOINT=http://orchestrator:8080
-      # Signs the s3:// build artifacts Appwrite submits when the builds
-      # device is not local (see Deployments::storage()); forwarded into
-      # the sidecar that runs them. Empty on the local device.
       - S3_ENDPOINT=${_APP_STORAGE_S3_ENDPOINT:-}
       - S3_REGION=${_APP_STORAGE_S3_REGION:-us-east-1}
       - S3_ACCESS_KEY_ID=${_APP_STORAGE_S3_ACCESS_KEY:-}

--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -42,8 +42,11 @@ use Utopia\VCS\Adapter\Git;
  * build.sh writes its artifact + the cache squashfs straight onto the volume
  * Appwrite already reads. On a remote device (S3 and friends) no volume spans
  * Appwrite and the build workers, so the sidecar moves them over s3://
- * upload/download artifacts instead. Either way the multi-hundred-MB output
- * stays off the (capped) HTTP upload path and out of the Appwrite process.
+ * upload/download artifacts instead. The orchestrator supports the generic
+ * _APP_STORAGE_S3_* configuration; legacy provider-specific variables and
+ * _APP_CONNECTIONS_STORAGE are retained by Appwrite only for backward
+ * compatibility. Either way the multi-hundred-MB output stays off the
+ * (capped) HTTP upload path and out of the Appwrite process.
  * Deployments that need yet another strategy override storage() — everything
  * else about the payload stays the same.
  *
@@ -544,8 +547,11 @@ readonly class Deployments
      * buildPath()/cachePath(). On a remote device (S3 and friends) build.sh
      * writes into the job workspace and the sidecar moves output and cache
      * over s3:// artifacts, keyed as buildPath()/cachePath(), so everything
-     * reading through deviceForBuilds works unchanged. 'job' in `depends`
-     * is the orchestrator's sentinel for "after the build command finishes".
+     * reading through deviceForBuilds works unchanged. Open Runtimes Orchestrator
+     * accepts the generic _APP_STORAGE_S3_* configuration, not deprecated
+     * provider-specific variables or _APP_CONNECTIONS_STORAGE. 'job' in
+     * `depends` is the orchestrator's sentinel for "after the build command
+     * finishes".
      *
      * @return array{volumes: array<Volume>, artifacts: array<mixed>, environment: array<string, string>}
      */
@@ -603,22 +609,32 @@ readonly class Deployments
     private static function bucket(Device $device): string
     {
         $type = $device->getType();
-        if (\in_array($type, [DeviceType::S3, DeviceType::AwsS3], true) && System::getEnv('_APP_STORAGE_S3_ENDPOINT', '') !== '') {
+        $configuredDevice = DeviceType::tryFrom(\strtolower(System::getEnv('_APP_STORAGE_DEVICE', DeviceType::Local->value))) ?? DeviceType::Local;
+        $s3AccessKey = System::getEnv('_APP_STORAGE_S3_ACCESS_KEY', '');
+        $s3AccessSecret = System::getEnv('_APP_STORAGE_S3_SECRET', '');
+        $s3Bucket = System::getEnv('_APP_STORAGE_S3_BUCKET', '');
+        $hasS3Configuration = $s3AccessKey !== '' && $s3AccessSecret !== '' && $s3Bucket !== '';
+        $connection = System::getEnv('_APP_CONNECTIONS_STORAGE', '');
+        $usesS3Configuration = $hasS3Configuration && ($connection === '' || \in_array($configuredDevice, [DeviceType::S3, DeviceType::AwsS3], true));
+
+        if ($usesS3Configuration && \in_array($type, [DeviceType::S3, DeviceType::AwsS3], true) && System::getEnv('_APP_STORAGE_S3_ENDPOINT', '') !== '') {
             return '';
         }
 
-        $connection = System::getEnv('_APP_CONNECTIONS_STORAGE', '');
-        if ($connection !== '') {
+        if (! $usesS3Configuration && $connection !== '') {
             return \trim((new DSN($connection))->getPath() ?? '', '/');
         }
 
+        if ($usesS3Configuration) {
+            return $s3Bucket;
+        }
+
         $prefix = match ($type) {
-            DeviceType::S3, DeviceType::AwsS3 => 'S3',
             DeviceType::DoSpaces => 'DO_SPACES',
             DeviceType::Backblaze => 'BACKBLAZE',
             DeviceType::Linode => 'LINODE',
             DeviceType::Wasabi => 'WASABI',
-            DeviceType::Local => null,
+            DeviceType::S3, DeviceType::AwsS3, DeviceType::Local => null,
         };
 
         return $prefix === null ? '' : System::getEnv("_APP_STORAGE_{$prefix}_BUCKET", '');

--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -601,13 +601,6 @@ readonly class Deployments
      */
     protected static function objectUrl(Device $device, string $path): string
     {
-        $bucket = self::bucket($device);
-
-        return 's3://' . \ltrim(($bucket !== '' ? "/{$bucket}" : '') . $path, '/');
-    }
-
-    private static function bucket(Device $device): string
-    {
         $type = $device->getType();
         $configuredDevice = DeviceType::tryFrom(\strtolower(System::getEnv('_APP_STORAGE_DEVICE', DeviceType::Local->value))) ?? DeviceType::Local;
         $s3AccessKey = System::getEnv('_APP_STORAGE_S3_ACCESS_KEY', '');
@@ -618,26 +611,23 @@ readonly class Deployments
         $usesS3Configuration = $hasS3Configuration && ($connection === '' || \in_array($configuredDevice, [DeviceType::S3, DeviceType::AwsS3], true));
 
         if ($usesS3Configuration && \in_array($type, [DeviceType::S3, DeviceType::AwsS3], true) && System::getEnv('_APP_STORAGE_S3_ENDPOINT', '') !== '') {
-            return '';
+            $bucket = '';
+        } elseif (! $usesS3Configuration && $connection !== '') {
+            $bucket = \trim((new DSN($connection))->getPath() ?? '', '/');
+        } elseif ($usesS3Configuration) {
+            $bucket = $s3Bucket;
+        } else {
+            $prefix = match ($type) {
+                DeviceType::DoSpaces => 'DO_SPACES',
+                DeviceType::Backblaze => 'BACKBLAZE',
+                DeviceType::Linode => 'LINODE',
+                DeviceType::Wasabi => 'WASABI',
+                DeviceType::S3, DeviceType::AwsS3, DeviceType::Local => null,
+            };
+            $bucket = $prefix === null ? '' : System::getEnv("_APP_STORAGE_{$prefix}_BUCKET", '');
         }
 
-        if (! $usesS3Configuration && $connection !== '') {
-            return \trim((new DSN($connection))->getPath() ?? '', '/');
-        }
-
-        if ($usesS3Configuration) {
-            return $s3Bucket;
-        }
-
-        $prefix = match ($type) {
-            DeviceType::DoSpaces => 'DO_SPACES',
-            DeviceType::Backblaze => 'BACKBLAZE',
-            DeviceType::Linode => 'LINODE',
-            DeviceType::Wasabi => 'WASABI',
-            DeviceType::S3, DeviceType::AwsS3, DeviceType::Local => null,
-        };
-
-        return $prefix === null ? '' : System::getEnv("_APP_STORAGE_{$prefix}_BUCKET", '');
+        return 's3://' . \ltrim(($bucket !== '' ? "/{$bucket}" : '') . $path, '/');
     }
 
     protected static function version(Document $resource): string

--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -570,10 +570,6 @@ readonly class Deployments
             ],
             default => [
                 'volumes' => [],
-                // 'in' paths are workspace-relative. Pull the cache only when
-                // a previous build saved one: a failed pre-job artifact aborts
-                // the job, so an unconditional download would break every
-                // first build.
                 'artifacts' => [
                     ...($device->exists($cachePath) ? [new DownloadArtifact(id: 'cachePull', in: static::objectUrl($device, $cachePath), out: "cache/{$cacheKey}.sqfs")] : []),
                     new UploadArtifact(id: 'output', in: 'output/' . static::artifact(), out: static::objectUrl($device, static::buildPath($projectId, $deploymentId)), depends: 'job'),

--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -537,27 +537,14 @@ readonly class Deployments
     }
 
     /**
-     * Where build.sh's output artifact and package-manager cache
-     * (a squashfs) land, and what the job needs to get them there. build.sh
-     * only cares that OPEN_RUNTIMES_BUILD_OUTPUT_DIR/_CACHE_ARTIFACT point
-     * somewhere on its local filesystem, volume-backed or not, so the
-     * strategy follows the builds device:
-     *   - local: the shared builds volume is mounted and build.sh writes to
-     *     outputDirectory()/cachePath() on it, which already are the device's
-     *     paths.
-     *   - remote (S3 and friends): no volume spans Appwrite and the build
-     *     workers, so build.sh writes into the job workspace and the sidecar
-     *     moves things in/out via s3:// 'artifacts', signed with the S3_*
-     *     credentials the orchestrator is configured with:
-     *       - cache pull, before the build: a plain DownloadArtifact (no
-     *         `depends`, so it runs before the command) into the local cache
-     *         path.
-     *       - cache push and output upload, after the build: an UploadArtifact
-     *         with `depends: 'job'` — 'job' is the orchestrator's sentinel id
-     *         for "after the build command finishes", not an id of another
-     *         artifact.
-     *     Object keys are the device's buildPath()/cachePath(), so everything
-     *     that reads builds through deviceForBuilds works unchanged.
+     * Where build.sh's output artifact and package-manager cache land, and
+     * what the job needs to get them there. On the local device the shared
+     * builds volume is mounted and build.sh writes straight to
+     * buildPath()/cachePath(). On a remote device (S3 and friends) build.sh
+     * writes into the job workspace and the sidecar moves output and cache
+     * over s3:// artifacts, keyed as buildPath()/cachePath(), so everything
+     * reading through deviceForBuilds works unchanged. 'job' in `depends`
+     * is the orchestrator's sentinel for "after the build command finishes".
      *
      * @return array{volumes: array<Volume>, artifacts: array<mixed>, environment: array<string, string>}
      */

--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -572,9 +572,6 @@ readonly class Deployments
 
         if ($device->getType() === DeviceType::Local) {
             return [
-                // Docker volume / K8s PVC named by _APP_BUILDS_VOLUME, attached
-                // to the worker at its Appwrite path so build.sh writes output +
-                // cache straight onto it.
                 'volumes' => [
                     new Volume(source: System::getEnv('_APP_BUILDS_VOLUME', 'appwrite-builds'), path: APP_STORAGE_BUILDS),
                 ],

--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -13,6 +13,7 @@ use OpenRuntimes\Orchestrator\Model\Artifact\DownloadArtifact;
 use OpenRuntimes\Orchestrator\Model\Artifact\ReadArtifact;
 use OpenRuntimes\Orchestrator\Model\Artifact\StatArtifact;
 use OpenRuntimes\Orchestrator\Model\Artifact\UnarchiveArtifact;
+use OpenRuntimes\Orchestrator\Model\Artifact\UploadArtifact;
 use OpenRuntimes\Orchestrator\Model\Callback;
 use OpenRuntimes\Orchestrator\Model\Volume;
 use Utopia\Config\Config;
@@ -22,8 +23,8 @@ use Utopia\Database\Document;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
 use Utopia\Database\Query;
+use Utopia\DSN\DSN;
 use Utopia\Storage\Device;
-use Utopia\Storage\Device\Local;
 use Utopia\Storage\DeviceType;
 use Utopia\System\System;
 use Utopia\VCS\Adapter\Git;
@@ -35,14 +36,16 @@ use Utopia\VCS\Adapter\Git;
  *
  * Source crosses the boundary via the artifacts system (presigned GET download
  * + unarchive, run by the sidecar) — a GET has no request-body cap, so large
- * sources are fine. The build output and package-manager cache, by default,
- * go on a mounted volume: the builds storage volume is attached to the build
- * worker at its Appwrite path, so build.sh writes its artifact + the cache
- * squashfs straight onto the volume Appwrite already reads. That keeps the
- * multi-hundred-MB output off the (capped) HTTP upload path and out of the
- * Appwrite process. Deployments that need a different strategy (e.g. S3
- * upload/download artifacts instead of a shared volume) override storage()
- * — everything else about the payload stays the same.
+ * sources are fine. The build output and package-manager cache go wherever
+ * the builds device is (see storage()). On the local device the builds
+ * storage volume is attached to the build worker at its Appwrite path, so
+ * build.sh writes its artifact + the cache squashfs straight onto the volume
+ * Appwrite already reads. On a remote device (S3 and friends) no volume spans
+ * Appwrite and the build workers, so the sidecar moves them over s3://
+ * upload/download artifacts instead. Either way the multi-hundred-MB output
+ * stays off the (capped) HTTP upload path and out of the Appwrite process.
+ * Deployments that need yet another strategy override storage() — everything
+ * else about the payload stays the same.
  *
  * Covers function and site deployments whose source is a tarball: manual
  * upload, duplicate/rebuild, VCS commits, and templates (public GitHub tarball
@@ -56,7 +59,6 @@ readonly class Deployments
         protected Database $dbForProject,
         protected Document $project,
         private array $platform,
-        private Device $deviceForBuilds,
     ) {
     }
 
@@ -186,7 +188,7 @@ readonly class Deployments
 
         $queued = $this->dbForProject->updateDocuments('deployments', new Document([
             'status' => 'waiting',
-            'buildPath' => $this->deviceForBuilds->getPath($deployment->getId() . '/' . static::artifact()),
+            'buildPath' => static::buildPath($this->project->getId(), $deployment->getId()),
         ]), [
             Query::equal('$id', [$deployment->getId()]),
             Query::notEqual('status', 'canceled'),
@@ -463,32 +465,6 @@ readonly class Deployments
     }
 
     /**
-     * Bring a finished build's artifact to the deployment's buildPath, once
-     * the job has exited and delivered its artifacts. With the volume strategy
-     * (see storage()) build.sh wrote it onto the builds volume, which on the
-     * local device already is the buildPath; on a remote device (S3 and
-     * friends) it is moved off the volume onto the device here. A strategy
-     * whose artifacts already land on the device overrides this with a no-op.
-     */
-    public function store(Document $deployment): void
-    {
-        if ($this->deviceForBuilds->getType() === DeviceType::Local) {
-            return;
-        }
-
-        $source = static::buildPath($this->project->getId(), $deployment->getId());
-        $target = (string) $deployment->getAttribute('buildPath', '');
-        $local = new Local();
-        if ($target === '' || ! $local->exists($source)) {
-            return;
-        }
-
-        if ($local->copy($source, $target, $this->deviceForBuilds)) {
-            $local->delete($source);
-        }
-    }
-
-    /**
      * The jobs-service job id for a deployment build (used to submit and cancel).
      */
     public static function id(string $projectId, string $deploymentId): string
@@ -497,8 +473,8 @@ readonly class Deployments
     }
 
     /**
-     * The build output directory on the builds volume. The produced artifact's
-     * complete path is discovered and persisted after the job finishes.
+     * The build output directory on the builds volume, where build.sh writes
+     * under the volume strategy (see storage()).
      */
     public static function outputDirectory(string $projectId, string $deploymentId): string
     {
@@ -506,13 +482,15 @@ readonly class Deployments
     }
 
     /**
-     * The build output path on the builds volume. On the local device this is
-     * also the deployment's buildPath; on a remote device (S3 and friends) the
-     * buildPath is a device path and the Jobs worker moves the artifact there.
+     * The build artifact's path on the builds device, declared at submission
+     * and read back through deviceForBuilds by the jobs worker, executions,
+     * downloads and deletes. On the local device it is outputDirectory() +
+     * the artifact, i.e. where build.sh writes; a path-style S3 device keys
+     * it under its bucket.
      */
     public static function buildPath(string $projectId, string $deploymentId): string
     {
-        return static::outputDirectory($projectId, $deploymentId) . '/' . static::artifact();
+        return static::device($projectId)->getPath("{$deploymentId}/" . static::artifact());
     }
 
     /**
@@ -541,24 +519,45 @@ readonly class Deployments
         return \substr(\hash('sha256', "{$projectId}:{$resourceId}:{$image}"), 0, 48);
     }
 
+    /**
+     * The package-manager cache's path on the builds device (see buildPath()).
+     */
     public static function cachePath(string $projectId, string $cacheKey): string
     {
-        return APP_STORAGE_BUILDS . "/app-{$projectId}/cache/{$cacheKey}.sqfs";
+        return static::device($projectId)->getPath("cache/{$cacheKey}.sqfs");
+    }
+
+    /**
+     * The builds device for a project, as everything else reads it
+     * (deviceForBuilds).
+     */
+    protected static function device(string $projectId): Device
+    {
+        return getDevice(APP_STORAGE_BUILDS . "/app-{$projectId}");
     }
 
     /**
      * Where build.sh's output artifact and package-manager cache
-     * (a squashfs) land, and what the job needs to get them there. The
-     * default mounts the shared builds volume at outputDirectory()/cachePath();
-     * build.sh only cares that OPEN_RUNTIMES_BUILD_OUTPUT_DIR/_CACHE_ARTIFACT
-     * point somewhere on its local filesystem, volume-backed or not — so a
-     * strategy without a shared volume (e.g. S3) instead points them at a
-     * local tmp path and moves things in/out via 'artifacts':
-     *   - cache pull, before the build: a plain DownloadArtifact (no
-     *     `depends`, so it runs before the command) into the local cache path.
-     *   - cache push and output upload, after the build: an UploadArtifact
-     *     with `depends: 'job'` — 'job' is the orchestrator's sentinel id for
-     *     "after the build command finishes", not an id of another artifact.
+     * (a squashfs) land, and what the job needs to get them there. build.sh
+     * only cares that OPEN_RUNTIMES_BUILD_OUTPUT_DIR/_CACHE_ARTIFACT point
+     * somewhere on its local filesystem, volume-backed or not, so the
+     * strategy follows the builds device:
+     *   - local: the shared builds volume is mounted and build.sh writes to
+     *     outputDirectory()/cachePath() on it, which already are the device's
+     *     paths.
+     *   - remote (S3 and friends): no volume spans Appwrite and the build
+     *     workers, so build.sh writes into the job workspace and the sidecar
+     *     moves things in/out via s3:// 'artifacts', signed with the S3_*
+     *     credentials the orchestrator is configured with:
+     *       - cache pull, before the build: a plain DownloadArtifact (no
+     *         `depends`, so it runs before the command) into the local cache
+     *         path.
+     *       - cache push and output upload, after the build: an UploadArtifact
+     *         with `depends: 'job'` — 'job' is the orchestrator's sentinel id
+     *         for "after the build command finishes", not an id of another
+     *         artifact.
+     *     Object keys are the device's buildPath()/cachePath(), so everything
+     *     that reads builds through deviceForBuilds works unchanged.
      *
      * @return array{volumes: array<Volume>, artifacts: array<mixed>, environment: array<string, string>}
      */
@@ -568,20 +567,86 @@ readonly class Deployments
         $deploymentId = $deployment->getId();
         $runtime = self::runtime($resource, self::version($resource));
         $cacheKey = static::cacheKey($projectId, $resource->getId(), $runtime['image'] ?? '');
+        $cachePath = static::cachePath($projectId, $cacheKey);
+        $device = static::device($projectId);
+
+        if ($device->getType() === DeviceType::Local) {
+            return [
+                // Docker volume / K8s PVC named by _APP_BUILDS_VOLUME, attached
+                // to the worker at its Appwrite path so build.sh writes output +
+                // cache straight onto it.
+                'volumes' => [
+                    new Volume(source: System::getEnv('_APP_BUILDS_VOLUME', 'appwrite-builds'), path: APP_STORAGE_BUILDS),
+                ],
+                'artifacts' => [],
+                'environment' => [
+                    'OPEN_RUNTIMES_BUILD_OUTPUT_DIR' => static::outputDirectory($projectId, $deploymentId),
+                    'OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT' => $cachePath,
+                ],
+            ];
+        }
+
+        // 'in' paths are workspace-relative.
+        $artifacts = [
+            new UploadArtifact(id: 'output', in: 'output/' . static::artifact(), out: static::objectUrl($device, static::buildPath($projectId, $deploymentId)), depends: 'job'),
+            new UploadArtifact(id: 'cache', in: "cache/{$cacheKey}.sqfs", out: static::objectUrl($device, $cachePath), depends: 'job'),
+        ];
+
+        // Pull the cache only when a previous build saved one: a failed
+        // pre-job artifact aborts the job, so an unconditional download
+        // would break every first build.
+        if ($device->exists($cachePath)) {
+            \array_unshift($artifacts, new DownloadArtifact(id: 'cachePull', in: static::objectUrl($device, $cachePath), out: "cache/{$cacheKey}.sqfs"));
+        }
 
         return [
-            // Docker volume / K8s PVC named by _APP_BUILDS_VOLUME, attached
-            // to the worker at its Appwrite path so build.sh writes output +
-            // cache straight onto it.
-            'volumes' => [
-                new Volume(source: System::getEnv('_APP_BUILDS_VOLUME', 'appwrite-builds'), path: APP_STORAGE_BUILDS),
-            ],
-            'artifacts' => [],
+            'volumes' => [],
+            'artifacts' => $artifacts,
             'environment' => [
-                'OPEN_RUNTIMES_BUILD_OUTPUT_DIR' => static::outputDirectory($projectId, $deploymentId),
-                'OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT' => static::cachePath($projectId, $cacheKey),
+                'OPEN_RUNTIMES_BUILD_OUTPUT_DIR' => '/mnt/code/output',
+                'OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT' => "/mnt/code/cache/{$cacheKey}.sqfs",
             ],
         ];
+    }
+
+    /**
+     * Map a builds device path to the s3://bucket/key artifact URL the sidecar
+     * uploads to, resolving the bucket from the same configuration getDevice()
+     * reads so artifact writes and device reads land on the same object. An
+     * S3 device with an explicit endpoint (S3-compatible stores such as MinIO)
+     * is path-style and already keys objects under its bucket, so the path is
+     * the URL as is; a virtual-host device passes paths verbatim, so the
+     * bucket is prepended.
+     */
+    protected static function objectUrl(Device $device, string $path): string
+    {
+        $bucket = self::bucket($device);
+
+        return 's3://' . \ltrim(($bucket !== '' ? "/{$bucket}" : '') . $path, '/');
+    }
+
+    private static function bucket(Device $device): string
+    {
+        $type = $device->getType();
+        if (\in_array($type, [DeviceType::S3, DeviceType::AwsS3], true) && System::getEnv('_APP_STORAGE_S3_ENDPOINT', '') !== '') {
+            return '';
+        }
+
+        $connection = System::getEnv('_APP_CONNECTIONS_STORAGE', '');
+        if ($connection !== '') {
+            return \trim((new DSN($connection))->getPath() ?? '', '/');
+        }
+
+        $prefix = match ($type) {
+            DeviceType::S3, DeviceType::AwsS3 => 'S3',
+            DeviceType::DoSpaces => 'DO_SPACES',
+            DeviceType::Backblaze => 'BACKBLAZE',
+            DeviceType::Linode => 'LINODE',
+            DeviceType::Wasabi => 'WASABI',
+            DeviceType::Local => null,
+        };
+
+        return $prefix === null ? '' : System::getEnv("_APP_STORAGE_{$prefix}_BUCKET", '');
     }
 
     protected static function version(Document $resource): string

--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -557,8 +557,8 @@ readonly class Deployments
         $cachePath = static::cachePath($projectId, $cacheKey);
         $device = static::device($projectId);
 
-        if ($device->getType() === DeviceType::Local) {
-            return [
+        return match ($device->getType()) {
+            DeviceType::Local => [
                 'volumes' => [
                     new Volume(source: System::getEnv('_APP_BUILDS_VOLUME', 'appwrite-builds'), path: APP_STORAGE_BUILDS),
                 ],
@@ -567,30 +567,24 @@ readonly class Deployments
                     'OPEN_RUNTIMES_BUILD_OUTPUT_DIR' => static::outputDirectory($projectId, $deploymentId),
                     'OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT' => $cachePath,
                 ],
-            ];
-        }
-
-        // 'in' paths are workspace-relative.
-        $artifacts = [
-            new UploadArtifact(id: 'output', in: 'output/' . static::artifact(), out: static::objectUrl($device, static::buildPath($projectId, $deploymentId)), depends: 'job'),
-            new UploadArtifact(id: 'cache', in: "cache/{$cacheKey}.sqfs", out: static::objectUrl($device, $cachePath), depends: 'job'),
-        ];
-
-        // Pull the cache only when a previous build saved one: a failed
-        // pre-job artifact aborts the job, so an unconditional download
-        // would break every first build.
-        if ($device->exists($cachePath)) {
-            \array_unshift($artifacts, new DownloadArtifact(id: 'cachePull', in: static::objectUrl($device, $cachePath), out: "cache/{$cacheKey}.sqfs"));
-        }
-
-        return [
-            'volumes' => [],
-            'artifacts' => $artifacts,
-            'environment' => [
-                'OPEN_RUNTIMES_BUILD_OUTPUT_DIR' => '/mnt/code/output',
-                'OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT' => "/mnt/code/cache/{$cacheKey}.sqfs",
             ],
-        ];
+            default => [
+                'volumes' => [],
+                // 'in' paths are workspace-relative. Pull the cache only when
+                // a previous build saved one: a failed pre-job artifact aborts
+                // the job, so an unconditional download would break every
+                // first build.
+                'artifacts' => [
+                    ...($device->exists($cachePath) ? [new DownloadArtifact(id: 'cachePull', in: static::objectUrl($device, $cachePath), out: "cache/{$cacheKey}.sqfs")] : []),
+                    new UploadArtifact(id: 'output', in: 'output/' . static::artifact(), out: static::objectUrl($device, static::buildPath($projectId, $deploymentId)), depends: 'job'),
+                    new UploadArtifact(id: 'cache', in: "cache/{$cacheKey}.sqfs", out: static::objectUrl($device, $cachePath), depends: 'job'),
+                ],
+                'environment' => [
+                    'OPEN_RUNTIMES_BUILD_OUTPUT_DIR' => '/mnt/code/output',
+                    'OPEN_RUNTIMES_BUILD_CACHE_ARTIFACT' => "/mnt/code/cache/{$cacheKey}.sqfs",
+                ],
+            ],
+        };
     }
 
     /**

--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -432,9 +432,10 @@ readonly class Deployments
         // Two terminal callbacks: exit carries the code (fires before
         // post-job artifacts), complete confirms artifact delivery — the
         // worker joins them, so readiness holds on any storage strategy.
-        // Artifact callbacks carry the source-size stat and the site manifest.
+        // Artifact callbacks carry the source-size stat, the site manifest
+        // and the outcome of a remote device's output upload.
         $events = [CallbackEvent::Log, CallbackEvent::Exit, CallbackEvent::Complete];
-        if ($source !== null || $isSite) {
+        if ($source !== null || $isSite || $output['artifacts'] !== []) {
             $events[] = CallbackEvent::Artifact;
         }
 

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -286,6 +286,13 @@ class Jobs extends Action
             return $this->ready($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus);
         }
 
+        // On a remote builds device the sidecar delivers the artifact; a failed
+        // upload is the build's failure, with the sidecar's reason (for
+        // instance, the orchestrator lacking storage credentials) in the log.
+        if (($data['artifactId'] ?? '') === 'output' && ($data['status'] ?? '') === 'failed') {
+            return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, 'Build output upload failed: ' . ($data['error'] ?? 'unknown error'), $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
+        }
+
         if (($data['artifactId'] ?? '') !== 'sourceSize' || ($data['status'] ?? '') !== 'success') {
             return $deployment;
         }

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -27,6 +27,7 @@ use Utopia\Database\Query;
 use Utopia\Platform\Action;
 use Utopia\Queue\Message;
 use Utopia\Storage\Device;
+use Utopia\Storage\DeviceType;
 use Utopia\System\System;
 
 /**
@@ -258,7 +259,8 @@ class Jobs extends Action
     /**
      * Record a reported artifact: 'sourceSize' (remote-source builds) becomes
      * the deployment's sourceSize; 'manifest' (site builds) is the output file
-     * listing for adapter detection, saved as a marker that joins readiness.
+     * listing for adapter detection; and 'output' confirms remote delivery.
+     * Manifest and output callbacks save markers that join readiness.
      */
     protected function onArtifact(
         Database $dbForProject,
@@ -286,11 +288,21 @@ class Jobs extends Action
             return $this->ready($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus);
         }
 
-        // On a remote builds device the sidecar delivers the artifact; a failed
-        // upload is the build's failure, with the sidecar's reason (for
-        // instance, the orchestrator lacking storage credentials) in the log.
-        if (($data['artifactId'] ?? '') === 'output' && ($data['status'] ?? '') === 'failed') {
-            return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, 'Build output upload failed: ' . ($data['error'] ?? 'unknown error'), $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
+        // On a remote builds device the sidecar delivers the artifact. Join its
+        // callback explicitly because complete is emitted after artifacts but
+        // the queue can deliver those callbacks out of order.
+        if (($data['artifactId'] ?? '') === 'output') {
+            if (($data['status'] ?? '') === 'failed') {
+                return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, 'Build output upload failed: ' . ($data['error'] ?? 'unknown error'), $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
+            }
+
+            if (($data['status'] ?? '') !== 'success') {
+                return $deployment;
+            }
+
+            $cache->save('jobs-output-' . $deployment->getId(), true);
+
+            return $this->ready($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus);
         }
 
         if (($data['artifactId'] ?? '') !== 'sourceSize' || ($data['status'] ?? '') !== 'success') {
@@ -311,9 +323,9 @@ class Jobs extends Action
 
     /**
      * Failures short-circuit here — no output is needed to fail. A success
-     * needs every terminal callback: exit carries the code but fires before
-     * post-job artifacts, complete confirms delivery, and site builds also
-     * need the manifest. Each leaves a cache marker and re-attempts the join
+     * needs every terminal callback: exit carries the code, complete confirms
+     * artifact processing, remote builds need successful output delivery, and
+     * site builds also need the manifest. Each leaves a marker and retries the join
      * via ready(), so whichever lands last finalizes.
      */
     protected function onExit(
@@ -342,8 +354,9 @@ class Jobs extends Action
     }
 
     /**
-     * The delivery half of the success join — see onExit. Fires once post-job
-     * artifacts have run, so the output is already where Appwrite reads it.
+     * The artifact-processing half of the success join — see onExit. It is
+     * emitted after post-job artifacts run, but can be dequeued before their
+     * callbacks, so remote output delivery has its own marker.
      */
     protected function onComplete(
         Database $dbForProject,
@@ -392,6 +405,10 @@ class Jobs extends Action
         $isSite = $deployment->getAttribute('resourceType') === 'sites';
 
         if ($cache->load('jobs-exit-' . $deploymentId, self::DEDUPE_TTL) === false || $cache->load('jobs-complete-' . $deploymentId, self::DEDUPE_TTL) === false) {
+            return $deployment;
+        }
+
+        if ($deviceForBuilds->getType() !== DeviceType::Local && $cache->load('jobs-output-' . $deploymentId, self::DEDUPE_TTL) === false) {
             return $deployment;
         }
 

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -3,7 +3,6 @@
 namespace Appwrite\Platform\Modules\Functions\Workers;
 
 use Appwrite\Bus\Events\RuleUpdated;
-use Appwrite\Deployment\Deployments;
 use Appwrite\Deployment\Detection;
 use Appwrite\Deployment\GitAction;
 use Appwrite\Event\Event;
@@ -88,7 +87,6 @@ class Jobs extends Action
             ->inject('platform')
             ->inject('plan')
             ->inject('bus')
-            ->inject('deployments')
             ->callback($this->action(...));
     }
 
@@ -111,7 +109,6 @@ class Jobs extends Action
         array $platform,
         array $plan,
         Bus $bus,
-        Deployments $deployments,
     ): void {
         $event = JobsMessage::fromArray($message->getPayload());
 
@@ -120,7 +117,7 @@ class Jobs extends Action
             return;
         }
 
-        $locks('jobs-deployment:' . $deploymentId, self::LOCK_TTL, function () use ($event, $project, $dbForProject, $dbForPlatform, $queueForRealtime, $queueForEvents, $queueForWebhooks, $publisherForFunctions, $publisherForScreenshots, $publisherForUsage, $usage, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $deploymentId, $bus, $deployments): void {
+        $locks('jobs-deployment:' . $deploymentId, self::LOCK_TTL, function () use ($event, $project, $dbForProject, $dbForPlatform, $queueForRealtime, $queueForEvents, $queueForWebhooks, $publisherForFunctions, $publisherForScreenshots, $publisherForUsage, $usage, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $deploymentId, $bus): void {
             if ($event->id !== '') {
                 $key = 'jobs-event-' . $event->id;
                 if ($cache->load($key, self::DEDUPE_TTL) !== false) {
@@ -138,10 +135,10 @@ class Jobs extends Action
 
             $deployment = match ($event->event) {
                 'orchestrator.job.log' => $this->onLog($dbForProject, $dbForPlatform, $project, $deployment, $event->data, $vcsFactory, $platform),
-                'orchestrator.job.artifact' => $this->onArtifact($dbForProject, $dbForPlatform, $project, $deployment, $event->data, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus, $deployments),
-                'orchestrator.job.exit' => $this->onExit($dbForProject, $dbForPlatform, $project, $deployment, (int) ($event->data['exitCode'] ?? 0), $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus, $deployments),
-                'orchestrator.job.complete' => $this->onComplete($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus, $deployments),
-                default => $this->onCallback($event->event, $dbForProject, $dbForPlatform, $project, $deployment, $event->data, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus, $deployments),
+                'orchestrator.job.artifact' => $this->onArtifact($dbForProject, $dbForPlatform, $project, $deployment, $event->data, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
+                'orchestrator.job.exit' => $this->onExit($dbForProject, $dbForPlatform, $project, $deployment, (int) ($event->data['exitCode'] ?? 0), $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
+                'orchestrator.job.complete' => $this->onComplete($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
+                default => $this->onCallback($event->event, $dbForProject, $dbForPlatform, $project, $deployment, $event->data, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
             };
 
             // Console realtime on every callback (log stream + status).
@@ -229,7 +226,6 @@ class Jobs extends Action
         array $platform,
         array $plan,
         Bus $bus,
-        Deployments $deployments,
     ): Document {
         return $deployment;
     }
@@ -279,7 +275,6 @@ class Jobs extends Action
         array $platform,
         array $plan,
         Bus $bus,
-        Deployments $deployments,
     ): Document {
         if (($data['artifactId'] ?? '') === 'manifest') {
             // A failed manifest degrades to an empty listing (detection
@@ -288,7 +283,7 @@ class Jobs extends Action
             $files = \is_array($manifest) ? (array) ($manifest['files'] ?? []) : [];
             $cache->save('jobs-manifest-' . $deployment->getId(), ['files' => \array_values($files)]);
 
-            return $this->ready($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus, $deployments);
+            return $this->ready($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus);
         }
 
         if (($data['artifactId'] ?? '') !== 'sourceSize' || ($data['status'] ?? '') !== 'success') {
@@ -329,7 +324,6 @@ class Jobs extends Action
         array $platform,
         array $plan,
         Bus $bus,
-        Deployments $deployments,
     ): Document {
         if ($exitCode !== 0) {
             return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, "Build failed with exit code {$exitCode}.", $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
@@ -337,7 +331,7 @@ class Jobs extends Action
 
         $cache->save('jobs-exit-' . $deployment->getId(), true);
 
-        return $this->ready($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus, $deployments);
+        return $this->ready($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus);
     }
 
     /**
@@ -358,11 +352,10 @@ class Jobs extends Action
         array $platform,
         array $plan,
         Bus $bus,
-        Deployments $deployments,
     ): Document {
         $cache->save('jobs-complete-' . $deployment->getId(), true);
 
-        return $this->ready($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus, $deployments);
+        return $this->ready($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus);
     }
 
     /**
@@ -383,7 +376,6 @@ class Jobs extends Action
         array $platform,
         array $plan,
         Bus $bus,
-        Deployments $deployments,
     ): Document {
         if (\in_array($deployment->getAttribute('status'), ['ready', 'failed'], true)) {
             return $deployment; // already finalized
@@ -407,10 +399,6 @@ class Jobs extends Action
                 return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, $mismatch, $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
             }
         }
-
-        // The build job wrote its artifact where the storage strategy put it;
-        // bring it to buildPath before checking for it.
-        $deployments->store($deployment);
 
         $path = (string) $deployment->getAttribute('buildPath', '');
         if ($path === '' || ! $deviceForBuilds->exists($path)) {

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -1034,9 +1034,9 @@ final class FunctionsCustomServerTest extends Scope
     /**
      * The build job writes onto the builds volume while the executor and the
      * download endpoint read the deployment through the configured storage
-     * device. Runs in the `s3` CI group against MinIO, where the artifact has
-     * to be moved off the volume and keyed under the bucket; on the default
-     * local device the two are the same path.
+     * device. Runs in the `s3` CI group against MinIO, where the sidecar
+     * uploads the artifact as an s3:// object keyed under the bucket; on the
+     * default local device build.sh writes it straight to buildPath.
      */
     #[Group('s3')]
     public function testDeploymentBuildOutputIsServedFromTheBuildsDevice(): void


### PR DESCRIPTION
## Summary

Reworks #13443. That fix had the Jobs worker copy the finished build artifact off the builds volume onto the storage device in a new `Deployments::store()`, which Cloud then had to override with an empty method. One decision (where build output lands) was split across two overridable methods that had to agree.

This moves the remote branch of Cloud's storage strategy down into CE and selects it by the builds device:

- **Local device:** unchanged. The shared builds volume is mounted and `build.sh` writes straight to `buildPath`.
- **Remote device (S3 and friends):** `build.sh` writes into the job workspace and the sidecar moves output and cache over `s3://` upload/download artifacts, signed with the orchestrator's `S3_*` credentials. The job delivers the artifact; the worker only checks `buildPath` exists.
- `buildPath()` / `cachePath()` return the builds device's path via `getDevice()->getPath()`. On the local device and on a virtual-host device that is the same string as before; on a path-style store with a bucket (MinIO with `_APP_STORAGE_S3_ENDPOINT`) it is keyed under the bucket, which was the original bug.
- `objectUrl()` maps a device path to the `s3://bucket/key` URL, from the same configuration `getDevice()` reads.
- `docker-compose.yml` passes `_APP_STORAGE_S3_*` through to the orchestrator as `S3_*`. Orchestrator 1.9.2 already signs `s3://` artifacts from those, so nothing changes there.
- `store()`, the device constructor parameter, and the `Deployments` injection into the Jobs worker are removed. `Jobs.php` and both factories are back to their pre-#13443 shape.

Unlike Cloud, compression stays in `build.sh` (`_APP_COMPUTE_BUILD_COMPRESSION`); the sidecar archive step remains Cloud's own override.

## Cloud

Cloud `main` compiles and behaves the same against this branch: the constructor is back to four arguments, Cloud's `storage()` override is untouched, and `buildPath()` / `cachePath()` return identical strings on its virtual-host AWS device. The new CE helper is `objectUrl()` rather than `url()` because Cloud has a `private static url()`, which would otherwise be a fatal visibility clash. appwrite-labs/cloud#5612 becomes unnecessary; a follow-up Cloud PR drops its private `url()` in favour of `objectUrl()`.

## Verification

- `composer lint`, PHPStan on the four PHP files, `composer refactor:check` pass.
- Local stack switched to MinIO (`_APP_STORAGE_DEVICE=s3`, executor on the same bucket): the `s3` group `testDeploymentBuildOutputIsServedFromTheBuildsDevice` passes (build ready, execution completed, output and source downloaded through the device), and Sites `testCreateDeployment` passes. The cache squashfs lands under `storage/builds/app-{project}/cache/` in the bucket.
- Stack restored to the local device: the same function test passes, so the volume branch is unchanged.
- The `S3 Storage` CI group and MinIO service from #13443 stay and cover this in CI.
