### PR TITLE
feat(workers): expose queued project context

### DIFF
--- a/app/init/worker/message.php
+++ b/app/init/worker/message.php
@@ -3,6 +3,7 @@
 use Appwrite\Database\Factory as DatabaseFactory;
 use Appwrite\Deployment\Deployments;
 use Appwrite\Event\Event;
+use Appwrite\Event\Message\ProjectContext;
 use Appwrite\Event\Publisher\Func as FunctionPublisher;
 use Appwrite\Event\Publisher\Notification as NotificationPublisher;
 use Appwrite\Event\Realtime;
@@ -52,6 +53,13 @@ return function (Container $container): void {
     ), ['pools', 'cache', 'authorization']);
 
     $container->set('dbForPlatform', fn (DatabaseFactory $databaseFactory) => $databaseFactory->platform(), ['databaseFactory']);
+
+    $container->set('projectContext', function ($message) {
+        $payload = $message->getPayload() ?? [];
+        $project = $payload['project'] ?? [];
+
+        return ProjectContext::fromArray(\is_array($project) ? $project : []);
+    }, ['message']);
 
     $container->set('project', function ($message, Database $dbForPlatform) {
         $payload = $message->getPayload() ?? [];

--- a/src/Appwrite/Event/Message/Audit.php
+++ b/src/Appwrite/Event/Message/Audit.php
@@ -26,13 +26,7 @@ final class Audit extends Base
     public function toArray(): array
     {
         return [
-            'project' => [
-                '$id' => $this->project->getId(),
-                '$sequence' => $this->project->getSequence(),
-                'database' => $this->project->getAttribute('database', ''),
-                'teamId' => $this->project->getAttribute('teamId', ''),
-                'teamInternalId' => $this->project->getAttribute('teamInternalId', ''),
-            ],
+            'project' => ProjectContext::fromDocument($this->project)->toArray(),
             'user' => $this->user->getArrayCopy(),
             'impersonatorUser' => $this->impersonatorUser->getArrayCopy(),
             'payload' => $this->payload,

--- a/src/Appwrite/Event/Message/ProjectContext.php
+++ b/src/Appwrite/Event/Message/ProjectContext.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Appwrite\Event\Message;
+
+use Utopia\Database\Document;
+
+final readonly class ProjectContext
+{
+    public function __construct(
+        public string $id = '',
+        public string $sequence = '',
+        public string $teamId = '',
+        public string $teamInternalId = '',
+        public string $createdAt = '',
+        public string $region = '',
+    ) {
+    }
+
+    public static function fromDocument(Document $project): self
+    {
+        return new self(
+            id: $project->getId(),
+            sequence: (string) $project->getSequence(),
+            teamId: (string) $project->getAttribute('teamId', ''),
+            teamInternalId: (string) $project->getAttribute('teamInternalId', ''),
+            createdAt: (string) $project->getCreatedAt(),
+            region: (string) $project->getAttribute('region', ''),
+        );
+    }
+
+    public static function fromArray(array $project): self
+    {
+        return new self(
+            id: (string) ($project['$id'] ?? ''),
+            sequence: (string) ($project['$sequence'] ?? ''),
+            teamId: (string) ($project['teamId'] ?? ''),
+            teamInternalId: (string) ($project['teamInternalId'] ?? ''),
+            createdAt: (string) ($project['$createdAt'] ?? ''),
+            region: (string) ($project['region'] ?? ''),
+        );
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->id === '';
+    }
+
+    public function isConsole(): bool
+    {
+        return $this->id === 'console';
+    }
+
+    public function toArray(): array
+    {
+        return [
+            '$id' => $this->id,
+            '$sequence' => $this->sequence,
+            'teamId' => $this->teamId,
+            'teamInternalId' => $this->teamInternalId,
+            '$createdAt' => $this->createdAt,
+            'region' => $this->region,
+        ];
+    }
+}

--- a/tests/unit/Event/Message/ProjectContextTest.php
+++ b/tests/unit/Event/Message/ProjectContextTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Event\Message;
+
+use Appwrite\Event\Message\ProjectContext;
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Document;
+
+final class ProjectContextTest extends TestCase
+{
+    public function testSerializesOnlyStableWorkerContext(): void
+    {
+        $context = ProjectContext::fromDocument(new Document([
+            '$id' => 'project-id',
+            '$sequence' => '42',
+            '$createdAt' => '2026-09-03T10:00:00.000+00:00',
+            'teamId' => 'team-id',
+            'teamInternalId' => '84',
+            'region' => 'fra',
+            'database' => 'mysql://user:secret@database/project',
+            'webhooks' => [['url' => 'https://example.test']],
+        ]));
+
+        $this->assertSame([
+            '$id' => 'project-id',
+            '$sequence' => '42',
+            'teamId' => 'team-id',
+            'teamInternalId' => '84',
+            '$createdAt' => '2026-09-03T10:00:00.000+00:00',
+            'region' => 'fra',
+        ], $context->toArray());
+    }
+
+    public function testParsesLegacyPartialContext(): void
+    {
+        $context = ProjectContext::fromArray([
+            '$id' => 'project-id',
+            '$sequence' => 42,
+        ]);
+
+        $this->assertSame('project-id', $context->id);
+        $this->assertSame('42', $context->sequence);
+        $this->assertSame('', $context->teamId);
+        $this->assertSame('', $context->teamInternalId);
+        $this->assertSame('', $context->createdAt);
+        $this->assertSame('', $context->region);
+    }
+}


### PR DESCRIPTION
## What changed

- adds a typed `ProjectContext` containing stable event-time project identity and attribution
- exposes it as a zero-I/O `projectContext` worker resource
- serializes audit messages through the shared context without database routing or mutable project configuration
- leaves the existing `project` and `dbForProject` resources unchanged for workers needing current state

## Why

Queue workers currently fetch the complete project document even when they only need immutable identity fields. Making snapshot context explicit lets workers opt out safely without weakening current configuration or database-routing semantics.

## Tests

- `ProjectContextTest` (2 tests, 7 assertions)
- Pint on changed files
- PHP syntax checks on changed production files

Cloud adoption: appwrite-labs/cloud#5634.