### PR TITLE
Fix ready deployment activation reconciliation

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -385,8 +385,14 @@ class Jobs extends Action
         Bus $bus,
         Deployments $deployments,
     ): Document {
-        if (\in_array($deployment->getAttribute('status'), ['ready', 'failed'], true)) {
-            return $deployment; // already finalized
+        if ($deployment->getAttribute('status') === 'ready') {
+            $this->activateIfNeeded($dbForProject, $dbForPlatform, $project, $deployment, $bus);
+
+            return $deployment;
+        }
+
+        if ($deployment->getAttribute('status') === 'failed') {
+            return $deployment;
         }
 
         $deploymentId = $deployment->getId();
@@ -530,8 +536,8 @@ class Jobs extends Action
             $this->updateLatestDeployment($dbForProject, $resource);
         }
 
-        if ($applied > 0 && $success && $deployment->getAttribute('activate') === true && ! $resource->isEmpty()) {
-            $this->activate($dbForProject, $dbForPlatform, $project, $resource, $deployment, $bus);
+        if ($success && $deployment->getAttribute('status') === 'ready') {
+            $this->activateIfNeeded($dbForProject, $dbForPlatform, $project, $deployment, $bus, $resource);
         }
 
         if ($applied > 0 && $success && $collection === 'sites' && ! $resource->isEmpty()) {
@@ -663,6 +669,36 @@ class Jobs extends Action
             Query::equal('trigger', ['manual']),
             Query::equal('deploymentVcsProviderBranch', ['']),
         ]);
+    }
+
+    /**
+     * Reconcile auto-activation after a successful build. Terminal job
+     * callbacks can be delivered more than once, and a worker can stop after
+     * persisting `ready` but before updating the resource. Keep activation
+     * idempotent so a later callback repairs that partial outcome.
+     */
+    private function activateIfNeeded(
+        Database $dbForProject,
+        Database $dbForPlatform,
+        Document $project,
+        Document $deployment,
+        Bus $bus,
+        ?Document $resource = null,
+    ): void {
+        if ($deployment->getAttribute('activate') !== true) {
+            return;
+        }
+
+        $resource ??= $dbForProject->getDocument(
+            $deployment->getAttribute('resourceType', 'functions'),
+            $deployment->getAttribute('resourceId')
+        );
+
+        if ($resource->isEmpty() || $resource->getAttribute('deploymentId') === $deployment->getId()) {
+            return;
+        }
+
+        $this->activate($dbForProject, $dbForPlatform, $project, $resource, $deployment, $bus);
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

Ensures an auto-activated deployment cannot remain `ready` while its function or site still points at no deployment or an older deployment.

Build completion persists the terminal deployment state before activation. If activation is skipped, returns no affected rows, or the worker stops between those writes, later terminal callbacks currently return immediately because the deployment is already `ready`. This leaves execution creation returning `deployment_not_found`.

This change makes activation idempotent and reconciles it both during finalization and when a later callback observes an already-ready deployment.

## Test Plan

- Reproduced twice in appwrite-labs/cloud#5466 with `VCSGiteaConsoleClientTest::testCreateDeploymentFromGitPush`: the deployment reached `ready`, but execution creation returned 404 `deployment_not_found`.
- `php -l src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php`
- Pint check for the changed file
- `git diff --check`
- Re-run the Cloud VCS and migrations E2E shard after updating its Appwrite pin to this commit.

## Related PRs and Issues

- appwrite-labs/cloud#5466
- appwrite/appwrite#13443