### PR TITLE
Remove inferred upload type metadata from OpenAPI specs

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -257,6 +257,7 @@ class OpenAPI3 extends Format
             $consumes = [$sdk->getRequestType()->value];
 
             $methodName = $sdk->getMethodName();
+            $methodType = $sdk->getType();
 
             $desc = $sdk->getDescriptionFilePath() ?: $sdk->getDescription();
             $produces = ($sdk->getContentType())->value;
@@ -280,7 +281,7 @@ class OpenAPI3 extends Format
                 'x-appwrite' => [ // Appwrite related metadata
                     'group' => $sdk->getGroup(),
                     'cookies' => $route->getLabel('sdk.cookies', false),
-                    'type' => $sdk->getType()->value ?? '',
+                    ...($methodType !== null && $methodType !== MethodType::UPLOAD ? ['type' => $methodType->value] : []),
                     'demo' => \strtolower($namespace) . '/' . Template::fromCamelCaseToDash($methodName) . '.md',
                     'rate-limit' => $route->getLabel('abuse-limit', 0),
                     'rate-time' => $route->getLabel('abuse-time', 3600),

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -281,7 +281,7 @@ class OpenAPI3 extends Format
                 'x-appwrite' => [ // Appwrite related metadata
                     'group' => $sdk->getGroup(),
                     'cookies' => $route->getLabel('sdk.cookies', false),
-                    ...($methodType !== null && $methodType !== MethodType::UPLOAD ? ['type' => $methodType->value] : []),
+                    'type' => $methodType?->value,
                     'demo' => \strtolower($namespace) . '/' . Template::fromCamelCaseToDash($methodName) . '.md',
                     'rate-limit' => $route->getLabel('abuse-limit', 0),
                     'rate-time' => $route->getLabel('abuse-time', 3600),
@@ -292,6 +292,10 @@ class OpenAPI3 extends Format
                     'public' => $sdk->isPublic(),
                 ],
             ];
+
+            if ($methodType === null || $methodType === MethodType::UPLOAD) {
+                unset($temp['x-appwrite']['type']);
+            }
 
             if ($sdk->getDescriptionFilePath() !== null) {
                 $temp['x-appwrite']['edit'] = 'https://github.com/appwrite/appwrite/edit/master' . $sdk->getDescription();


### PR DESCRIPTION
## Summary

- stop emitting `x-appwrite.type: upload` for multipart binary operations
- stop emitting empty `x-appwrite.type` values for ordinary operations
- retain non-inferable SDK method types such as `location`, `webAuth`, and `graphql`

Upload behavior is fully described by the standard `multipart/form-data` request body and its `type: string`, `format: binary` property.

## Validation

- `composer lint src/Appwrite/SDK/Specification/Format/OpenAPI3.php`
- `vendor/bin/phpunit tests/unit/SDK/Specification/FormatTest.php`
- generated all client, server, and console `latest` OpenAPI specs
- confirmed generated specs contain no empty or `upload` method types while retaining non-inferable method types
- confirmed every multipart binary operation omits the redundant extension

Depends on appwrite/sdk-generator#1869 for consumer-side inference.

Related to [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards).
