### PR TITLE
Enforce personal data check on password recovery

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -4123,6 +4123,13 @@ Http::put('/v1/account/recovery')
             $history = array_slice($history, (count($history) - $historyLimit), $historyLimit);
         }
 
+        if ($project->getAttribute('auths', [])['personalDataCheck'] ?? false) {
+            $personalDataValidator = new PersonalData($profile->getId(), $profile->getAttribute('email'), $profile->getAttribute('name'), $profile->getAttribute('phone'));
+            if (!$personalDataValidator->isValid($password)) {
+                throw new Exception(Exception::USER_PASSWORD_PERSONAL_DATA);
+            }
+        }
+
         $hooks->trigger('passwordValidator', [$dbForProject, $project, $password, &$user, true]);
 
         $sessions = $profile->getAttribute('sessions', []);

--- a/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
+++ b/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
@@ -3572,6 +3572,54 @@ final class ProjectsConsoleClientTest extends Scope
 
         $this->assertEquals(201, $response['headers']['status-code']);
 
+        /**
+         * Setup password recovery for the personal data check on account/recovery
+         */
+        $response = $this->client->call(Client::METHOD_POST, '/account/recovery', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $id,
+        ]), [
+            'email' => $email,
+            'url' => 'http://localhost/recovery',
+        ]);
+
+        $this->assertEquals(201, $response['headers']['status-code']);
+
+        $lastEmail = $this->getLastEmailByAddress($email, function ($email) {
+            $this->assertStringContainsString('Password Reset', (string) $email['subject']);
+        });
+        $tokens = $this->extractQueryParamsFromEmailLink($lastEmail['html']);
+
+        /**
+         * Test for failure
+         */
+        $response = $this->client->call(Client::METHOD_PUT, '/account/recovery', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $id,
+        ]), [
+            'userId' => $userId,
+            'secret' => $tokens['secret'],
+            'password' => $phone,
+        ]);
+
+        $this->assertEquals(400, $response['headers']['status-code']);
+        $this->assertEquals(400, $response['body']['code']);
+        $this->assertEquals(Exception::USER_PASSWORD_PERSONAL_DATA, $response['body']['type']);
+
+        /** Test for success */
+        $response = $this->client->call(Client::METHOD_PUT, '/account/recovery', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $id,
+        ]), [
+            'userId' => $userId,
+            'secret' => $tokens['secret'],
+            'password' => 'not-personal-data',
+        ]);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
 
         /**
          * Reset


### PR DESCRIPTION
## Summary
- `PUT /v1/account/recovery` (the password-recovery confirmation endpoint) never ran the `personalDataCheck` validation, unlike account creation, `PATCH /v1/account/password`, and `PATCH /v1/users/:userId/password`, which all already enforce it.
- With a project's "Disallow Personal Data in Passwords" setting enabled, a user could still set a recovered password containing their email, name, or phone number through this endpoint (e.g. via the Flutter SDK's recovery flow), even though the same password would be rejected by the other password-update endpoints.
- Added the same `PersonalData` validator call used by the sibling endpoints, placed before the new password is hashed and persisted.

Fixes #8658

## Test plan
- [x] Added a regression test in `ProjectsConsoleClientTest::testUpdateDisallowPersonalData` that enables `personalDataCheck`, requests a recovery email for an existing user, and asserts:
  - Submitting a recovery password containing the user's phone number returns `400` with `USER_PASSWORD_PERSONAL_DATA`.
  - Submitting a safe password on the same recovery token succeeds with `200`.
- [x] `docker compose exec appwrite test tests/e2e/Services/Projects --filter=testUpdateDisallowPersonalData` — ran locally, passes.
