### PR TITLE
chore: bump console to 1.1.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -267,7 +267,7 @@ services:
         max-file: "5"
         max-size: 10m
     container_name: appwrite-console
-    image: appwrite/new:0.6.1
+    image: appwrite/new:1.1.8
     restart: unless-stopped
     networks:
       - appwrite


### PR DESCRIPTION
Release metadata for `2.0.0-rc.3`.

`docker-compose.yml` pinned the console to `appwrite/new:0.6.1`, which on a self-hosted install renders the cloud Region/Edge picker and `appwrite.network` domains in function create, and reloads over-eagerly on stale chunks.

`1.1.8` fixes those, keeps pre-launch mode off so `/init` does not lock a self-hosted install behind the marketing page, and carries the secure-context UUID fix from appwrite/vibes#248.

## Why the UUID fix matters here

`crypto.randomUUID` is only exposed in a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts). Served over plain HTTP on anything that isn't literally `localhost` / `127.0.0.1` / `::1` it is `undefined`, and the console's CLI-shell provider called it from a `useState` initializer — so it threw on first render and the error boundary replaced **every** `/projects/...` page with a full-page error.

Our own installer explicitly provisions that setup: HTTPS is off for loopback, `.local`, `.internal` and bare IPs. So a stock self-hosted install on a LAN IP or internal hostname had a console that could not open a single project. Reported against 2.0.0-rc.2.

## Test Plan

Verified against the **published** `appwrite/new:1.1.8` image on a local 2.0.0 stack.

Image contents:

```
src/lib/random-uuid.ts:                  present
files importing it:                           17
bare crypto.randomUUID in src/:                0
```

Over `http://appwrite.test` — a genuinely insecure origin, confirmed in-page:

```
isSecureContext: false
crypto.randomUUID: undefined     crypto.subtle: undefined
```

- Organizations page loads and the org is reachable — covers `fix(organizations): keep every organization reachable on single-tenant profiles`, which landed between 1.1.5 and 1.1.8.
- Project dashboard renders fully, 0 console errors.
- Swept functions, storage, auth, messaging, sites, settings, realtime, usage — no error boundary on any.
- Function detail page renders with its active deployment.
- The only console errors are 404s on `/v1/console/plans` and `/v1/avatars/favicon` — cloud-only endpoints, expected on self-hosted, unrelated.

On `http://localhost` (secure context, where the bug never reproduced): fresh signup, project creation, no Region/Edge picker, domain suffix `.functions.localhost`, and a Node template function built in 5s and executed `Completed` / `200` / 733ms.