### PR TITLE
docs: describe what APP_CACHE_BUSTER actually does

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,11 +303,13 @@ Preview builds set the flag on **both** the `specs` and `sdks` steps in `.github
 When bumping a patch (e.g. `1.9.0` → `1.9.1`):
 
 - [`docker-compose.yml`](docker-compose.yml) — `appwrite-console` image tag (`appwrite/new:X.Y.Z`)
-- [`app/init/constants.php`](app/init/constants.php) — set `APP_VERSION_STABLE`; increment `APP_CACHE_BUSTER` by 1
+- [`app/init/constants.php`](app/init/constants.php) — set `APP_VERSION_STABLE`
 - [`README.md`](README.md) and [`README-CN.md`](README-CN.md) — `appwrite/appwrite:X.Y.Z` in all three install blocks each
 - [`src/Appwrite/Migration/Migration.php`](src/Appwrite/Migration/Migration.php) — add the version to `$versions`, mapping to a new migration class or the same class as the previous version
 
 Ask the user to review, publish notes on the [Appwrite changelog](https://appwrite.io/changelog), generate specs if the API changed, and add request/response filters if needed.
+
+`APP_CACHE_BUSTER` is not a version number and does not track releases. It salts the response cache key in [`Request::cacheIdentifier()`](src/Appwrite/Utopia/Request.php) for the routes labelled `cache` (file preview, avatars). Bump it only when cached output would now be wrong — a changed image pipeline or new bundled avatar assets — since every bump orphans every entry and regenerates them.
 
 ### Self-hosted RC / final
 
@@ -317,6 +319,6 @@ A release is not ready until a **fresh install** and an **upgrade from the previ
 
 **Upgrade:** install the previous stable image, seed broad data (empty values, long strings, relationships, mixed permissions), keep volumes, switch to the target image, run migrate. Migration must complete, be idempotent, and preserve seeded data through public API reads/writes.
 
-**Metadata:** `APP_VERSION_STABLE` / `APP_CACHE_BUSTER`; Appwrite and console tags in `docker-compose.yml` and [`app/views/install/compose.phtml`](app/views/install/compose.phtml); README install snippets; `Migration.php` `$versions`; [changelog](https://appwrite.io/changelog). For public API breaks: request filters in `src/Appwrite/Utopia/Request/Filters/V*.php`, response filters in `src/Appwrite/Utopia/Response/Filters/V*.php`, registered in [`app/controllers/general.php`](app/controllers/general.php) for `x-appwrite-response-format`. Unit-test filters under `tests/unit/Utopia/{Request,Response}/Filters`; add e2e with that header when routing, auth, or persistence is involved.
+**Metadata:** `APP_VERSION_STABLE`; Appwrite and console tags in `docker-compose.yml` and [`app/views/install/compose.phtml`](app/views/install/compose.phtml); README install snippets; `Migration.php` `$versions`; [changelog](https://appwrite.io/changelog). For public API breaks: request filters in `src/Appwrite/Utopia/Request/Filters/V*.php`, response filters in `src/Appwrite/Utopia/Response/Filters/V*.php`, registered in [`app/controllers/general.php`](app/controllers/general.php) for `x-appwrite-response-format`. Unit-test filters under `tests/unit/Utopia/{Request,Response}/Filters`; add e2e with that header when routing, auth, or persistence is involved.
 
 Do not approve an RC/final until both gates pass, metadata matches the target, and unintended public breaks have filters (or the owner documents the break on the changelog).


### PR DESCRIPTION
## What does this PR do?

The release checklist said to `increment APP_CACHE_BUSTER by 1` on every patch, and listed it alongside `APP_VERSION_STABLE` as metadata that must match the target version. It is not a version number and does not track releases.

Its only consumer is the md5 in [`Request::cacheIdentifier()`](src/Appwrite/Utopia/Request.php), which keys the server-side response cache for the seven routes labelled `cache` — file preview and the avatars endpoints. Changing it changes every key at once, so every entry is orphaned and every image transform and screenshot regenerates. That is worth doing only when the cached bytes would now be wrong.

Practice already disagreed with the docs: `1.9.6` → `2.0.0` deliberately kept `4327` in 98f425f3, because 2.0 changes no cached response shape. This makes the docs match.

Docs only, no behaviour change.