### PR TITLE
fix(usage): route document delete op metric per database type

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Delete.php
@@ -219,7 +219,7 @@ class Delete extends Action
         $usage
             ->setResource('database')
             ->setResourceInternalId((string) $database->getSequence())
-            ->addMetric(METRIC_DATABASES_OPERATIONS_WRITES, 1);
+            ->addMetric($this->getDatabasesOperationWriteMetric(), 1);
 
         $response->addHeader('X-Debug-Operations', 1);
 


### PR DESCRIPTION
The bug would add billing to the tablesDB meter and not the vectorsDB.

### Problem

Single-document delete (`.../Databases/Collections/Documents/Delete.php`) hardcoded the base billable metric `databases.operations.writes`:

```php
->addMetric(METRIC_DATABASES_OPERATIONS_WRITES, 1);
```

Every other document write action (create, update, upsert, bulk update/upsert/delete, increment, decrement) routes through `getDatabasesOperationWriteMetric()`, which picks the metric key by database type — `databases.operations.writes` for legacy/tablesDB, but `documentsdb.databases.operations.writes` / `vectorsdb.databases.operations.writes` for those products. Delete was the lone straggler.

As a result, a delete against a **documentsdb/vectorsdb** database landed in the shared, project-wide `databasesWrites` billing meter (the one with a plan base limit + overage) — the meter that legacy/tablesDB feed. For a **dedicated** vectorsdb/documentsdb — already billed separately as reserved compute (`dedicatedDatabases.compute`) — the same delete was counted twice: once as compute (correct), once as `databasesWrites` overage (spurious). Because that meter is shared across the whole project, the leak also consumed legitimate legacy/tablesDB write quota, pulling unrelated usage into overage sooner.

### Fix

```php
->addMetric($this->getDatabasesOperationWriteMetric(), 1);
```

One line: delete now routes exactly like every other write action.

### How billing is *not* impacted (by design)

The two billing tracks are independent and stay independent:

| Track | Fed by | Affected by this change? |
|---|---|---|
| Per-op meter `databasesReads`/`databasesWrites` (base limit + overage) | **only** `databases.operations.reads`/`writes` | see below |
| Dedicated compute | `dedicatedDatabases.compute\|storage\|inbound\|outbound` (pushed from edge via the manager endpoint) | **No** — never depended on the op metric |

- **Legacy / tablesDB** — `getDatabasesOperationWriteMetric()` returns `databases.operations.writes` for these types, so the emitted key is **byte-for-byte identical** to before. Their billing is unchanged.
- **documentsdb / vectorsdb** — deletes now emit the per-type key (`vectorsdb.databases.operations.writes`), which the cloud billing aggregator (`ProjectAggregation::getDatabasesOperations()`) does **not** sum into `databasesWrites`. This is consistent with how creates/updates/upserts on these types have always been recorded — delete now matches them.
- **Dedicated compute charge** is untouched: it is billed from the `dedicatedDatabases.*` metrics, not from any `*.operations.*` key.

Net effect: legacy/tablesDB billing is bit-identical; documentsdb/vectorsdb deletes stop polluting the shared `databasesWrites` meter, removing the double-charge and the cross-product quota leak. No plan config, aggregation, or pricing changes required.

### Testing note

There is no unit test asserting the emitted metric key per database type on the delete path — that seam runs through the request `Context` → StatsUsage worker. A regression test could drive `DELETE /v1/vectorsdb/:id/collections/:id/documents/:id` and assert the recorded metric is `vectorsdb.databases.operations.writes`, not `databases.operations.writes`.
