### PR TITLE
Remove PostgreSQL durability-disabling flags from the shipped compose template

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1836,12 +1836,6 @@ services:
       start_period: 10s
     command:
       - postgres
-      - -c
-      - fsync=off
-      - -c
-      - synchronous_commit=off
-      - -c
-      - full_page_writes=off
   appwrite-embedding:
     image: appwrite/embedding:0.1.0
     environment:

--- a/tests/unit/Docker/Compose/GeneratorTest.php
+++ b/tests/unit/Docker/Compose/GeneratorTest.php
@@ -149,15 +149,7 @@ final class GeneratorTest extends TestCase
         ]);
 
         $this->assertSame(['mysqld', '--innodb-flush-method=fsync'], $mariadb['services']['mariadb']['command']);
-        $this->assertSame([
-            'postgres',
-            '-c',
-            'fsync=off',
-            '-c',
-            'synchronous_commit=off',
-            '-c',
-            'full_page_writes=off',
-        ], $postgresql['services']['postgresql']['command']);
+        $this->assertSame(['postgres'], $postgresql['services']['postgresql']['command']);
         $this->assertSame([
             'redis-server',
             '--maxmemory',


### PR DESCRIPTION
## Problem

The `postgresql` service in `docker-compose.yml` starts PostgreSQL with three settings that turn off its crash-safety guarantees:

```yaml
command:
  - postgres
  - -c
  - fsync=off
  - -c
  - synchronous_commit=off
  - -c
  - full_page_writes=off
```

- `fsync=off`: PostgreSQL no longer forces WAL and data files to disk. After an OS crash or power loss the cluster can be left in an unrecoverable, corrupted state.
- `full_page_writes=off`: the first modification of a page after a checkpoint is no longer written in full to the WAL, so a crash mid-write can leave torn pages that crash recovery cannot repair.
- `synchronous_commit=off`: a transaction is reported as committed before its WAL record is on disk, so a crash can lose the most recent committed transactions.

These are reasonable for throwaway CI databases. They are not appropriate for the compose file a self-hoster runs in production.

## Evidence path from this file to a user's install

`docker-compose.yml` is not only the local dev file. It is the template the installer ships and renders for self-hosted installs:

1. `Dockerfile` line 45: `COPY ./docker-compose.yml /usr/local/share/appwrite/docker-compose.yml`
2. `src/Appwrite/Platform/Tasks/Install.php` lines 555-560 read that file and hand it to `Appwrite\Docker\Compose\Generator`
3. `src/Appwrite/Docker/Compose/Generator::render()` selects the database service and volumes and rewrites `depends_on` and bind mounts, but never touches a service's `command`, so the flags pass through verbatim
4. `_APP_DB_ADAPTER` defaults to `postgresql` (`Install.php` line 562, `Generator::PARAM_DEFAULTS`), so this is the database most 2.0 installs land on

The result is that a default `appwrite/appwrite:2.0.0` install runs PostgreSQL with durability off.

## How this happened

- `2c0c62f297` ("chore: inline postgres durability flags into docker-compose.yml") moved the flags from the CI-only `docker-compose.ci-postgres.yml` into the base `docker-compose.yml`. At that point `docker-compose.yml` was only the dev/CI file, and the installer rendered its own template from `app/views/install/compose.phtml`, which used `command: "postgres"` with no flags.
- `ed6d4c1e1f` ("Generate installer compose from base compose") deleted `compose.phtml` and made the installer generate from `docker-compose.yml`. From that commit on, the flags reached self-hosters.

## Fix

Remove the three `-c <setting>` pairs, leaving `command: [postgres]`. This matches what the old installer template shipped and what the `appwrite/postgres:0.1.0` image runs on its own (`Entrypoint=["docker-entrypoint.sh"]`, `Cmd=["postgres"]`), so the container starts exactly as before apart from the three durability settings returning to their PostgreSQL defaults (`fsync=on`, `synchronous_commit=on`, `full_page_writes=on`).

I kept the `command:` key rather than dropping it entirely. It is the smaller diff, it keeps the invocation explicit instead of depending on the image's `Cmd`, and it keeps `GeneratorTest::testKeepsLongCommandsReadable` covering the postgres service. That test asserted the full flag list, so it is updated to assert `['postgres']`.

## Out of scope

- `mariadb`'s `--innodb-flush-method=fsync` is left as is. `fsync` is the safe flush method, not a durability-off setting.
- `docker-compose.override.yml` is unchanged. CI runs with `COMPOSE_FILE: docker-compose.yml:docker-compose.override.yml` (`.github/workflows/ci.yml` line 8), and the override only adds a port mapping for `postgresql` (lines 536-538), so CI has been inheriting these flags from the base file. If the CI speedup is still wanted, the override is the right place to put the flags back, since it is never shipped. I have not done that here so that this PR stays limited to the correctness fix.

## Verification

- `docker-compose.yml` still parses; `docker compose -f docker-compose.yml --profile postgresql config` resolves the `postgresql` command to `['postgres']` and leaves `mariadb` at `['mysqld', '--innodb-flush-method=fsync']`.
- The `postgresql` service keeps its `image`, `container_name`, `logging`, `networks`, `volumes`, `environment`, and `healthcheck` unchanged; only the six `command` list entries are removed.
- `tests/unit/Docker/Compose/GeneratorTest.php` passes (10 tests, 72 assertions) against the updated file.
