### PR TITLE
perf(stats): use queued project context

### DIFF
--- a/src/Appwrite/Platform/Workers/StatsUsage.php
+++ b/src/Appwrite/Platform/Workers/StatsUsage.php
@@ -3,9 +3,9 @@
 namespace Appwrite\Platform\Workers;
 
 use Appwrite\Detector\Detector;
+use Appwrite\Event\Message\ProjectContext;
 use Appwrite\Usage\Connection;
 use Utopia\Console;
-use Utopia\Database\Document;
 use Utopia\Platform\Action;
 use Utopia\Queue\Message;
 use Utopia\Usage\Accumulator;
@@ -30,12 +30,12 @@ class StatsUsage extends Action
         $this
             ->desc('Stats usage worker')
             ->inject('message')
-            ->inject('project')
+            ->inject('projectContext')
             ->inject('usageConnection')
             ->callback($this->action(...));
     }
 
-    public function action(Message $message, Document $project, Connection $usageConnection): void
+    public function action(Message $message, ProjectContext $projectContext, Connection $usageConnection): void
     {
         if (!$usageConnection->isEnabled()) {
             return;
@@ -49,11 +49,11 @@ class StatsUsage extends Action
             throw new \RuntimeException('Missing payload');
         }
 
-        if ((string) ($payload['project']['$id'] ?? '') !== $project->getId()) {
+        if ((string) ($payload['project']['$id'] ?? '') !== $projectContext->id) {
             throw new \RuntimeException('Usage payload project does not match resolved project');
         }
 
-        $tenant = (string) $project->getSequence();
+        $tenant = $projectContext->sequence;
         if ($tenant === '') {
             Console::warning('Skipping usage event write: project has no sequence');
             return;


### PR DESCRIPTION
## What changed

- inject the typed `ProjectContext` into the stats-usage worker instead of resolving the current project document
- retain the queued payload/context project ID consistency check
- use the queued project sequence as the usage tenant

## Why

Usage is event-time data. Resolving the mutable platform project for every queued usage message adds a platform database/cache read and can discard attribution when a project is deleted before its already-enqueued usage is consumed. The message already carries the immutable identity needed by this worker.

Cloud has a separate batched stats-usage implementation that already consumes the queued project payload without resolving the platform project. This change optimizes the CE worker path.

## Verification

- `php -l src/Appwrite/Platform/Workers/StatsUsage.php`
- Pint on `src/Appwrite/Platform/Workers/StatsUsage.php`
- PHPStan on `src/Appwrite/Platform/Workers/StatsUsage.php`

No worker unit test was added because this repository requires worker behavior to be covered through E2E rather than unit-testing action internals; this dependency-only change has no dedicated stats-usage E2E seam.