### PR TITLE
chore: bump console to 1.1.16 and embedding to 0.3.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -267,7 +267,7 @@ services:
         max-file: "5"
         max-size: 10m
     container_name: appwrite-console
-    image: appwrite/new:1.1.8
+    image: appwrite/new:1.1.16
     restart: unless-stopped
     networks:
       - appwrite
@@ -1828,7 +1828,7 @@ services:
     command:
       - postgres
   appwrite-embedding:
-    image: appwrite/embedding:0.1.0
+    image: appwrite/embedding:0.3.1
     profiles:
       - embedding
     environment:


### PR DESCRIPTION
## What does this PR do?

Bumps the self-hosted console image from `appwrite/new:1.1.8` to `1.1.16` and the opt-in embedding service from `appwrite/embedding:0.1.0` to `0.3.1`.

**Console 1.1.16** ([release](https://github.com/appwrite/vibes/releases/tag/1.1.16)): hides the organization Domains page on self-hosted installs (appwrite/vibes#262).

**Embedding 0.3.1** ([release](https://github.com/appwrite/embedding/releases/tag/0.3.1)), cumulative since 0.1.0: configurable `EMBEDDING_PORT` (default still 3000, so `_APP_EMBEDDING_ENDPOINT` is unchanged), a health endpoint, and a model pool sized from the cgroup memory limit so the container no longer OOMs under a memory cap.

## Test Plan

Verified locally against a running 2.0.0 stack, see the test report comment below.


## Related PRs and Issues

- appwrite/vibes#262
- appwrite/embedding#6

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
