### PR TITLE
Remove x-appwrite.type from OpenAPI specifications

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -280,7 +280,6 @@ class OpenAPI3 extends Format
                 'x-appwrite' => [ // Appwrite related metadata
                     'group' => $sdk->getGroup(),
                     'cookies' => $route->getLabel('sdk.cookies', false),
-                    'type' => $sdk->getType()->value ?? '',
                     'demo' => \strtolower($namespace) . '/' . Template::fromCamelCaseToDash($methodName) . '.md',
                     'rate-limit' => $route->getLabel('abuse-limit', 0),
                     'rate-time' => $route->getLabel('abuse-time', 3600),


### PR DESCRIPTION
## What does this PR do?

Stops emitting `x-appwrite.type` from generated OpenAPI 3 specifications. SDK Generator now infers upload, binary response, web-authentication, and GraphQL behavior exclusively from standard OpenAPI fields.

This removes the final producer dependency on the custom method-type extension.

Depends on the merged [appwrite/sdk-generator#1871](https://github.com/appwrite/sdk-generator/pull/1871).

Related to [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards).

## Validation

- `composer lint src/Appwrite/SDK/Specification/Format/OpenAPI3.php`
- generated latest client, server, and console OpenAPI 3 specifications
- confirmed no generated operation contains `x-appwrite.type`
- confirmed generated specifications are byte-structure equivalent after removing only `x-appwrite.type` from the baseline:
  - client: 152 fields removed, 17 non-empty
  - server: 563 fields removed, 20 non-empty
  - console: 621 fields removed, 21 non-empty