### PR TITLE
Publish audits and usage in the background

### DIFF
--- a/app/cli.php
+++ b/app/cli.php
@@ -199,8 +199,8 @@ $container->set('bus', function (Registry $register) use ($container) {
 $exitCode = 0;
 
 $cli->init()->action(function () use ($container): void {
-    $container->get('backgroundPublisherForAudits');
-    $container->get('backgroundPublisherForUsage');
+    $container->get('publisherForAudits')->start();
+    $container->get('publisherForUsage')->start();
 });
 
 $cli
@@ -215,14 +215,14 @@ $cli
         ]);
 
         $exitCode = 1;
-        $container->get('backgroundPublisherForAudits')->shutdown();
-        $container->get('backgroundPublisherForUsage')->shutdown();
+        $container->get('publisherForAudits')->shutdown();
+        $container->get('publisherForUsage')->shutdown();
         Timer::clearAll();
     });
 
 $cli->shutdown()->action(function () use ($container): void {
-    $container->get('backgroundPublisherForAudits')->shutdown();
-    $container->get('backgroundPublisherForUsage')->shutdown();
+    $container->get('publisherForAudits')->shutdown();
+    $container->get('publisherForUsage')->shutdown();
     Timer::clearAll();
 });
 

--- a/app/cli.php
+++ b/app/cli.php
@@ -198,11 +198,16 @@ $container->set('bus', function (Registry $register) use ($container) {
 
 $exitCode = 0;
 
+$cli->init()->action(function () use ($container): void {
+    $container->get('backgroundPublisherForAudits');
+    $container->get('backgroundPublisherForUsage');
+});
+
 $cli
     ->error()
     ->inject('error')
     ->inject('logError')
-    ->action(function (Throwable $error, callable $logError) use ($taskName, &$exitCode) {
+    ->action(function (Throwable $error, callable $logError) use ($taskName, &$exitCode, $container) {
         call_user_func_array($logError, [
             $error,
             'Task',
@@ -210,10 +215,16 @@ $cli
         ]);
 
         $exitCode = 1;
+        $container->get('backgroundPublisherForAudits')->shutdown();
+        $container->get('backgroundPublisherForUsage')->shutdown();
         Timer::clearAll();
     });
 
-$cli->shutdown()->action(fn () => Timer::clearAll());
+$cli->shutdown()->action(function () use ($container): void {
+    $container->get('backgroundPublisherForAudits')->shutdown();
+    $container->get('backgroundPublisherForUsage')->shutdown();
+    Timer::clearAll();
+});
 
 Runtime::enableCoroutine(SWOOLE_HOOK_ALL);
 require_once __DIR__ . '/init/span.php';

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -556,7 +556,7 @@ Http::delete('/v1/account')
 
         $dbForProject->deleteDocument('users', $targetUser->getId());
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $project,
             type: DELETE_TYPE_DOCUMENT,
             document: $targetUser,
@@ -679,7 +679,7 @@ Http::delete('/v1/account/sessions')
                 $queueForEvents
                     ->setPayload($response->output($session, Response::MODEL_SESSION));
 
-                $publisherForDeletes->enqueue(new DeleteMessage(
+                $publisherForDeletes->publish(new DeleteMessage(
                     project: $queueForEvents->getProject(),
                     type: DELETE_TYPE_SESSION_TARGETS,
                     document: $session,
@@ -827,7 +827,7 @@ Http::delete('/v1/account/sessions/:sessionId')
                 ->setParam('sessionId', $session->getId())
                 ->setPayload($response->output($session, Response::MODEL_SESSION));
 
-            $publisherForDeletes->enqueue(new DeleteMessage(
+            $publisherForDeletes->publish(new DeleteMessage(
                 project: $queueForEvents->getProject(),
                 type: DELETE_TYPE_SESSION_TARGETS,
                 document: $session,
@@ -2605,7 +2605,7 @@ Http::post('/v1/account/tokens/magic-url')
             'team' => '',
         ];
 
-        $publisherForMails->enqueue(new MailMessage(
+        $publisherForMails->publish(new MailMessage(
             project: $project,
             recipient: $email,
             subject: $subject,
@@ -2953,7 +2953,7 @@ Http::post('/v1/account/tokens/email')
             ]);
         }
 
-        $publisherForMails->enqueue(new MailMessage(
+        $publisherForMails->publish(new MailMessage(
             project: $project,
             recipient: $email,
             subject: $subject,
@@ -3256,7 +3256,7 @@ Http::post('/v1/account/tokens/phone')
                 ],
             ]);
 
-            $publisherForMessaging->enqueue(new MessagingMessage(
+            $publisherForMessaging->publish(new MessagingMessage(
                 type: MESSAGE_SEND_TYPE_INTERNAL,
                 project: $project,
                 message: $messageDoc,
@@ -4022,7 +4022,7 @@ Http::post('/v1/account/recovery')
             ];
         }
 
-        $publisherForMails->enqueue(new MailMessage(
+        $publisherForMails->publish(new MailMessage(
             project: $project,
             recipient: $profile->getAttribute('email', ''),
             name: $profile->getAttribute('name', ''),
@@ -4378,7 +4378,7 @@ Http::post('/v1/account/verifications/email')
             ]);
         }
 
-        $publisherForMails->enqueue(new MailMessage(
+        $publisherForMails->publish(new MailMessage(
             project: $project,
             recipient: $user->getAttribute('email'),
             name: $user->getAttribute('name') ?? '',
@@ -4602,7 +4602,7 @@ Http::post('/v1/account/verifications/phone')
                 ],
             ]);
 
-            $publisherForMessaging->enqueue(new MessagingMessage(
+            $publisherForMessaging->publish(new MessagingMessage(
                 type: MESSAGE_SEND_TYPE_INTERNAL,
                 project: $project,
                 message: $messageDoc,
@@ -4895,7 +4895,7 @@ Http::delete('/v1/account/targets/:targetId/push')
 
         $dbForProject->purgeCachedDocument('users', $user->getId());
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $queueForEvents->getProject(),
             type: DELETE_TYPE_TARGET,
             document: $target,

--- a/app/controllers/api/messaging.php
+++ b/app/controllers/api/messaging.php
@@ -2792,7 +2792,7 @@ Http::delete('/v1/messaging/topics/:topicId')
 
         $dbForProject->deleteDocument('topics', $topicId);
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $queueForEvents->getProject(),
             type: DELETE_TYPE_TOPIC,
             document: $topic,
@@ -3238,7 +3238,7 @@ Http::post('/v1/messaging/messages/email')
 
         switch ($status) {
             case MessageStatus::PROCESSING:
-                $publisherForMessaging->enqueue(new MessagingMessage(
+                $publisherForMessaging->publish(new MessagingMessage(
                     type: MESSAGE_SEND_TYPE_EXTERNAL,
                     project: $project,
                     messageId: $message->getId(),
@@ -3385,7 +3385,7 @@ Http::post('/v1/messaging/messages/sms')
 
         switch ($status) {
             case MessageStatus::PROCESSING:
-                $publisherForMessaging->enqueue(new MessagingMessage(
+                $publisherForMessaging->publish(new MessagingMessage(
                     type: MESSAGE_SEND_TYPE_EXTERNAL,
                     project: $project,
                     messageId: $message->getId(),
@@ -3610,7 +3610,7 @@ Http::post('/v1/messaging/messages/push')
 
         switch ($status) {
             case MessageStatus::PROCESSING:
-                $publisherForMessaging->enqueue(new MessagingMessage(
+                $publisherForMessaging->publish(new MessagingMessage(
                     type: MESSAGE_SEND_TYPE_EXTERNAL,
                     project: $project,
                     messageId: $message->getId(),
@@ -4020,7 +4020,7 @@ Http::patch('/v1/messaging/messages/email/:messageId')
         $message = $dbForProject->updateDocument('messages', $message->getId(), $message);
 
         if ($status === MessageStatus::PROCESSING) {
-            $publisherForMessaging->enqueue(new MessagingMessage(
+            $publisherForMessaging->publish(new MessagingMessage(
                 type: MESSAGE_SEND_TYPE_EXTERNAL,
                 project: $project,
                 messageId: $message->getId(),
@@ -4206,7 +4206,7 @@ Http::patch('/v1/messaging/messages/sms/:messageId')
         $message = $dbForProject->updateDocument('messages', $message->getId(), $message);
 
         if ($status === MessageStatus::PROCESSING) {
-            $publisherForMessaging->enqueue(new MessagingMessage(
+            $publisherForMessaging->publish(new MessagingMessage(
                 type: MESSAGE_SEND_TYPE_EXTERNAL,
                 project: $project,
                 messageId: $message->getId(),
@@ -4473,7 +4473,7 @@ Http::patch('/v1/messaging/messages/push/:messageId')
         $message = $dbForProject->updateDocument('messages', $message->getId(), $message);
 
         if ($status === MessageStatus::PROCESSING) {
-            $publisherForMessaging->enqueue(new MessagingMessage(
+            $publisherForMessaging->publish(new MessagingMessage(
                 type: MESSAGE_SEND_TYPE_EXTERNAL,
                 project: $project,
                 messageId: $message->getId(),

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -796,7 +796,7 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
                 ? RESOURCE_TYPE_FUNCTIONS
                 : RESOURCE_TYPE_SITES;
 
-            $publisherForDeletes->enqueue(new DeleteMessage(
+            $publisherForDeletes->publish(new DeleteMessage(
                 project: $project,
                 type: DELETE_TYPE_EXECUTIONS_LIMIT,
                 resource: (string) $resource->getSequence(),
@@ -1189,7 +1189,7 @@ Http::init()
                $bus->dispatch(new RuleCreated($document->getArrayCopy()));
 
                Console::info('Issuing a TLS certificate for the main domain (' . $domain->get() . ') in a few seconds...');
-               $publisherForCertificates->enqueue(new \Appwrite\Event\Message\Certificate(
+               $publisherForCertificates->publish(new \Appwrite\Event\Message\Certificate(
                    project: $console,
                    domain: $document,
                    skipRenewCheck: true,

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -897,7 +897,7 @@ Http::shutdown()
         if (! empty($functionsEvents)) {
             foreach ($generatedEvents as $event) {
                 if (isset($functionsEvents[$event])) {
-                    $publisherForFunctions->enqueue(FunctionMessage::fromEvent(
+                    $publisherForFunctions->publish(FunctionMessage::fromEvent(
                         event: $queueForEvents->getEvent(),
                         params: $queueForEvents->getParams(),
                         project: $queueForEvents->getProject(),

--- a/app/http.php
+++ b/app/http.php
@@ -67,8 +67,8 @@ $http = $swoole->getServer();
 
 $http->on(Constant::EVENT_WORKER_START, function ($server, $workerId) use ($swoole) {
     Coroutine::create(function () use ($swoole): void {
-        $swoole->resources()->get('backgroundPublisherForAudits');
-        $swoole->resources()->get('backgroundPublisherForUsage');
+        $swoole->resources()->get('publisherForAudits')->start();
+        $swoole->resources()->get('publisherForUsage')->start();
     });
 });
 
@@ -76,8 +76,8 @@ $http->on(Constant::EVENT_WORKER_STOP, function ($server, $workerId) use ($swool
     Timer::clearAll();
 
     Coroutine::create(function () use ($swoole): void {
-        $swoole->resources()->get('backgroundPublisherForAudits')->shutdown();
-        $swoole->resources()->get('backgroundPublisherForUsage')->shutdown();
+        $swoole->resources()->get('publisherForAudits')->shutdown();
+        $swoole->resources()->get('publisherForUsage')->shutdown();
     });
 
     Console::success('Worker ' . ++$workerId . ' stopped successfully');

--- a/app/http.php
+++ b/app/http.php
@@ -9,6 +9,7 @@ use Appwrite\Geo\Geo;
 use Appwrite\Utopia\Request;
 use Appwrite\Utopia\Response;
 use Swoole\Constant;
+use Swoole\Coroutine;
 use Swoole\Process;
 use Swoole\Table;
 use Swoole\Timer;
@@ -64,11 +65,21 @@ $swoole = new Server(
 
 $http = $swoole->getServer();
 
-$http->on(Constant::EVENT_WORKER_START, function ($server, $workerId) {
+$http->on(Constant::EVENT_WORKER_START, function ($server, $workerId) use ($swoole) {
+    Coroutine::create(function () use ($swoole): void {
+        $swoole->resources()->get('backgroundPublisherForAudits');
+        $swoole->resources()->get('backgroundPublisherForUsage');
+    });
 });
 
-$http->on(Constant::EVENT_WORKER_STOP, function ($server, $workerId) {
+$http->on(Constant::EVENT_WORKER_STOP, function ($server, $workerId) use ($swoole) {
     Timer::clearAll();
+
+    Coroutine::create(function () use ($swoole): void {
+        $swoole->resources()->get('backgroundPublisherForAudits')->shutdown();
+        $swoole->resources()->get('backgroundPublisherForUsage')->shutdown();
+    });
+
     Console::success('Worker ' . ++$workerId . ' stopped successfully');
 });
 

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -46,6 +46,7 @@ use Utopia\Lock\Distributed;
 use Utopia\Pools\Adapter\Swoole as SwoolePoolAdapter;
 use Utopia\Pools\Group;
 use Utopia\Pools\Pool as Connections;
+use Utopia\Queue\Broker\Background as BackgroundPublisher;
 use Utopia\Queue\Broker\Pool as BrokerPool;
 use Utopia\Queue\Publisher\Synchronous as Publisher;
 use Utopia\Queue\Queue;
@@ -108,10 +109,22 @@ $container->set('authorization', fn () => new Authorization(), []);
 
 $container->set('publisher', fn (Group $pools) => new BrokerPool(publisher: $pools->get('publisher')), ['pools']);
 
-$container->set('publisherForAudits', fn (Publisher $publisher) => new AuditPublisher(
+$container->set('backgroundPublisherForAudits', function (Publisher $publisher, Telemetry $telemetry) {
+    $background = new BackgroundPublisher(
+        $publisher,
+        telemetry: $telemetry,
+        maxBatchInterval: 0.01,
+        maxBatchSize: 100,
+    );
+    $background->start();
+
+    return $background;
+}, ['publisher', 'telemetry']);
+
+$container->set('publisherForAudits', fn (BackgroundPublisher $publisher) => new AuditPublisher(
     $publisher,
     new Queue(System::getEnv('_APP_AUDITS_QUEUE_NAME', Event::AUDITS_QUEUE_NAME))
-), ['publisher']);
+), ['backgroundPublisherForAudits']);
 
 $container->set('publisherForCertificates', fn (Publisher $publisher) => new CertificatePublisher(
     $publisher,
@@ -128,10 +141,22 @@ $container->set('publisherForScreenshots', fn (Publisher $publisher) => new Scre
     new Queue(System::getEnv('_APP_SCREENSHOTS_QUEUE_NAME', Event::SCREENSHOTS_QUEUE_NAME))
 ), ['publisher']);
 
-$container->set('publisherForUsage', fn (Publisher $publisher) => new UsagePublisher(
+$container->set('backgroundPublisherForUsage', function (Publisher $publisher, Telemetry $telemetry) {
+    $background = new BackgroundPublisher(
+        $publisher,
+        telemetry: $telemetry,
+        maxBatchInterval: 0.01,
+        maxBatchSize: 100,
+    );
+    $background->start();
+
+    return $background;
+}, ['publisher', 'telemetry']);
+
+$container->set('publisherForUsage', fn (BackgroundPublisher $publisher) => new UsagePublisher(
     $publisher,
     new Queue(System::getEnv('_APP_STATS_USAGE_QUEUE_NAME', Event::STATS_USAGE_QUEUE_NAME))
-), ['publisher']);
+), ['backgroundPublisherForUsage']);
 
 $container->set('publisherForExecutions', fn (Publisher $publisher) => new ExecutionPublisher(
     $publisher,

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -113,7 +113,7 @@ $container->set('backgroundPublisherForAudits', function (Publisher $publisher, 
     $background = new BackgroundPublisher(
         $publisher,
         telemetry: $telemetry,
-        maxBatchInterval: 0.01,
+        maxBatchInterval: 1.0,
         maxBatchSize: 100,
     );
     $background->start();
@@ -145,7 +145,7 @@ $container->set('backgroundPublisherForUsage', function (Publisher $publisher, T
     $background = new BackgroundPublisher(
         $publisher,
         telemetry: $telemetry,
-        maxBatchInterval: 0.01,
+        maxBatchInterval: 1.0,
         maxBatchSize: 100,
     );
     $background->start();

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -109,22 +109,17 @@ $container->set('authorization', fn () => new Authorization(), []);
 
 $container->set('publisher', fn (Group $pools) => new BrokerPool(publisher: $pools->get('publisher')), ['pools']);
 
-$container->set('backgroundPublisherForAudits', function (Publisher $publisher, Telemetry $telemetry) {
-    $background = new BackgroundPublisher(
-        $publisher,
-        telemetry: $telemetry,
-        maxBatchInterval: 10.0,
-        maxBatchSize: 100,
+$container->set('publisherForAudits', function (Publisher $publisher, Telemetry $telemetry) {
+    return new AuditPublisher(
+        new BackgroundPublisher(
+            $publisher,
+            telemetry: $telemetry,
+            maxBatchInterval: 10.0,
+            maxBatchSize: 100,
+        ),
+        new Queue(System::getEnv('_APP_AUDITS_QUEUE_NAME', Event::AUDITS_QUEUE_NAME)),
     );
-    $background->start();
-
-    return $background;
 }, ['publisher', 'telemetry']);
-
-$container->set('publisherForAudits', fn (BackgroundPublisher $publisher) => new AuditPublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_AUDITS_QUEUE_NAME', Event::AUDITS_QUEUE_NAME))
-), ['backgroundPublisherForAudits']);
 
 $container->set('publisherForCertificates', fn (Publisher $publisher) => new CertificatePublisher(
     $publisher,
@@ -141,22 +136,17 @@ $container->set('publisherForScreenshots', fn (Publisher $publisher) => new Scre
     new Queue(System::getEnv('_APP_SCREENSHOTS_QUEUE_NAME', Event::SCREENSHOTS_QUEUE_NAME))
 ), ['publisher']);
 
-$container->set('backgroundPublisherForUsage', function (Publisher $publisher, Telemetry $telemetry) {
-    $background = new BackgroundPublisher(
-        $publisher,
-        telemetry: $telemetry,
-        maxBatchInterval: 10.0,
-        maxBatchSize: 100,
+$container->set('publisherForUsage', function (Publisher $publisher, Telemetry $telemetry) {
+    return new UsagePublisher(
+        new BackgroundPublisher(
+            $publisher,
+            telemetry: $telemetry,
+            maxBatchInterval: 10.0,
+            maxBatchSize: 100,
+        ),
+        new Queue(System::getEnv('_APP_STATS_USAGE_QUEUE_NAME', Event::STATS_USAGE_QUEUE_NAME)),
     );
-    $background->start();
-
-    return $background;
 }, ['publisher', 'telemetry']);
-
-$container->set('publisherForUsage', fn (BackgroundPublisher $publisher) => new UsagePublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_STATS_USAGE_QUEUE_NAME', Event::STATS_USAGE_QUEUE_NAME))
-), ['backgroundPublisherForUsage']);
 
 $container->set('publisherForExecutions', fn (Publisher $publisher) => new ExecutionPublisher(
     $publisher,

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -113,7 +113,7 @@ $container->set('backgroundPublisherForAudits', function (Publisher $publisher, 
     $background = new BackgroundPublisher(
         $publisher,
         telemetry: $telemetry,
-        maxBatchInterval: 1.0,
+        maxBatchInterval: 10.0,
         maxBatchSize: 100,
     );
     $background->start();
@@ -145,7 +145,7 @@ $container->set('backgroundPublisherForUsage', function (Publisher $publisher, T
     $background = new BackgroundPublisher(
         $publisher,
         telemetry: $telemetry,
-        maxBatchInterval: 1.0,
+        maxBatchInterval: 10.0,
         maxBatchSize: 100,
     );
     $background->start();

--- a/app/init/resources/request.php
+++ b/app/init/resources/request.php
@@ -700,7 +700,7 @@ return function (Container $context): void {
                 ->setPayload($response->output($document, Response::MODEL_USER));
 
             // Trigger functions, webhooks, and realtime events
-            $publisherForFunctions->enqueue(FunctionMessage::fromEvent(
+            $publisherForFunctions->publish(FunctionMessage::fromEvent(
                 event: $queueForEvents->getEvent(),
                 params: $queueForEvents->getParams(),
                 project: $queueForEvents->getProject(),

--- a/app/realtime.php
+++ b/app/realtime.php
@@ -502,7 +502,7 @@ $server->onStart(function () use ($stats, $containerId, &$statsDocument) {
     }
 });
 
-$server->onWorkerStart(function (int $workerId) use ($server, $register, $stats, $realtime, $eventTailRegistry) {
+$server->onWorkerStart(function (int $workerId) use ($server, $register, $stats, $realtime, $eventTailRegistry, $container) {
     Console::success('Worker ' . $workerId . ' started successfully');
 
     $telemetry = getTelemetry($workerId);
@@ -531,6 +531,11 @@ $server->onWorkerStart(function (int $workerId) use ($server, $register, $stats,
         advisory: ['ExplicitBucketBoundaries' => $realtimeDelayBuckets],
     ));
     $register->get('telemetry.workerCounter')->add(1);
+
+    Coroutine::create(function () use ($container): void {
+        $container->get('backgroundPublisherForAudits');
+        $container->get('backgroundPublisherForUsage');
+    });
 
     $attempts = 0;
     $start = time();
@@ -852,8 +857,13 @@ $server->onWorkerStart(function (int $workerId) use ($server, $register, $stats,
     Console::error('Failed to restart pub/sub...');
 });
 
-$server->onWorkerStop(function (int $workerId) use ($register) {
+$server->onWorkerStop(function (int $workerId) use ($register, $container) {
     Console::warning('Worker ' . $workerId . ' stopping');
+
+    Coroutine::create(function () use ($container): void {
+        $container->get('backgroundPublisherForAudits')->shutdown();
+        $container->get('backgroundPublisherForUsage')->shutdown();
+    });
 
     try {
         $register->get('telemetry.workerCounter')->add(-1);

--- a/app/realtime.php
+++ b/app/realtime.php
@@ -533,8 +533,8 @@ $server->onWorkerStart(function (int $workerId) use ($server, $register, $stats,
     $register->get('telemetry.workerCounter')->add(1);
 
     Coroutine::create(function () use ($container): void {
-        $container->get('backgroundPublisherForAudits');
-        $container->get('backgroundPublisherForUsage');
+        $container->get('publisherForAudits')->start();
+        $container->get('publisherForUsage')->start();
     });
 
     $attempts = 0;
@@ -861,8 +861,8 @@ $server->onWorkerStop(function (int $workerId) use ($register, $container) {
     Console::warning('Worker ' . $workerId . ' stopping');
 
     Coroutine::create(function () use ($container): void {
-        $container->get('backgroundPublisherForAudits')->shutdown();
-        $container->get('backgroundPublisherForUsage')->shutdown();
+        $container->get('publisherForAudits')->shutdown();
+        $container->get('publisherForUsage')->shutdown();
     });
 
     try {

--- a/app/worker.php
+++ b/app/worker.php
@@ -114,13 +114,13 @@ try {
     });
 
     $worker->workerStart()->action(function () use ($container): void {
-        $container->get('backgroundPublisherForAudits');
-        $container->get('backgroundPublisherForUsage');
+        $container->get('publisherForAudits')->start();
+        $container->get('publisherForUsage')->start();
     });
 
     $worker->workerStop()->action(function () use ($container): void {
-        $container->get('backgroundPublisherForAudits')->shutdown();
-        $container->get('backgroundPublisherForUsage')->shutdown();
+        $container->get('publisherForAudits')->shutdown();
+        $container->get('publisherForUsage')->shutdown();
     });
 
     $container->set('bus', function ($register) use ($worker) {

--- a/app/worker.php
+++ b/app/worker.php
@@ -113,6 +113,16 @@ try {
         Span::current()?->finish();
     });
 
+    $worker->workerStart()->action(function () use ($container): void {
+        $container->get('backgroundPublisherForAudits');
+        $container->get('backgroundPublisherForUsage');
+    });
+
+    $worker->workerStop()->action(function () use ($container): void {
+        $container->get('backgroundPublisherForAudits')->shutdown();
+        $container->get('backgroundPublisherForUsage')->shutdown();
+    });
+
     $container->set('bus', function ($register) use ($worker) {
         return $register->get('bus')->setResolver(
             fn (string $name) => $worker->context()->get($name)

--- a/src/Appwrite/Bus/Listeners/ExecutionCancelledCleanup.php
+++ b/src/Appwrite/Bus/Listeners/ExecutionCancelledCleanup.php
@@ -40,7 +40,7 @@ class ExecutionCancelledCleanup extends Listener
         Span::add('function.id', $execution->getAttribute('resourceId', ''));
         Span::add('execution.id', $execution->getId());
 
-        $publisherForExecutions->enqueue(new ExecutionCancelledMessage(
+        $publisherForExecutions->publish(new ExecutionCancelledMessage(
             project: $project,
             execution: $execution,
         ));

--- a/src/Appwrite/Bus/Listeners/Log.php
+++ b/src/Appwrite/Bus/Listeners/Log.php
@@ -46,7 +46,7 @@ class Log extends Listener
             Span::add('execution.status', $execution->getAttribute('status', ''));
         }
 
-        $publisherForExecutions->enqueue(new ExecutionMessage(
+        $publisherForExecutions->publish(new ExecutionMessage(
             project: $project,
             execution: $execution,
         ));

--- a/src/Appwrite/Bus/Listeners/Mails.php
+++ b/src/Appwrite/Bus/Listeners/Mails.php
@@ -139,7 +139,7 @@ class Mails extends Listener
             ];
         }
 
-        $publisherForMails->enqueue(new MailMessage(
+        $publisherForMails->publish(new MailMessage(
             project: $project,
             recipient: $event->user['email'],
             subject: $subject,

--- a/src/Appwrite/Event/Publisher/Audit.php
+++ b/src/Appwrite/Event/Publisher/Audit.php
@@ -3,21 +3,15 @@
 namespace Appwrite\Event\Publisher;
 
 use Appwrite\Event\Message\Audit as AuditMessage;
+use Appwrite\Event\Message\Base as BaseMessage;
 use Utopia\Console;
-use Utopia\Queue\Publisher\Synchronous as Publisher;
 use Utopia\Queue\Queue;
 use Utopia\System\System;
 
+/** @extends Base<AuditMessage> */
 readonly class Audit extends Base
 {
-    public function __construct(
-        Publisher $publisher,
-        protected Queue $queue
-    ) {
-        parent::__construct($publisher);
-    }
-
-    public function enqueue(AuditMessage $message): string|bool
+    protected function dispatch(BaseMessage $message, ?Queue $queue, bool $background): string|bool
     {
         if (System::getEnv('_APP_EDITION', 'self-hosted') === 'self-hosted') {
             return false;
@@ -25,7 +19,7 @@ readonly class Audit extends Base
 
         // Audit delivery is best-effort and should never fail the request lifecycle.
         try {
-            return $this->publish($this->queue, $message);
+            return parent::dispatch($message, $queue, $background);
         } catch (\Throwable $th) {
             Console::error('[Audit] Failed to publish audit message: ' . $th->getMessage());
 
@@ -33,8 +27,4 @@ readonly class Audit extends Base
         }
     }
 
-    public function getSize(bool $failed = false): int
-    {
-        return $this->getQueueSize($this->queue, $failed);
-    }
 }

--- a/src/Appwrite/Event/Publisher/Base.php
+++ b/src/Appwrite/Event/Publisher/Base.php
@@ -3,25 +3,49 @@
 namespace Appwrite\Event\Publisher;
 
 use Appwrite\Event\Message\Base as BaseMessage;
+use Utopia\Queue\Broker\Background;
 use Utopia\Queue\Publisher\Asynchronous;
 use Utopia\Queue\Publisher\Synchronous as Publisher;
 use Utopia\Queue\Queue;
 
+/**
+ * @template TMessage of BaseMessage
+ */
 readonly class Base
 {
     public function __construct(
-        protected Publisher $publisher
+        protected Publisher $publisher,
+        protected Queue $queue,
     ) {
     }
 
     /**
-     * Publish a message to the queue
+     * Wait for the broker to accept the message.
+     *
+     * @param TMessage $message
      */
-    public function publish(Queue $queue, BaseMessage $message): string|bool
+    public function publish(BaseMessage $message, ?Queue $queue = null): string|bool
     {
+        return $this->dispatch($message, $queue, false);
+    }
+
+    /**
+     * Accept background delivery when supported, otherwise publish directly.
+     *
+     * @param TMessage $message
+     */
+    public function enqueue(BaseMessage $message, ?Queue $queue = null): string|bool
+    {
+        return $this->dispatch($message, $queue, true);
+    }
+
+    /** @param TMessage $message */
+    protected function dispatch(BaseMessage $message, ?Queue $queue, bool $background): string|bool
+    {
+        $queue ??= $this->queue;
         $payload = $message->toArray();
 
-        if ($this->publisher instanceof Asynchronous) {
+        if ($background && $this->publisher instanceof Asynchronous) {
             $this->publisher->enqueue($queue, $payload);
 
             return true;
@@ -30,11 +54,22 @@ readonly class Base
         return $this->publisher->publish($queue, $payload);
     }
 
-    /**
-     * Get the size of a queue
-     */
-    public function getQueueSize(Queue $queue, bool $failed = false): int
+    public function getSize(bool $failed = false, ?Queue $queue = null): int
     {
-        return $this->publisher->getQueueSize($queue, $failed);
+        return $this->publisher->getQueueSize($queue ?? $this->queue, $failed);
+    }
+
+    public function start(): void
+    {
+        if ($this->publisher instanceof Background) {
+            $this->publisher->start();
+        }
+    }
+
+    public function shutdown(): void
+    {
+        if ($this->publisher instanceof Background) {
+            $this->publisher->shutdown();
+        }
     }
 }

--- a/src/Appwrite/Event/Publisher/Base.php
+++ b/src/Appwrite/Event/Publisher/Base.php
@@ -3,6 +3,7 @@
 namespace Appwrite\Event\Publisher;
 
 use Appwrite\Event\Message\Base as BaseMessage;
+use Utopia\Queue\Publisher\Asynchronous;
 use Utopia\Queue\Publisher\Synchronous as Publisher;
 use Utopia\Queue\Queue;
 
@@ -19,6 +20,12 @@ readonly class Base
     public function publish(Queue $queue, BaseMessage $message): string|bool
     {
         $payload = $message->toArray();
+
+        if ($this->publisher instanceof Asynchronous) {
+            $this->publisher->enqueue($queue, $payload);
+
+            return true;
+        }
 
         return $this->publisher->publish($queue, $payload);
     }

--- a/src/Appwrite/Event/Publisher/Build.php
+++ b/src/Appwrite/Event/Publisher/Build.php
@@ -3,25 +3,8 @@
 namespace Appwrite\Event\Publisher;
 
 use Appwrite\Event\Message\Build as BuildMessage;
-use Utopia\Queue\Publisher\Synchronous as Publisher;
-use Utopia\Queue\Queue;
 
+/** @extends Base<BuildMessage> */
 readonly class Build extends Base
 {
-    public function __construct(
-        Publisher $publisher,
-        protected Queue $queue
-    ) {
-        parent::__construct($publisher);
-    }
-
-    public function enqueue(BuildMessage $message, ?Queue $queue = null): string|bool
-    {
-        return $this->publish($queue ?? $this->queue, $message);
-    }
-
-    public function getSize(bool $failed = false, ?Queue $queue = null): int
-    {
-        return $this->getQueueSize($queue ?? $this->queue, $failed);
-    }
 }

--- a/src/Appwrite/Event/Publisher/Certificate.php
+++ b/src/Appwrite/Event/Publisher/Certificate.php
@@ -3,25 +3,8 @@
 namespace Appwrite\Event\Publisher;
 
 use Appwrite\Event\Message\Certificate as CertificateMessage;
-use Utopia\Queue\Publisher\Synchronous as Publisher;
-use Utopia\Queue\Queue;
 
+/** @extends Base<CertificateMessage> */
 readonly class Certificate extends Base
 {
-    public function __construct(
-        Publisher $publisher,
-        protected Queue $queue
-    ) {
-        parent::__construct($publisher);
-    }
-
-    public function enqueue(CertificateMessage $message): string|bool
-    {
-        return $this->publish($this->queue, $message);
-    }
-
-    public function getSize(bool $failed = false): int
-    {
-        return $this->getQueueSize($this->queue, $failed);
-    }
 }

--- a/src/Appwrite/Event/Publisher/Database.php
+++ b/src/Appwrite/Event/Publisher/Database.php
@@ -2,30 +2,20 @@
 
 namespace Appwrite\Event\Publisher;
 
+use Appwrite\Event\Message\Base as BaseMessage;
 use Appwrite\Event\Message\Database as DatabaseMessage;
 use Utopia\Database\Document;
 use Utopia\DSN\DSN;
-use Utopia\Queue\Publisher\Synchronous as Publisher;
 use Utopia\Queue\Queue;
 
+/** @extends Base<DatabaseMessage> */
 readonly class Database extends Base
 {
-    public function __construct(
-        Publisher $publisher,
-        protected Queue $queue,
-    ) {
-        parent::__construct($publisher);
+    protected function dispatch(BaseMessage $message, ?Queue $queue, bool $background): string|bool
+    {
+        return parent::dispatch($message, $queue ?? $this->getQueueFromProject($message->project), $background);
     }
 
-    public function enqueue(DatabaseMessage $message, ?Queue $queue = null): string|bool
-    {
-        return $this->publish($queue ?? $this->getQueueFromProject($message->project), $message);
-    }
-
-    public function getSize(bool $failed = false, ?Queue $queue = null): int
-    {
-        return $this->getQueueSize($queue ?? $this->queue, $failed);
-    }
 
     private function getQueueFromProject(?Document $project): Queue
     {

--- a/src/Appwrite/Event/Publisher/Delete.php
+++ b/src/Appwrite/Event/Publisher/Delete.php
@@ -3,25 +3,8 @@
 namespace Appwrite\Event\Publisher;
 
 use Appwrite\Event\Message\Delete as DeleteMessage;
-use Utopia\Queue\Publisher\Synchronous as Publisher;
-use Utopia\Queue\Queue;
 
+/** @extends Base<DeleteMessage> */
 readonly class Delete extends Base
 {
-    public function __construct(
-        Publisher $publisher,
-        protected Queue $queue,
-    ) {
-        parent::__construct($publisher);
-    }
-
-    public function enqueue(DeleteMessage $message, ?Queue $queue = null): string|bool
-    {
-        return $this->publish($queue ?? $this->queue, $message);
-    }
-
-    public function getSize(bool $failed = false, ?Queue $queue = null): int
-    {
-        return $this->getQueueSize($queue ?? $this->queue, $failed);
-    }
 }

--- a/src/Appwrite/Event/Publisher/Execution.php
+++ b/src/Appwrite/Event/Publisher/Execution.php
@@ -5,25 +5,8 @@ namespace Appwrite\Event\Publisher;
 use Appwrite\Event\Message\Execution as ExecutionMessage;
 use Appwrite\Event\Message\ExecutionCancelled as ExecutionCancelledMessage;
 use Appwrite\Event\Message\Executions as ExecutionsMessage;
-use Utopia\Queue\Publisher\Synchronous as Publisher;
-use Utopia\Queue\Queue;
 
+/** @extends Base<ExecutionMessage|ExecutionCancelledMessage|ExecutionsMessage> */
 readonly class Execution extends Base
 {
-    public function __construct(
-        Publisher $publisher,
-        protected Queue $queue
-    ) {
-        parent::__construct($publisher);
-    }
-
-    public function enqueue(ExecutionMessage|ExecutionCancelledMessage|ExecutionsMessage $message): string|bool
-    {
-        return $this->publish($this->queue, $message);
-    }
-
-    public function getSize(bool $failed = false): int
-    {
-        return $this->getQueueSize($this->queue, $failed);
-    }
 }

--- a/src/Appwrite/Event/Publisher/Func.php
+++ b/src/Appwrite/Event/Publisher/Func.php
@@ -3,25 +3,8 @@
 namespace Appwrite\Event\Publisher;
 
 use Appwrite\Event\Message\Func as FunctionMessage;
-use Utopia\Queue\Publisher\Synchronous as Publisher;
-use Utopia\Queue\Queue;
 
+/** @extends Base<FunctionMessage> */
 readonly class Func extends Base
 {
-    public function __construct(
-        Publisher $publisher,
-        protected Queue $queue,
-    ) {
-        parent::__construct($publisher);
-    }
-
-    public function enqueue(FunctionMessage $message, ?Queue $queue = null): string|bool
-    {
-        return $this->publish($queue ?? $this->queue, $message);
-    }
-
-    public function getSize(bool $failed = false, ?Queue $queue = null): int
-    {
-        return $this->getQueueSize($queue ?? $this->queue, $failed);
-    }
 }

--- a/src/Appwrite/Event/Publisher/Jobs.php
+++ b/src/Appwrite/Event/Publisher/Jobs.php
@@ -3,20 +3,8 @@
 namespace Appwrite\Event\Publisher;
 
 use Appwrite\Event\Message\Jobs as JobsMessage;
-use Utopia\Queue\Publisher\Synchronous as Publisher;
-use Utopia\Queue\Queue;
 
+/** @extends Base<JobsMessage> */
 readonly class Jobs extends Base
 {
-    public function __construct(
-        Publisher $publisher,
-        protected Queue $queue
-    ) {
-        parent::__construct($publisher);
-    }
-
-    public function enqueue(JobsMessage $message, ?Queue $queue = null): string|bool
-    {
-        return $this->publish($queue ?? $this->queue, $message);
-    }
 }

--- a/src/Appwrite/Event/Publisher/Mail.php
+++ b/src/Appwrite/Event/Publisher/Mail.php
@@ -3,25 +3,8 @@
 namespace Appwrite\Event\Publisher;
 
 use Appwrite\Event\Message\Mail as MailMessage;
-use Utopia\Queue\Publisher\Synchronous as Publisher;
-use Utopia\Queue\Queue;
 
+/** @extends Base<MailMessage> */
 readonly class Mail extends Base
 {
-    public function __construct(
-        Publisher $publisher,
-        protected Queue $queue
-    ) {
-        parent::__construct($publisher);
-    }
-
-    public function enqueue(MailMessage $message, ?Queue $queue = null): string|bool
-    {
-        return $this->publish($queue ?? $this->queue, $message);
-    }
-
-    public function getSize(bool $failed = false, ?Queue $queue = null): int
-    {
-        return $this->getQueueSize($queue ?? $this->queue, $failed);
-    }
 }

--- a/src/Appwrite/Event/Publisher/Messaging.php
+++ b/src/Appwrite/Event/Publisher/Messaging.php
@@ -3,25 +3,8 @@
 namespace Appwrite\Event\Publisher;
 
 use Appwrite\Event\Message\Messaging as MessagingMessage;
-use Utopia\Queue\Publisher\Synchronous as Publisher;
-use Utopia\Queue\Queue;
 
+/** @extends Base<MessagingMessage> */
 readonly class Messaging extends Base
 {
-    public function __construct(
-        Publisher $publisher,
-        protected Queue $queue
-    ) {
-        parent::__construct($publisher);
-    }
-
-    public function enqueue(MessagingMessage $message, ?Queue $queue = null): string|bool
-    {
-        return $this->publish($queue ?? $this->queue, $message);
-    }
-
-    public function getSize(bool $failed = false, ?Queue $queue = null): int
-    {
-        return $this->getQueueSize($queue ?? $this->queue, $failed);
-    }
 }

--- a/src/Appwrite/Event/Publisher/Migration.php
+++ b/src/Appwrite/Event/Publisher/Migration.php
@@ -3,25 +3,8 @@
 namespace Appwrite\Event\Publisher;
 
 use Appwrite\Event\Message\Migration as MigrationMessage;
-use Utopia\Queue\Publisher\Synchronous as Publisher;
-use Utopia\Queue\Queue;
 
+/** @extends Base<MigrationMessage> */
 readonly class Migration extends Base
 {
-    public function __construct(
-        Publisher $publisher,
-        protected Queue $queue
-    ) {
-        parent::__construct($publisher);
-    }
-
-    public function enqueue(MigrationMessage $message): string|bool
-    {
-        return $this->publish($this->queue, $message);
-    }
-
-    public function getSize(bool $failed = false): int
-    {
-        return $this->getQueueSize($this->queue, $failed);
-    }
 }

--- a/src/Appwrite/Event/Publisher/Notification.php
+++ b/src/Appwrite/Event/Publisher/Notification.php
@@ -3,25 +3,8 @@
 namespace Appwrite\Event\Publisher;
 
 use Appwrite\Event\Message\Notification as NotificationMessage;
-use Utopia\Queue\Publisher\Synchronous as Publisher;
-use Utopia\Queue\Queue;
 
+/** @extends Base<NotificationMessage> */
 readonly class Notification extends Base
 {
-    public function __construct(
-        Publisher $publisher,
-        protected Queue $queue,
-    ) {
-        parent::__construct($publisher);
-    }
-
-    public function enqueue(NotificationMessage $message, ?Queue $queue = null): string|bool
-    {
-        return $this->publish($queue ?? $this->queue, $message);
-    }
-
-    public function getSize(bool $failed = false, ?Queue $queue = null): int
-    {
-        return $this->getQueueSize($queue ?? $this->queue, $failed);
-    }
 }

--- a/src/Appwrite/Event/Publisher/Screenshot.php
+++ b/src/Appwrite/Event/Publisher/Screenshot.php
@@ -3,25 +3,8 @@
 namespace Appwrite\Event\Publisher;
 
 use Appwrite\Event\Message\Screenshot as ScreenshotMessage;
-use Utopia\Queue\Publisher\Synchronous as Publisher;
-use Utopia\Queue\Queue;
 
+/** @extends Base<ScreenshotMessage> */
 readonly class Screenshot extends Base
 {
-    public function __construct(
-        Publisher $publisher,
-        protected Queue $queue
-    ) {
-        parent::__construct($publisher);
-    }
-
-    public function enqueue(ScreenshotMessage $message): string|bool
-    {
-        return $this->publish($this->queue, $message);
-    }
-
-    public function getSize(bool $failed = false): int
-    {
-        return $this->getQueueSize($this->queue, $failed);
-    }
 }

--- a/src/Appwrite/Event/Publisher/StatsResources.php
+++ b/src/Appwrite/Event/Publisher/StatsResources.php
@@ -2,22 +2,16 @@
 
 namespace Appwrite\Event\Publisher;
 
+use Appwrite\Event\Message\Base as BaseMessage;
 use Appwrite\Event\Message\StatsResources as StatsResourcesMessage;
 use Utopia\Console;
-use Utopia\Queue\Publisher\Synchronous as Publisher;
 use Utopia\Queue\Queue;
 use Utopia\System\System;
 
+/** @extends Base<StatsResourcesMessage> */
 readonly class StatsResources extends Base
 {
-    public function __construct(
-        Publisher $publisher,
-        protected Queue $queue
-    ) {
-        parent::__construct($publisher);
-    }
-
-    public function enqueue(StatsResourcesMessage $message): string|bool
+    protected function dispatch(BaseMessage $message, ?Queue $queue, bool $background): string|bool
     {
         if (System::getEnv('_APP_USAGE_STATS', 'enabled') === 'disabled') {
             return false;
@@ -25,15 +19,11 @@ readonly class StatsResources extends Base
 
         // Resource stats are best-effort; publishing failures should not interrupt the scheduler loop.
         try {
-            return $this->publish($this->queue, $message);
+            return parent::dispatch($message, $queue, $background);
         } catch (\Throwable $th) {
             Console::error('[StatsResources] Failed to publish stats resources message: ' . $th->getMessage());
             return false;
         }
     }
 
-    public function getSize(bool $failed = false): int
-    {
-        return $this->getQueueSize($this->queue, $failed);
-    }
 }

--- a/src/Appwrite/Event/Publisher/Usage.php
+++ b/src/Appwrite/Event/Publisher/Usage.php
@@ -2,43 +2,27 @@
 
 namespace Appwrite\Event\Publisher;
 
+use Appwrite\Event\Message\Base as BaseMessage;
 use Appwrite\Event\Message\Usage as UsageMessage;
 use Utopia\Console;
-use Utopia\Queue\Publisher\Synchronous as Publisher;
 use Utopia\Queue\Queue;
 use Utopia\System\System;
 
+/** @extends Base<UsageMessage> */
 readonly class Usage extends Base
 {
-    public function __construct(
-        Publisher $publisher,
-        protected Queue $queue
-    ) {
-        parent::__construct($publisher);
-    }
-
-    /**
-     * Enqueue a usage message
-     */
-    public function enqueue(UsageMessage $message): string|bool
+    protected function dispatch(BaseMessage $message, ?Queue $queue, bool $background): string|bool
     {
         if (System::getEnv('_APP_USAGE_STATS', 'enabled') === 'disabled') {
             return false;
         }
 
         try {
-            return $this->publish($this->queue, $message);
+            return parent::dispatch($message, $queue, $background);
         } catch (\Throwable $th) {
             Console::error('[Usage] Failed to publish usage message: ' . $th->getMessage());
             return false;
         }
     }
 
-    /**
-     * Get the size of the usage queue
-     */
-    public function getSize(bool $failed = false): int
-    {
-        return $this->getQueueSize($this->queue, $failed);
-    }
 }

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Create.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Create.php
@@ -195,7 +195,7 @@ class Create extends Action
                 $message = $message->render();
 
                 $phone = $user->getAttribute('phone');
-                $publisherForMessaging->enqueue(new MessagingMessage(
+                $publisherForMessaging->publish(new MessagingMessage(
                     type: MESSAGE_SEND_TYPE_INTERNAL,
                     project: $project,
                     message: new Document([
@@ -338,7 +338,7 @@ class Create extends Action
                     ]);
                 }
 
-                $publisherForMails->enqueue(new MailMessage(
+                $publisherForMails->publish(new MailMessage(
                     project: $project,
                     recipient: $user->getAttribute('email'),
                     subject: $subject,

--- a/src/Appwrite/Platform/Modules/Advisor/Http/Reports/Delete.php
+++ b/src/Appwrite/Platform/Modules/Advisor/Http/Reports/Delete.php
@@ -85,7 +85,7 @@ class Delete extends Action
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove report from DB');
         }
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $project,
             type: DELETE_TYPE_REPORT,
             document: $report,

--- a/src/Appwrite/Platform/Modules/Compute/Base.php
+++ b/src/Appwrite/Platform/Modules/Compute/Base.php
@@ -195,7 +195,7 @@ class Base extends Action
                 'status' => 'waiting',
             ]));
 
-            $publisherForBuilds->enqueue(new BuildMessage(
+            $publisherForBuilds->publish(new BuildMessage(
                 project: $project,
                 resource: $function,
                 deployment: $deployment,
@@ -412,7 +412,7 @@ class Base extends Action
                 $site->getAttribute('providerRootDirectory', ''),
             );
         } else {
-            $publisherForBuilds->enqueue(new BuildMessage(
+            $publisherForBuilds->publish(new BuildMessage(
                 project: $project,
                 resource: $site,
                 deployment: $deployment,

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Action.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Action.php
@@ -476,7 +476,7 @@ abstract class Action extends DatabasesAction
             ->setParam('columnId', $attribute->getId())
             ->setContext($this->getCollectionsEventsContext(), $collection);
 
-        $publisherForDatabase->enqueue(new DatabaseMessage(
+        $publisherForDatabase->publish(new DatabaseMessage(
             project: $queueForEvents->getProject(),
             user: $queueForEvents->getUser(),
             type: DATABASE_TYPE_CREATE_ATTRIBUTE,

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Delete.php
@@ -146,7 +146,7 @@ class Delete extends Action
             ->setPayload($response->output($attribute, $model))
             ->setContext($this->getCollectionsEventsContext(), $collection);
 
-        $publisherForDatabase->enqueue(new DatabaseMessage(
+        $publisherForDatabase->publish(new DatabaseMessage(
             project: $queueForEvents->getProject(),
             user: $queueForEvents->getUser(),
             type: DATABASE_TYPE_DELETE_ATTRIBUTE,

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Delete.php
@@ -97,7 +97,7 @@ class Delete extends Action
             ->setParam($this->getEventsParamKey(), $collection->getId())
             ->setPayload($response->output($collection, $this->getResponseModel()));
 
-        $publisherForDatabase->enqueue(new DatabaseMessage(
+        $publisherForDatabase->publish(new DatabaseMessage(
             project: $queueForEvents->getProject(),
             user: $queueForEvents->getUser(),
             type: DATABASE_TYPE_DELETE_COLLECTION,

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Action.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Action.php
@@ -507,7 +507,7 @@ abstract class Action extends DatabasesAction
             if (!empty($functionsEvents)) {
                 foreach ($generatedEvents as $event) {
                     if (isset($functionsEvents[$event])) {
-                        $publisherForFunctions->enqueue(FunctionMessage::fromEvent(
+                        $publisherForFunctions->publish(FunctionMessage::fromEvent(
                             event: $queueForEvents->getEvent(),
                             params: $queueForEvents->getParams(),
                             project: $queueForEvents->getProject(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Create.php
@@ -239,7 +239,7 @@ class Create extends Action
             ->setParam('tableId', $collection->getId())
             ->setContext($this->getCollectionsEventsContext(), $collection);
 
-        $publisherForDatabase->enqueue(new DatabaseMessage(
+        $publisherForDatabase->publish(new DatabaseMessage(
             project: $queueForEvents->getProject(),
             user: $queueForEvents->getUser(),
             type: DATABASE_TYPE_CREATE_INDEX,

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Delete.php
@@ -114,7 +114,7 @@ class Delete extends Action
             ->setContext($this->getCollectionsEventsContext(), $collection)
             ->setPayload($response->output($index, $this->getResponseModel()));
 
-        $publisherForDatabase->enqueue(new DatabaseMessage(
+        $publisherForDatabase->publish(new DatabaseMessage(
             project: $queueForEvents->getProject(),
             user: $queueForEvents->getUser(),
             type: DATABASE_TYPE_DELETE_INDEX,

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Delete.php
@@ -83,7 +83,7 @@ class Delete extends Action
             ->setParam('databaseId', $database->getId())
             ->setPayload($response->output($database, UtopiaResponse::MODEL_DATABASE));
 
-        $publisherForDatabase->enqueue(new DatabaseMessage(
+        $publisherForDatabase->publish(new DatabaseMessage(
             project: $queueForEvents->getProject(),
             user: $queueForEvents->getUser(),
             type: DATABASE_TYPE_DELETE_DATABASE,

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Delete.php
@@ -68,7 +68,7 @@ class Delete extends Action
 
         $dbForProject->deleteDocument('transactions', $transactionId);
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $project,
             type: DELETE_TYPE_DOCUMENT,
             document: $transaction,

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Update.php
@@ -163,7 +163,7 @@ class Update extends Action
                     new Document(['status' => 'committed'])
                 ));
 
-                $publisherForDeletes->enqueue(new DeleteMessage(
+                $publisherForDeletes->publish(new DeleteMessage(
                     project: $project,
                     type: DELETE_TYPE_DOCUMENT,
                     document: $transaction,
@@ -304,7 +304,7 @@ class Update extends Action
                     new Document(['status' => 'committed'])
                 ));
 
-                $publisherForDeletes->enqueue(new DeleteMessage(
+                $publisherForDeletes->publish(new DeleteMessage(
                     project: $project,
                     type: DELETE_TYPE_DOCUMENT,
                     document: $transaction,
@@ -486,7 +486,7 @@ class Update extends Action
                     if (!empty($functionsEvents)) {
                         foreach ($generatedEvents as $event) {
                             if (isset($functionsEvents[$event])) {
-                                $publisherForFunctions->enqueue(FunctionMessage::fromEvent(
+                                $publisherForFunctions->publish(FunctionMessage::fromEvent(
                                     event: $queueForEvents->getEvent(),
                                     params: $queueForEvents->getParams(),
                                     project: $queueForEvents->getProject(),
@@ -524,7 +524,7 @@ class Update extends Action
                 new Document(['status' => 'failed'])
             ));
 
-            $publisherForDeletes->enqueue(new DeleteMessage(
+            $publisherForDeletes->publish(new DeleteMessage(
                 project: $project,
                 type: DELETE_TYPE_DOCUMENT,
                 document: $transaction,

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Delete.php
@@ -144,7 +144,7 @@ class Delete extends Action
             ->setParam('functionId', $function->getId())
             ->setParam('deploymentId', $deployment->getId());
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $queueForEvents->getProject(),
             type: DELETE_TYPE_DOCUMENT,
             document: $deployment,

--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
@@ -302,7 +302,7 @@ class Create extends Base
 
         if ($async) {
             if (is_null($scheduledAt)) {
-                $publisherForFunctions->enqueue(new FunctionMessage(
+                $publisherForFunctions->publish(new FunctionMessage(
                     project: $project,
                     user: $user,
                     function: $function,
@@ -350,7 +350,7 @@ class Create extends Base
             ));
 
             if ($executionsRetentionCount > 0 && ENABLE_EXECUTIONS_LIMIT_ON_ROUTE) {
-                $publisherForDeletes->enqueue(new DeleteMessage(
+                $publisherForDeletes->publish(new DeleteMessage(
                     project: $project,
                     type: DELETE_TYPE_EXECUTIONS_LIMIT,
                     resource: (string) $function->getSequence(),
@@ -534,7 +534,7 @@ class Create extends Base
         }
 
         if ($executionsRetentionCount > 0 && ENABLE_EXECUTIONS_LIMIT_ON_ROUTE) {
-            $publisherForDeletes->enqueue(new DeleteMessage(
+            $publisherForDeletes->publish(new DeleteMessage(
                 project: $project,
                 type: DELETE_TYPE_EXECUTIONS_LIMIT,
                 resource: (string) $function->getSequence(),

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Create.php
@@ -455,7 +455,7 @@ class Create extends Base
                     ->trigger();
 
                 /** Trigger Functions */
-                $publisherForFunctions->enqueue(FunctionMessage::fromEvent(
+                $publisherForFunctions->publish(FunctionMessage::fromEvent(
                     event: $ruleCreate->getEvent(),
                     params: $ruleCreate->getParams(),
                     project: $ruleCreate->getProject(),
@@ -475,7 +475,7 @@ class Create extends Base
                     'domain' => $domain,
                     'owner' => 'Appwrite',
                 ]))) {
-                    $publisherForCertificates->enqueue(new CertificateMessage(
+                    $publisherForCertificates->publish(new CertificateMessage(
                         project: $project,
                         domain: new Document([
                             'domain' => $domain,

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Delete.php
@@ -99,7 +99,7 @@ class Delete extends Base
             ])));
         }
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $queueForEvents->getProject(),
             type: DELETE_TYPE_DOCUMENT,
             document: $function,

--- a/src/Appwrite/Platform/Modules/Functions/Http/Jobs/Event/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Jobs/Event/Create.php
@@ -62,7 +62,7 @@ class Create extends Action
         // worker reloads the full project document from this id.
         $projectId = $event['data']['meta']['projectId'] ?? '';
 
-        $publisherForJobs->enqueue(new JobsMessage(
+        $publisherForJobs->publish(new JobsMessage(
             project: new Document(['$id' => $projectId]),
             id: $event['id'] ?? '',
             event: $event['type'] ?? '',

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -550,7 +550,7 @@ class Jobs extends Action
             // Every successful site build, activated or not, repoints the
             // branch preview rule and refreshes the console screenshots.
             Base::activateBranchPreviewRule($project, $resource, $deployment, $dbForPlatform, $bus, $platform['sitesDomain']);
-            $publisherForScreenshots->enqueue(new \Appwrite\Event\Message\Screenshot(
+            $publisherForScreenshots->publish(new \Appwrite\Event\Message\Screenshot(
                 project: $project,
                 deploymentId: $deployment->getId(),
             ));
@@ -752,7 +752,7 @@ class Jobs extends Action
 
         $queueForWebhooks->from($update)->trigger();
 
-        $publisherForFunctions->enqueue(FunctionMessage::fromEvent(
+        $publisherForFunctions->publish(FunctionMessage::fromEvent(
             event: $update->getEvent(),
             params: $update->getParams(),
             project: $update->getProject(),

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Create.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Create.php
@@ -104,7 +104,7 @@ class Create extends Action
 
         $queueForEvents->setParam('migrationId', $migration->getId());
 
-        $publisherForMigrations->enqueue(new MigrationMessage(
+        $publisherForMigrations->publish(new MigrationMessage(
             project: $project,
             migration: $migration,
             platform: $platform,

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/CSV/Exports/Create.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/CSV/Exports/Create.php
@@ -178,7 +178,7 @@ class Create extends Action
 
         $queueForEvents->setParam('migrationId', $migration->getId());
 
-        $publisherForMigrations->enqueue(new MigrationMessage(
+        $publisherForMigrations->publish(new MigrationMessage(
             project: $project,
             migration: $migration,
             platform: $platform,

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/CSV/Imports/Create.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/CSV/Imports/Create.php
@@ -212,7 +212,7 @@ class Create extends Action
 
         $queueForEvents->setParam('migrationId', $migration->getId());
 
-        $publisherForMigrations->enqueue(new MigrationMessage(
+        $publisherForMigrations->publish(new MigrationMessage(
             project: $project,
             migration: $migration,
         ));

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Firebase/Create.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Firebase/Create.php
@@ -102,7 +102,7 @@ class Create extends Action
 
         $queueForEvents->setParam('migrationId', $migration->getId());
 
-        $publisherForMigrations->enqueue(new MigrationMessage(
+        $publisherForMigrations->publish(new MigrationMessage(
             project: $project,
             migration: $migration,
             platform: $platform,

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/JSON/Exports/Create.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/JSON/Exports/Create.php
@@ -163,7 +163,7 @@ class Create extends Action
 
         $queueForEvents->setParam('migrationId', $migration->getId());
 
-        $publisherForMigrations->enqueue(new MigrationMessage(
+        $publisherForMigrations->publish(new MigrationMessage(
             project: $project,
             migration: $migration,
             platform: $platform,

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/JSON/Imports/Create.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/JSON/Imports/Create.php
@@ -208,7 +208,7 @@ class Create extends Action
 
         $queueForEvents->setParam('migrationId', $migration->getId());
 
-        $publisherForMigrations->enqueue(new MigrationMessage(
+        $publisherForMigrations->publish(new MigrationMessage(
             project: $project,
             migration: $migration,
             platform: $platform,

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/NHost/Create.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/NHost/Create.php
@@ -111,7 +111,7 @@ class Create extends Action
 
         $queueForEvents->setParam('migrationId', $migration->getId());
 
-        $publisherForMigrations->enqueue(new MigrationMessage(
+        $publisherForMigrations->publish(new MigrationMessage(
             project: $project,
             migration: $migration,
             platform: $platform,

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Supabase/Create.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Supabase/Create.php
@@ -109,7 +109,7 @@ class Create extends Action
 
         $queueForEvents->setParam('migrationId', $migration->getId());
 
-        $publisherForMigrations->enqueue(new MigrationMessage(
+        $publisherForMigrations->publish(new MigrationMessage(
             project: $project,
             migration: $migration,
             platform: $platform,

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Update.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Update.php
@@ -79,7 +79,7 @@ class Update extends Action
             ->setAttribute('status', 'pending')
             ->setAttribute('dateUpdated', \time());
 
-        $publisherForMigrations->enqueue(new MigrationMessage(
+        $publisherForMigrations->publish(new MigrationMessage(
             project: $project,
             migration: $migration,
             platform: $platform,

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Delete.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Delete.php
@@ -82,7 +82,7 @@ class Delete extends Action
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove project from DB');
         }
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $project,
             type: DELETE_TYPE_DOCUMENT,
             document: $project,

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Delete.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Delete.php
@@ -71,7 +71,7 @@ class Delete extends Action
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove project from DB');
         }
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $project,
             type: DELETE_TYPE_DOCUMENT,
             document: $project,

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/SMTP/Tests/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/SMTP/Tests/Create.php
@@ -150,7 +150,7 @@ class Create extends Action
             ->setParam('{{replyTo}}', "{$replyToNameDisplay} ({$replyToEmailDisplay})");
 
         foreach ($emails as $email) {
-            $publisherForMails->enqueue(new MailMessage(
+            $publisherForMails->publish(new MailMessage(
                 project: $project,
                 recipient: $email,
                 subject: $subject,

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/API/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/API/Create.php
@@ -127,7 +127,7 @@ class Create extends Action
         $rule = $this->createRule($rule, $dbForPlatform, $authorization, $bus);
 
         if ($rule->getAttribute('status', '') === RULE_STATUS_CERTIFICATE_GENERATING) {
-            $publisherForCertificates->enqueue(new \Appwrite\Event\Message\Certificate(
+            $publisherForCertificates->publish(new \Appwrite\Event\Message\Certificate(
                 project: $project,
                 domain: new Document([
                     'domain' => $rule->getAttribute('domain'),

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Delete.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Delete.php
@@ -87,7 +87,7 @@ class Delete extends Action
 
         $bus->dispatch(new RuleDeleted($rule->getArrayCopy()));
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $project,
             type: DELETE_TYPE_DOCUMENT,
             document: $rule,

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Function/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Function/Create.php
@@ -155,7 +155,7 @@ class Create extends Action
             || $certificateIssuer->isAutoIssueEnabled($rule);
 
         if ($needsCertificate) {
-            $publisherForCertificates->enqueue(new \Appwrite\Event\Message\Certificate(
+            $publisherForCertificates->publish(new \Appwrite\Event\Message\Certificate(
                 project: $project,
                 domain: new Document([
                     'domain' => $rule->getAttribute('domain'),

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Redirect/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Redirect/Create.php
@@ -171,7 +171,7 @@ class Create extends Action
         $rule = $this->createRule($rule, $dbForPlatform, $authorization, $bus);
 
         if ($rule->getAttribute('status', '') === RULE_STATUS_CERTIFICATE_GENERATING) {
-            $publisherForCertificates->enqueue(new \Appwrite\Event\Message\Certificate(
+            $publisherForCertificates->publish(new \Appwrite\Event\Message\Certificate(
                 project: $project,
                 domain: new Document([
                     'domain' => $rule->getAttribute('domain'),

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Site/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Site/Create.php
@@ -155,7 +155,7 @@ class Create extends Action
             || $certificateIssuer->isAutoIssueEnabled($rule);
 
         if ($needsCertificate) {
-            $publisherForCertificates->enqueue(new \Appwrite\Event\Message\Certificate(
+            $publisherForCertificates->publish(new \Appwrite\Event\Message\Certificate(
                 project: $project,
                 domain: new Document([
                     'domain' => $rule->getAttribute('domain'),

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Status/Update.php
@@ -117,7 +117,7 @@ class Update extends Action
         }
 
         // Issue a TLS certificate when DNS verification is successful
-        $publisherForCertificates->enqueue(new \Appwrite\Event\Message\Certificate(
+        $publisherForCertificates->publish(new \Appwrite\Event\Message\Certificate(
             project: $project,
             domain: new Document([
                 'domain' => $rule->getAttribute('domain'),

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Delete.php
@@ -144,7 +144,7 @@ class Delete extends Action
             ->setParam('siteId', $site->getId())
             ->setParam('deploymentId', $deployment->getId());
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $queueForEvents->getProject(),
             type: DELETE_TYPE_DOCUMENT,
             document: $deployment,

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Delete.php
@@ -80,7 +80,7 @@ class Delete extends Base
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove site from DB');
         }
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $queueForEvents->getProject(),
             type: DELETE_TYPE_DOCUMENT,
             document: $site,

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Delete.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Delete.php
@@ -77,7 +77,7 @@ class Delete extends Action
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove bucket from DB');
         }
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $queueForEvents->getProject(),
             type: DELETE_TYPE_DOCUMENT,
             document: $bucket,

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Delete.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Delete.php
@@ -128,7 +128,7 @@ class Delete extends Action
         }
 
         if ($deviceDeleted) {
-            $publisherForDeletes->enqueue(new DeleteMessage(
+            $publisherForDeletes->publish(new DeleteMessage(
                 project: $queueForEvents->getProject(),
                 type: DELETE_TYPE_CACHE_BY_RESOURCE,
                 resource: 'file/' . $fileId,

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
@@ -457,7 +457,7 @@ class Create extends Action
                     ];
                 }
 
-                $publisherForMails->enqueue(new MailMessage(
+                $publisherForMails->publish(new MailMessage(
                     project: $project,
                     recipient: $invitee->getAttribute('email'),
                     name: $invitee->getAttribute('name', ''),
@@ -488,7 +488,7 @@ class Create extends Action
                     ],
                 ]);
 
-                $publisherForMessaging->enqueue(new MessagingMessage(
+                $publisherForMessaging->publish(new MessagingMessage(
                     type: MESSAGE_SEND_TYPE_INTERNAL,
                     project: $project,
                     message: $messageDoc,

--- a/src/Appwrite/Platform/Modules/Teams/Http/Teams/Delete.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Teams/Delete.php
@@ -80,14 +80,14 @@ class Delete extends Action
 
         // Async delete
         if ($project->getId() === 'console') {
-            $publisherForDeletes->enqueue(new DeleteMessage(
+            $publisherForDeletes->publish(new DeleteMessage(
                 project: $project,
                 type: DELETE_TYPE_TEAM_PROJECTS,
                 document: $team,
             ));
         }
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $project,
             type: DELETE_TYPE_DOCUMENT,
             document: $team,

--- a/src/Appwrite/Platform/Modules/Users/Http/Users/Delete.php
+++ b/src/Appwrite/Platform/Modules/Users/Http/Users/Delete.php
@@ -76,7 +76,7 @@ class Delete extends Action
         DeleteIdentities::delete($dbForProject, Query::equal('userInternalId', [$user->getSequence()]));
         DeleteTargets::delete($dbForProject, Query::equal('userInternalId', [$user->getSequence()]));
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $queueForEvents->getProject(),
             type: DELETE_TYPE_DOCUMENT,
             document: $clone,

--- a/src/Appwrite/Platform/Modules/Users/Http/Users/Targets/Delete.php
+++ b/src/Appwrite/Platform/Modules/Users/Http/Users/Targets/Delete.php
@@ -80,7 +80,7 @@ class Delete extends Action
         $dbForProject->deleteDocument('targets', $target->getId());
         $dbForProject->purgeCachedDocument('users', $user->getId());
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $queueForEvents->getProject(),
             type: DELETE_TYPE_TARGET,
             document: $target,

--- a/src/Appwrite/Platform/Modules/VCS/Http/Installations/Delete.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/Installations/Delete.php
@@ -77,7 +77,7 @@ class Delete extends Action
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove installation from DB');
         }
 
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             project: $project,
             type: DELETE_TYPE_DOCUMENT,
             document: $installation,

--- a/src/Appwrite/Platform/Tasks/Interval.php
+++ b/src/Appwrite/Platform/Tasks/Interval.php
@@ -115,7 +115,7 @@ class Interval extends Action
 
         foreach ($rules as $rule) {
             try {
-                $publisherForCertificates->enqueue(new \Appwrite\Event\Message\Certificate(
+                $publisherForCertificates->publish(new \Appwrite\Event\Message\Certificate(
                     project: new Document([
                         '$id' => $rule->getAttribute('projectId', ''),
                         '$sequence' => $rule->getAttribute('projectInternalId', 0),

--- a/src/Appwrite/Platform/Tasks/Maintenance.php
+++ b/src/Appwrite/Platform/Tasks/Maintenance.php
@@ -75,7 +75,7 @@ class Maintenance extends Action
                 fn () => $dbForPlatform->foreach(
                     'projects',
                     function (Document $project) use ($publisherForDeletes, $usageStatsRetentionHourly) {
-                        $publisherForDeletes->enqueue(new DeleteMessage(
+                        $publisherForDeletes->publish(new DeleteMessage(
                             project: $project,
                             type: DELETE_TYPE_MAINTENANCE,
                             hourlyUsageRetentionDatetime: DatabaseDateTime::addSeconds(new \DateTime(), -1 * $usageStatsRetentionHourly),
@@ -91,7 +91,7 @@ class Maintenance extends Action
                 APP_PROJECTS_SUBQUERIES
             );
 
-            $publisherForDeletes->enqueue(new DeleteMessage(
+            $publisherForDeletes->publish(new DeleteMessage(
                 project: $console,
                 type: DELETE_TYPE_MAINTENANCE,
                 hourlyUsageRetentionDatetime: DatabaseDateTime::addSeconds(new \DateTime(), -1 * $usageStatsRetentionHourly),
@@ -117,7 +117,7 @@ class Maintenance extends Action
 
     private function notifyDeleteConnections(DeletePublisher $publisherForDeletes): void
     {
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             type: DELETE_TYPE_REALTIME,
             datetime: DatabaseDateTime::addSeconds(new \DateTime(), -60),
         ));
@@ -125,7 +125,7 @@ class Maintenance extends Action
 
     private function notifyDeleteCSVExports(DeletePublisher $publisherForDeletes): void
     {
-        $publisherForDeletes->enqueue(new DeleteMessage(type: DELETE_TYPE_CSV_EXPORTS));
+        $publisherForDeletes->publish(new DeleteMessage(type: DELETE_TYPE_CSV_EXPORTS));
     }
 
     private function renewCertificates(Database $dbForPlatform, Certificate $publisherForCertificate, Certificates $certificateIssuer): void
@@ -169,7 +169,7 @@ class Maintenance extends Action
                 continue;
             }
 
-            $publisherForCertificate->enqueue(new \Appwrite\Event\Message\Certificate(
+            $publisherForCertificate->publish(new \Appwrite\Event\Message\Certificate(
                 project: new Document([
                     '$id' => $rule->getAttribute('projectId', ''),
                     '$sequence' => $rule->getAttribute('projectInternalId', 0),
@@ -185,7 +185,7 @@ class Maintenance extends Action
 
     private function notifyDeleteCache($interval, DeletePublisher $publisherForDeletes): void
     {
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             type: DELETE_TYPE_CACHE_BY_TIMESTAMP,
             datetime: DatabaseDateTime::addSeconds(new \DateTime(), -1 * $interval),
         ));
@@ -193,7 +193,7 @@ class Maintenance extends Action
 
     private function notifyDeleteSchedules($interval, DeletePublisher $publisherForDeletes): void
     {
-        $publisherForDeletes->enqueue(new DeleteMessage(
+        $publisherForDeletes->publish(new DeleteMessage(
             type: DELETE_TYPE_SCHEDULES,
             datetime: DatabaseDateTime::addSeconds(new \DateTime(), -1 * $interval),
         ));

--- a/src/Appwrite/Platform/Tasks/SSL.php
+++ b/src/Appwrite/Platform/Tasks/SSL.php
@@ -106,7 +106,7 @@ class SSL extends Action
             Console::info('Updated existing rule ' . $rule->getId() . ' for domain: ' . $domain->get());
         }
 
-        $publisherForCertificates->enqueue(new \Appwrite\Event\Message\Certificate(
+        $publisherForCertificates->publish(new \Appwrite\Event\Message\Certificate(
             project: $console,
             domain: new Document([
                 'domain' => $domain->get(),

--- a/src/Appwrite/Platform/Tasks/ScheduleExecutions.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleExecutions.php
@@ -77,7 +77,7 @@ class ScheduleExecutions extends Action
                 Span::add('occurrence.batch', $batch);
                 Span::add('occurrence.index', $index);
 
-                $publisherForFunctions->enqueue(new FunctionMessage(
+                $publisherForFunctions->publish(new FunctionMessage(
                     project: $schedule['project'],
                     functionId: $schedule['resource']->getAttribute('resourceId', ''),
                     execution: new Document([

--- a/src/Appwrite/Platform/Tasks/ScheduleFunctions.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleFunctions.php
@@ -87,7 +87,7 @@ class ScheduleFunctions extends Action
                 Span::add('occurrence.batch', $batch);
                 Span::add('occurrence.index', $index);
 
-                $publisherForFunctions->enqueue(new FunctionMessage(
+                $publisherForFunctions->publish(new FunctionMessage(
                     project: $schedule['project'],
                     function: $schedule['resource'],
                     type: 'schedule',

--- a/src/Appwrite/Platform/Tasks/ScheduleMessages.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleMessages.php
@@ -116,7 +116,7 @@ class ScheduleMessages extends Action
 
                 $this->updateProjectAccess($schedule['project'], $dbForPlatform);
 
-                $publisherForMessaging->enqueue(new MessagingMessage(
+                $publisherForMessaging->publish(new MessagingMessage(
                     type: MESSAGE_SEND_TYPE_EXTERNAL,
                     project: $schedule['project'],
                     messageId: $schedule['resourceId'],

--- a/src/Appwrite/Platform/Tasks/StatsResources.php
+++ b/src/Appwrite/Platform/Tasks/StatsResources.php
@@ -82,9 +82,9 @@ class StatsResources extends Action
                     Query::equal('region', [System::getEnv('_APP_REGION', 'default')]),
                     Query::orderAsc('$sequence'), // accessedAt Can be updated during iteration
                 ], function ($project) use ($publisherForStatsResources, &$projectsQueued, &$projectsFailed): void {
-                    // enqueue() swallows a publish failure, reporting it only to
+                    // publish() swallows a broker failure, reporting it only to
                     // Console and returning false — as it does when stats are off.
-                    if ($publisherForStatsResources->enqueue(new StatsResourcesMessage(project: $project)) === false) {
+                    if ($publisherForStatsResources->publish(new StatsResourcesMessage(project: $project)) === false) {
                         $projectsFailed++;
                         return;
                     }

--- a/src/Appwrite/Platform/Workers/Certificates.php
+++ b/src/Appwrite/Platform/Workers/Certificates.php
@@ -191,7 +191,7 @@ class Certificates extends Action
 
         // Issue a TLS certificate when domain is verified
         if ($rule->getAttribute('status', '') === RULE_STATUS_CERTIFICATE_GENERATING) {
-            $publisherForCertificates->enqueue(new \Appwrite\Event\Message\Certificate(
+            $publisherForCertificates->publish(new \Appwrite\Event\Message\Certificate(
                 project: new Document([
                     '$id' => $rule->getAttribute('projectId', ''),
                     '$sequence' => $rule->getAttribute('projectInternalId', 0),
@@ -462,7 +462,7 @@ class Certificates extends Action
             ->trigger();
 
         /** Trigger Functions */
-        $publisherForFunctions->enqueue(FunctionMessage::fromEvent(
+        $publisherForFunctions->publish(FunctionMessage::fromEvent(
             event: $queueForEvents->getEvent(),
             params: $queueForEvents->getParams(),
             project: $queueForEvents->getProject(),
@@ -573,7 +573,7 @@ class Certificates extends Action
         $subject = $locale->getText("emails.certificate.subject");
         $preview = $locale->getText("emails.certificate.preview");
 
-        $publisherForMails->enqueue(new MailMessage(
+        $publisherForMails->publish(new MailMessage(
             recipient: System::getEnv('_APP_EMAIL_CERTIFICATES', System::getEnv('_APP_SYSTEM_SECURITY_EMAIL_ADDRESS')),
             name: 'Appwrite Administrator',
             subject: $subject,

--- a/src/Appwrite/Platform/Workers/Deletes.php
+++ b/src/Appwrite/Platform/Workers/Deletes.php
@@ -600,7 +600,7 @@ class Deletes extends Action
                 $queries,
                 $dbForProject,
                 function (Document $deployment) use ($publisherForDeletes, $project) {
-                    $publisherForDeletes->enqueue(new DeleteMessage(
+                    $publisherForDeletes->publish(new DeleteMessage(
                         project: $project,
                         type: DELETE_TYPE_DOCUMENT,
                         document: $deployment,

--- a/src/Appwrite/Platform/Workers/Functions.php
+++ b/src/Appwrite/Platform/Workers/Functions.php
@@ -127,7 +127,7 @@ class Functions extends Action
                 project: $project,
                 execution: $execution,
                 functionId: $functionId,
-                enqueue: fn (FunctionMessage $message) => $publisherForFunctions->enqueue($message),
+                enqueue: fn (FunctionMessage $message) => $publisherForFunctions->publish($message),
             );
             return;
         }
@@ -782,7 +782,7 @@ class Functions extends Action
             ->trigger();
 
         /** Trigger Functions */
-        $publisherForFunctions->enqueue(FunctionMessage::fromEvent(
+        $publisherForFunctions->publish(FunctionMessage::fromEvent(
             event: $queueForEvents->getEvent(),
             params: $queueForEvents->getParams(),
             project: $queueForEvents->getProject(),

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -1041,7 +1041,7 @@ class Migrations extends Action
             'type' => $exportType,
         ];
 
-        $publisherForMails->enqueue(new MailMessage(
+        $publisherForMails->publish(new MailMessage(
             project: $project,
             recipient: $user->getAttribute('email'),
             name: $user->getAttribute('name', $user->getAttribute('email')),

--- a/src/Appwrite/Platform/Workers/Webhooks.php
+++ b/src/Appwrite/Platform/Workers/Webhooks.php
@@ -326,7 +326,7 @@ class Webhooks extends Action
                 : "/projects/{$projectId}/settings/webhooks");
             $template->setParam('{{attempts}}', $attempts);
 
-            $publisherForNotifications->enqueue(new NotificationMessage(
+            $publisherForNotifications->publish(new NotificationMessage(
                 project: $project,
                 recipients: $recipients,
                 deduplicationKey: 'webhook:' . $webhook->getId() . ':paused:' . $webhook->getUpdatedAt(),

--- a/tests/unit/Event/Publisher/BackgroundTest.php
+++ b/tests/unit/Event/Publisher/BackgroundTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Event\Publisher;
+
+use Appwrite\Event\Message\Audit as AuditMessage;
+use Appwrite\Event\Message\Usage as UsageMessage;
+use Appwrite\Event\Publisher\Audit;
+use Appwrite\Event\Publisher\Usage;
+use PHPUnit\Framework\TestCase;
+use Tests\Unit\Event\MockPublisher;
+use Utopia\Database\Document;
+use Utopia\Queue\Publisher\Asynchronous;
+use Utopia\Queue\Publisher\Synchronous;
+use Utopia\Queue\Queue;
+
+final class RecordingPublisher implements Synchronous, Asynchronous
+{
+    /** @var list<string> */
+    public array $enqueued = [];
+
+    /** @var list<string> */
+    public array $published = [];
+
+    public function enqueue(Queue $queue, array $payload, bool $priority = false): void
+    {
+        $this->enqueued[] = $queue->name;
+    }
+
+    public function publish(Queue $queue, array $payload, bool $priority = false): bool
+    {
+        $this->published[] = $queue->name;
+
+        return true;
+    }
+
+    public function enqueueMany(Queue $queue, array $payloads, bool $priority = false): bool
+    {
+        return true;
+    }
+
+    public function retry(Queue $queue, ?int $limit = null): void
+    {
+    }
+
+    public function getQueueSize(Queue $queue, bool $failedJobs = false): int
+    {
+        return 0;
+    }
+}
+
+final class BackgroundTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        putenv('_APP_EDITION=cloud');
+        putenv('_APP_USAGE_STATS=enabled');
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('_APP_EDITION');
+        putenv('_APP_USAGE_STATS');
+        parent::tearDown();
+    }
+
+    public function testAuditUsesAsynchronousPublisher(): void
+    {
+        $publisher = new RecordingPublisher();
+        $audit = new Audit($publisher, new Queue('audits'));
+
+        $this->assertTrue($audit->enqueue(new AuditMessage('document.create', ['id' => 'document'])));
+        $this->assertSame(['audits'], $publisher->enqueued);
+        $this->assertSame([], $publisher->published);
+    }
+
+    public function testUsageUsesAsynchronousPublisher(): void
+    {
+        $publisher = new RecordingPublisher();
+        $usage = new Usage($publisher, new Queue('usage'));
+
+        $this->assertTrue($usage->enqueue(new UsageMessage(
+            new Document(['$id' => 'project', '$sequence' => 42]),
+            [['key' => 'requests', 'value' => 1]],
+        )));
+        $this->assertSame(['usage'], $publisher->enqueued);
+        $this->assertSame([], $publisher->published);
+    }
+
+    public function testUsageRetainsSynchronousFallback(): void
+    {
+        $publisher = new MockPublisher();
+        $usage = new Usage($publisher, new Queue('usage'));
+
+        $this->assertTrue($usage->enqueue(new UsageMessage(
+            new Document(['$id' => 'project', '$sequence' => 42]),
+            [['key' => 'requests', 'value' => 1]],
+        )));
+        $this->assertCount(1, $publisher->getEvents('usage'));
+    }
+}

--- a/tests/unit/Event/Publisher/BackgroundTest.php
+++ b/tests/unit/Event/Publisher/BackgroundTest.php
@@ -5,12 +5,19 @@ declare(strict_types=1);
 namespace Tests\Unit\Event\Publisher;
 
 use Appwrite\Event\Message\Audit as AuditMessage;
+use Appwrite\Event\Message\Database as DatabaseMessage;
 use Appwrite\Event\Message\Usage as UsageMessage;
 use Appwrite\Event\Publisher\Audit;
+use Appwrite\Event\Publisher\Database;
 use Appwrite\Event\Publisher\Usage;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
+use Swoole\Coroutine;
 use Tests\Unit\Event\MockPublisher;
 use Utopia\Database\Document;
+use Utopia\Queue\Broker\Background;
 use Utopia\Queue\Publisher\Asynchronous;
 use Utopia\Queue\Publisher\Synchronous;
 use Utopia\Queue\Queue;
@@ -87,6 +94,86 @@ final class BackgroundTest extends TestCase
         )));
         $this->assertSame(['usage'], $publisher->enqueued);
         $this->assertSame([], $publisher->published);
+    }
+
+    public function testPublishUsesBrokerEvenWhenBackgroundDeliveryIsAvailable(): void
+    {
+        $publisher = new RecordingPublisher();
+        $usage = new Usage($publisher, new Queue('usage'));
+        $message = new UsageMessage(
+            new Document(['$id' => 'project', '$sequence' => 42]),
+            [['key' => 'requests', 'value' => 1]],
+        );
+
+        $this->assertTrue($usage->publish($message));
+        $this->assertSame(['usage'], $publisher->published);
+        $this->assertSame([], $publisher->enqueued);
+    }
+
+    public static function dispatchMethods(): array
+    {
+        return [['publish'], ['enqueue']];
+    }
+
+    #[DataProvider('dispatchMethods')]
+    public function testDisabledUsageDoesNotReachEitherDeliveryPath(string $method): void
+    {
+        putenv('_APP_USAGE_STATS=disabled');
+        $publisher = new RecordingPublisher();
+        $usage = new Usage($publisher, new Queue('usage'));
+
+        $this->assertFalse($usage->$method(new UsageMessage(new Document(['$id' => 'project']), [])));
+        $this->assertSame([], $publisher->published);
+        $this->assertSame([], $publisher->enqueued);
+    }
+
+    #[DataProvider('dispatchMethods')]
+    public function testSelfHostedAuditsRemainDisabled(string $method): void
+    {
+        putenv('_APP_EDITION=self-hosted');
+        $publisher = new RecordingPublisher();
+        $audit = new Audit($publisher, new Queue('audits'));
+
+        $this->assertFalse($audit->$method(new AuditMessage('document.create', ['id' => 'document'])));
+        $this->assertSame([], $publisher->published);
+        $this->assertSame([], $publisher->enqueued);
+    }
+
+    #[DataProvider('dispatchMethods')]
+    public function testDatabaseKeepsProjectRoutingAndExplicitOverrides(string $method): void
+    {
+        $publisher = new MockPublisher();
+        $database = new Database($publisher, new Queue('default'));
+        $message = new DatabaseMessage(project: new Document(['database' => 'mysql://shard-a:3306']));
+
+        $database->$method($message);
+        $database->$method($message, new Queue('override'));
+        $database->$method(new DatabaseMessage());
+
+        $this->assertSame([$message->toArray()], $publisher->getEvents('shard-a'));
+        $this->assertSame([$message->toArray()], $publisher->getEvents('override'));
+        $this->assertCount(1, $publisher->getEvents('default'));
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testBoundPublisherDrainsBufferedMessagesAndPublishesSynchronously(): void
+    {
+        Coroutine\run(function (): void {
+            $broker = new MockPublisher();
+            $usage = new Usage(new Background($broker, maxBatchInterval: 60.0, maxBatchSize: 100), new Queue('usage'));
+            $buffered = new UsageMessage(new Document(['$id' => 'buffered']), [['key' => 'requests', 'value' => 1]]);
+            $synchronous = new UsageMessage(new Document(['$id' => 'synchronous']), [['key' => 'requests', 'value' => 2]]);
+
+            $usage->start();
+            $usage->enqueue($buffered);
+            $usage->publish($synchronous);
+            $this->assertSame([$synchronous->toArray()], $broker->getEvents('usage'));
+
+            $usage->shutdown();
+            $this->assertSame([$synchronous->toArray(), $buffered->toArray()], $broker->getEvents('usage'));
+            $this->assertSame(2, $usage->getSize());
+        });
     }
 
     public function testUsageRetainsSynchronousFallback(): void


### PR DESCRIPTION
## What does this PR do?

Moves audit and usage queue writes onto Queue 2 background publishers, with explicit delivery semantics at call sites. `publisherForX` binds the queue: `publish(message)` waits for broker acceptance, while `enqueue(message)` accepts background delivery when available. Other queue call sites explicitly retain synchronous publication.

Audit and usage each own a bounded process-local buffer, flushing at 100 messages or ten seconds. HTTP, worker, CLI, and realtime lifecycles start and drain those publishers through the queue-bound wrapper; there are no separate `backgroundPublisherForX` resources. Existing self-hosted audit and usage enablement policies remain unchanged.

Cloud subclasses require the companion [publisher adapter changes](https://github.com/appwrite-labs/cloud/tree/codex/explicit-publisher-dispatch) when adopting this CE version, so both delivery modes retain concurrency admission, payload enrichment, and routing. The Cloud dependency lock has not been advanced to the new CE revision.

## Validation

- CE Event and execution-log listener tests: 26 tests, 315 assertions. The new synchronous-publication regression was observed failing before implementation.
- Separate-process Swoole test verifies immediate synchronous delivery, buffered delivery on shutdown, payload preservation, and queue size.
- Cloud publisher tests against the modified CE classes: 14 tests, 46 assertions.
- PHPStan level 4 and Pint passed for changed CE files and Cloud publisher adapters/tests.
- Local 20-VU HTTP smoke run after refactoring: 10,322 requests, zero HTTP or flow failures.
- Full Cloud integration/deployment testing was not run.

## Performance findings

The original PR comparison showed median usage enqueue time falling from 0.287 ms to 0.012 ms, but these calls occur after the HTTP response is sent. Self-hosted mode also skips audit publication. Consequently, the mixed HTTP benchmark does not show a substantial latency improvement. A clean local comparison of the original PR measured 437 vs 424 API requests/sec; small differences varied across exploratory repeats. These measurements are not a performance claim for the subsequent API refactor.
