### PR TITLE
feat(audit): carry the Origin request header into audit events

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -664,6 +664,10 @@ Http::init()
         $auditContext->hostname = $request->getHostname();
         $auditContext->sdk = \strtolower($request->getHeaderLine('x-sdk-name', ''));
         $auditContext->sdkVersion = $request->getHeaderLine('x-sdk-version', '');
+        // Unlike hostname (the host that served the request) this identifies the
+        // caller. Browsers always send it and cannot forge it, so an empty
+        // origin on a session-authenticated request means no browser made it.
+        $auditContext->origin = $request->getOrigin();
         $auditContext->event = $route->getLabel('audits.event', '');
         $auditContext->project = $project;
         $auditContext->impersonatorUser = $impersonatorUser->isEmpty() ? null : $impersonatorUser;

--- a/src/Appwrite/Event/Context/Audit.php
+++ b/src/Appwrite/Event/Context/Audit.php
@@ -16,6 +16,7 @@ class Audit
         public string $hostname = '',
         public string $sdk = '',
         public string $sdkVersion = '',
+        public string $origin = '',
         public string $event = '',
         public string $resource = '',
         public array $payload = [],
@@ -33,6 +34,7 @@ class Audit
             && $this->hostname === ''
             && $this->sdk === ''
             && $this->sdkVersion === ''
+            && $this->origin === ''
             && $this->event === ''
             && $this->resource === ''
             && $this->payload === [];

--- a/src/Appwrite/Event/Message/Audit.php
+++ b/src/Appwrite/Event/Message/Audit.php
@@ -20,6 +20,7 @@ final class Audit extends Base
         public readonly string $hostname = '',
         public readonly string $sdk = '',
         public readonly string $sdkVersion = '',
+        public readonly string $origin = '',
     ) {
     }
 
@@ -38,6 +39,7 @@ final class Audit extends Base
             'hostname' => $this->hostname,
             'sdk' => $this->sdk,
             'sdkVersion' => $this->sdkVersion,
+            'origin' => $this->origin,
         ];
     }
 
@@ -56,6 +58,7 @@ final class Audit extends Base
             hostname: $data['hostname'] ?? '',
             sdk: $data['sdk'] ?? '',
             sdkVersion: $data['sdkVersion'] ?? '',
+            origin: $data['origin'] ?? '',
         );
     }
 
@@ -74,6 +77,7 @@ final class Audit extends Base
             hostname: $context->hostname,
             sdk: $context->sdk,
             sdkVersion: $context->sdkVersion,
+            origin: $context->origin,
         );
     }
 }

--- a/src/Appwrite/Platform/Modules/Notifications/Http/Notifications/Logos/Appwrite/Get.php
+++ b/src/Appwrite/Platform/Modules/Notifications/Http/Notifications/Logos/Appwrite/Get.php
@@ -186,6 +186,7 @@ class Get extends Action
             ip: $request->getIP(),
             userAgent: $request->getUserAgent(''),
             hostname: $request->getHostname(),
+            origin: $request->getOrigin(),
         ));
     }
 

--- a/tests/unit/Event/Message/AuditTest.php
+++ b/tests/unit/Event/Message/AuditTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Event\Message;
+
+use Appwrite\Event\Context\Audit as AuditContext;
+use Appwrite\Event\Message\Audit as AuditMessage;
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Document;
+
+require_once __DIR__ . '/../../../../app/init.php';
+
+final class AuditTest extends TestCase
+{
+    /**
+     * The request context and the queue payload are separated by a serialize /
+     * deserialize hop, so a field the context carries but `toArray()` omits is
+     * dropped without any error — the worker just sees nothing. Walk the whole
+     * hop the way the request lifecycle does: context → message → payload →
+     * message.
+     */
+    public function testAuditMessageCarriesRequestFieldsAcrossTheQueue(): void
+    {
+        $context = new AuditContext(
+            project: new Document(['$id' => 'project-1', '$sequence' => '1']),
+            user: new Document(['$id' => 'user-1']),
+            mode: APP_MODE_ADMIN,
+            userAgent: 'Mozilla/5.0',
+            ip: '8.8.8.8',
+            hostname: 'sgp.cloud.appwrite.io',
+            sdk: 'console',
+            sdkVersion: '16.0.0',
+            origin: 'https://cloud.appwrite.io',
+            event: 'database.delete',
+            resource: 'database/database-1',
+        );
+
+        $payload = AuditMessage::fromContext($context)->toArray();
+
+        $this->assertSame('https://cloud.appwrite.io', $payload['origin']);
+        $this->assertSame('sgp.cloud.appwrite.io', $payload['hostname']);
+        $this->assertSame('console', $payload['sdk']);
+        $this->assertSame(APP_MODE_ADMIN, $payload['mode']);
+
+        $this->assertSame('https://cloud.appwrite.io', AuditMessage::fromArray($payload)->origin);
+        $this->assertSame($payload, AuditMessage::fromArray($payload)->toArray());
+    }
+
+    /**
+     * A caller that is not a browser sends no `Origin` header, and that absence
+     * is the reason the field exists — it is what separates a console click
+     * from a script replaying a console session cookie. It has to survive the
+     * queue hop as an empty string rather than becoming a missing key, because
+     * a consumer reading a missing key cannot tell "no origin" from "this build
+     * does not send origin yet".
+     */
+    public function testAuditMessageKeepsAnAbsentOriginAsAnEmptyString(): void
+    {
+        $payload = AuditMessage::fromContext(new AuditContext(
+            mode: APP_MODE_ADMIN,
+            hostname: 'sgp.cloud.appwrite.io',
+            event: 'database.delete',
+            resource: 'database/database-1',
+        ))->toArray();
+
+        $this->assertArrayHasKey('origin', $payload);
+        $this->assertSame('', $payload['origin']);
+        $this->assertSame('', AuditMessage::fromArray($payload)->origin);
+    }
+
+    /**
+     * `isEmpty()` decides whether the lifecycle publishes anything at all, so a
+     * field it does not check makes a context that carries only that field look
+     * empty and never reach the queue.
+     */
+    public function testContextCarryingOnlyAnOriginIsNotEmpty(): void
+    {
+        $this->assertTrue((new AuditContext())->isEmpty());
+        $this->assertFalse((new AuditContext(origin: 'https://cloud.appwrite.io'))->isEmpty());
+    }
+}


### PR DESCRIPTION
## What

Adds `origin` to the audit event context and message, populated from the `Origin` request header.

## Why

An audit event records `hostname` — the host that served the request — but nothing identifying the caller. For an admin-mode event that leaves no way to tell a console click apart from a script replaying a console session cookie: `sdk` is the client-declared `X-Sdk-Name` header, so `sdk: console` proves nothing.

`Origin` is the header that answers it. Browsers always send it and cannot forge it. `general.php` already reads it for CORS — but only when present:

```php
$origin = $request->getOrigin();
if (empty($origin) || !$devKey->isEmpty() || !empty($request->getHeaderLine('x-appwrite-key'))) {
    return;
}
```

so a caller that sends no `Origin` skips origin validation entirely. Recording it captures both halves: which app made the call, and the absence that marks a call no browser made.

## Changes

- `Event\Context\Audit` — `origin` property, included in `isEmpty()`.
- `Event\Message\Audit` — `origin` through the constructor, `toArray()`, `fromArray()` and `fromContext()`.
- `app/controllers/shared/api.php` — populated alongside `hostname` / `sdk` in the request lifecycle.
- `Notifications/.../Logos/Appwrite/Get.php` — populated from the request on the notification-view event, which builds its own message rather than going through the context.

## Tests

`tests/unit/Event/Message/AuditTest.php` walks the whole context → message → payload → message hop, which is where this class of bug lives: a field the context carries but `toArray()` omits is dropped silently and the worker just sees nothing.

- Fields survive the round trip, and `fromArray(toArray())` is stable.
- An absent origin stays `''` rather than becoming a missing key — a consumer reading a missing key cannot tell "no origin" from "this build does not send origin yet".
- A context carrying only an origin is not `isEmpty()`, since `isEmpty()` gates whether anything is published at all.

Verified with `pint` and PHPStan on the changed paths.

## Consumers

Appwrite Cloud writes this to its ClickHouse audit schema and exposes it on the activity event model. The column itself is utopia-php/monorepo#210. Both are additive — until they land the value is `''` and the audit adapter drops the unknown key, so merge order does not matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)