### PR TITLE
Upgrade Compose orchestrator to 2.1.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1678,7 +1678,7 @@ services:
     # One image carrying every orchestrator control plane. Appwrite drives the
     # jobs plane today; the per-plane images exist for Kubernetes, where each
     # scales, fails and gets RBAC on its own.
-    image: ghcr.io/open-runtimes/orchestrator/orchestrator:1.9.2
+    image: ghcr.io/open-runtimes/orchestrator/orchestrator:2.1.0
     restart: unless-stopped
     user: root
     networks:


### PR DESCRIPTION
Upgrade the combined orchestrator Docker Compose image from 1.9.2 to 2.1.0. This brings local Appwrite builds onto the orchestrator release verified by staging Cloud function and site builds.

Validation: Docker Compose configuration renders successfully and selects `ghcr.io/open-runtimes/orchestrator/orchestrator:2.1.0`; `git diff --check` passes. The local Docker stack was not restarted and Docker-backend E2E was not rerun for this image bump.
