### PR TITLE
refactor: replace CLI and migration logError callbacks with spans

### DIFF
--- a/app/cli.php
+++ b/app/cli.php
@@ -187,7 +187,7 @@ $cli
     ->error()
     ->inject('error')
     ->action(function (Throwable $error) use ($taskName, &$exitCode) {
-        $span = Span::current() ?? Span::init('actions.cli');
+        $span = Span::current() ?? Span::init("task.$taskName");
         $span->set('cli.task', $taskName);
         $span->finish(error: $error);
 
@@ -196,7 +196,7 @@ $cli
     });
 
 $cli->init()->action(function () use ($taskName) {
-    Span::init('actions.cli')->set('cli.task', $taskName);
+    Span::init("task.$taskName")->set('cli.task', $taskName);
 });
 
 $cli->shutdown()->action(function () {

--- a/app/cli.php
+++ b/app/cli.php
@@ -188,7 +188,6 @@ $cli
     ->inject('error')
     ->action(function (Throwable $error) use ($taskName, &$exitCode) {
         $span = Span::current() ?? Span::init("task.$taskName");
-        Span::add('cli.task', $taskName);
         $span->finish(error: $error);
 
         $exitCode = 1;
@@ -197,7 +196,6 @@ $cli
 
 $cli->init()->action(function () use ($taskName) {
     Span::init("task.$taskName");
-    Span::add('cli.task', $taskName);
 });
 
 $cli->shutdown()->action(function () {

--- a/app/cli.php
+++ b/app/cli.php
@@ -177,21 +177,6 @@ $container->set('getLogsDB', function (Group $pools, Cache $cache, Authorization
 $container->set('usage', function () {
     return new UsageContext();
 }, []);
-$container->set('logError', function () {
-    return function (Throwable $error, string $namespace, string $action) {
-        Console::error('[Error] Timestamp: ' . date('c', time()));
-        Console::error('[Error] Type: ' . get_class($error));
-        Console::error('[Error] Message: ' . $error->getMessage());
-        Console::error('[Error] File: ' . $error->getFile());
-        Console::error('[Error] Line: ' . $error->getLine());
-        Console::error('[Error] Trace: ' . $error->getTraceAsString());
-
-        // Tasks run outside a request span; open one so the failure reaches the exporters.
-        $span = Span::current() ?? Span::init($action);
-        $span->finish(error: $error);
-    };
-}, []);
-
 $container->set('bus', function (Registry $register) use ($container) {
     return $register->get('bus')->setResolver(fn (string $name) => $container->get($name));
 }, ['register']);
@@ -201,19 +186,23 @@ $exitCode = 0;
 $cli
     ->error()
     ->inject('error')
-    ->inject('logError')
-    ->action(function (Throwable $error, callable $logError) use ($taskName, &$exitCode) {
-        call_user_func_array($logError, [
-            $error,
-            'Task',
-            $taskName,
-        ]);
+    ->action(function (Throwable $error) use ($taskName, &$exitCode) {
+        $span = Span::current() ?? Span::init('actions.cli');
+        $span->set('cli.task', $taskName);
+        $span->finish(error: $error);
 
         $exitCode = 1;
         Timer::clearAll();
     });
 
-$cli->shutdown()->action(fn () => Timer::clearAll());
+$cli->init()->action(function () use ($taskName) {
+    Span::init('actions.cli')->set('cli.task', $taskName);
+});
+
+$cli->shutdown()->action(function () {
+    Span::current()?->finish();
+    Timer::clearAll();
+});
 
 Runtime::enableCoroutine(SWOOLE_HOOK_ALL);
 require_once __DIR__ . '/init/span.php';

--- a/app/cli.php
+++ b/app/cli.php
@@ -188,7 +188,7 @@ $cli
     ->inject('error')
     ->action(function (Throwable $error) use ($taskName, &$exitCode) {
         $span = Span::current() ?? Span::init("task.$taskName");
-        $span->set('cli.task', $taskName);
+        Span::add('cli.task', $taskName);
         $span->finish(error: $error);
 
         $exitCode = 1;
@@ -196,7 +196,8 @@ $cli
     });
 
 $cli->init()->action(function () use ($taskName) {
-    Span::init("task.$taskName")->set('cli.task', $taskName);
+    Span::init("task.$taskName");
+    Span::add('cli.task', $taskName);
 });
 
 $cli->shutdown()->action(function () {

--- a/app/init/span.php
+++ b/app/init/span.php
@@ -18,8 +18,13 @@ $traceFunctionId = System::getEnv('_APP_TRACE_FUNCTION_ID', '');
 $traceEnabled = $traceProjectId !== '' || $traceFunctionId !== '';
 
 $sampler = function (Span $span) use ($traceEnabled, $traceProjectId, $traceFunctionId): bool {
+    $warning = $span->get('warning.message') !== null || (int) $span->get('embedding.errors') > 0;
+    if ($warning && $span->getError() === null) {
+        $span->set('level', 'warn');
+    }
+
     if (\str_starts_with($span->getAction(), 'listener.')) {
-        return $span->getError() !== null;
+        return $span->getError() !== null || $warning;
     }
 
     // Selective tracing: when _APP_TRACE_PROJECT_ID / _APP_TRACE_FUNCTION_ID are set,

--- a/app/init/span.php
+++ b/app/init/span.php
@@ -18,17 +18,23 @@ $traceFunctionId = System::getEnv('_APP_TRACE_FUNCTION_ID', '');
 $traceEnabled = $traceProjectId !== '' || $traceFunctionId !== '';
 
 $sampler = function (Span $span) use ($traceEnabled, $traceProjectId, $traceFunctionId): bool {
+    // Terminal diagnostics must survive tracing filters, including failures
+    // before project or function resolution.
+    if ($span->getError() !== null) {
+        return true;
+    }
+
     $warning = $span->get('warning.message') !== null || (int) $span->get('embedding.errors') > 0;
-    if ($warning && $span->getError() === null) {
+    if ($warning) {
         $span->set('level', 'warn');
     }
 
     if (\str_starts_with($span->getAction(), 'listener.')) {
-        return $span->getError() !== null || $warning;
+        return $warning;
     }
 
     // Selective tracing: when _APP_TRACE_PROJECT_ID / _APP_TRACE_FUNCTION_ID are set,
-    // only export spans tagged with matching project.id / function.id.
+    // only export non-terminal spans tagged with matching project.id / function.id.
     if ($traceEnabled) {
         if ($traceProjectId !== '' && $span->get('project.id') !== $traceProjectId) {
             return false;

--- a/app/init/worker/message.php
+++ b/app/init/worker/message.php
@@ -13,7 +13,6 @@ use OpenRuntimes\Orchestrator\Jobs;
 use Utopia\Audit\Adapter\Database as AdapterDatabase;
 use Utopia\Audit\Audit as UtopiaAudit;
 use Utopia\Cache\Cache;
-use Utopia\Console;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -197,32 +196,6 @@ return function (Container $container): void {
     $container->set('deployments', function (Jobs $jobs, Database $dbForProject, Document $project, array $platform) {
         return new Deployments($jobs, $dbForProject, $project, $platform);
     }, ['jobs', 'dbForProject', 'project', 'platform']);
-
-    $container->set('logError', function (Document $project) {
-        return function (Throwable $error, string $namespace, string $action, ?array $extras = null) use ($project) {
-            $span = Span::current();
-            if ($span !== null) {
-                $span->setError($error);
-                $span->set('project.id', $project->getId());
-                $span->set('error.action', $action);
-                foreach (($extras ?? []) as $key => $value) {
-                    if (\is_scalar($value) || $value === null) {
-                        $span->set('error.' . $key, $value);
-                    }
-                }
-            }
-
-            Console::warning("Failed: {$error->getMessage()}");
-            Console::warning($error->getTraceAsString());
-
-            if ($error->getPrevious() !== null) {
-                if ($error->getPrevious()->getMessage() != $error->getMessage()) {
-                    Console::warning("Previous Failed: {$error->getPrevious()->getMessage()}");
-                }
-                Console::warning("Previous File: {$error->getPrevious()->getFile()} Line: {$error->getPrevious()->getLine()}");
-            }
-        };
-    }, ['project']);
 
     $container->set('getAudit', function (Database $dbForPlatform, callable $getProjectDB) {
         return function (Document $project) use ($dbForPlatform, $getProjectDB) {

--- a/app/worker.php
+++ b/app/worker.php
@@ -150,15 +150,10 @@ Console::success('Listening for jobs…');
 $worker
     ->error()
     ->inject('error')
-    ->inject('project')
-    ->action(function (Throwable $error, Document $project) {
-        Span::current()?->setError($error);
-        Span::add('project.id', $project->getId());
-
-        Console::error('[Error] Type: ' . get_class($error));
-        Console::error('[Error] Message: ' . $error->getMessage());
-        Console::error('[Error] File: ' . $error->getFile());
-        Console::error('[Error] Line: ' . $error->getLine());
+    ->action(function (Throwable $error) use ($workerName) {
+        // Initialization can fail before the message span or project is available.
+        $span = Span::current() ?? Span::init("worker.{$workerName}");
+        $span->finish(error: $error);
     });
 
 $worker->start();

--- a/src/Appwrite/Platform/Action.php
+++ b/src/Appwrite/Platform/Action.php
@@ -12,13 +12,6 @@ use Utopia\Platform\Action as UtopiaAction;
 
 class Action extends UtopiaAction
 {
-    /**
-     * Log Error Callback
-     *
-     * @var callable
-     */
-    protected mixed $logError;
-
     protected array $filters = [
         ...APP_PROJECTS_SUBQUERIES, // Project
         ...APP_USERS_SUBQUERIES, // Users
@@ -54,19 +47,11 @@ class Action extends UtopiaAction
 
         while ($sum === $limit) {
             $newQueries = $queries;
-            try {
-                if ($latestDocument !== null) {
-                    array_unshift($newQueries, Query::cursorAfter($latestDocument));
-                }
-                $newQueries[] = Query::limit($limit);
-                $database->disableValidation();
-                $results = $database->find($collection, $newQueries);
-                $database->enableValidation();
-            } catch (\Exception $e) {
-                if (!empty($this->logError)) {
-                    call_user_func_array($this->logError, [$e, "CLI", "fetch_documents_namespace_{$database->getNamespace()}_collection{$collection}"]);
-                }
+            if ($latestDocument !== null) {
+                array_unshift($newQueries, Query::cursorAfter($latestDocument));
             }
+            $newQueries[] = Query::limit($limit);
+            $results = $database->skipValidation(fn () => $database->find($collection, $newQueries));
 
             if (empty($results)) {
                 return;

--- a/src/Appwrite/Platform/Modules/Databases/Http/Embeddings/Text/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Embeddings/Text/Create.php
@@ -112,7 +112,9 @@ class Create extends CreateDocumentAction
                 }
             } catch (\Exception $e) {
                 $totalErrors += \count($batch);
-                $this->logError($e, $model);
+                Span::add('embedding.model', $model);
+                Span::add('warning.message', $e->getMessage());
+                Span::add('warning.code', $e->getCode());
 
                 // One error result per text in the failed batch.
                 foreach ($batch as $ignored) {
@@ -120,6 +122,8 @@ class Create extends CreateDocumentAction
                 }
             }
         }
+
+        Span::add('embedding.errors', $totalErrors);
 
         $embeddings = new Document([
             'embeddings' => $results,
@@ -156,10 +160,4 @@ class Create extends CreateDocumentAction
         ]);
     }
 
-    private function logError(\Throwable $e, string $model): void
-    {
-        Span::add('embedding.model', $model);
-        Span::add('embedding.error', $e->getMessage());
-        Span::add('embedding.error_code', $e->getCode());
-    }
 }

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -590,17 +590,18 @@ class Migrations extends Action
             }
 
             if ($publish) {
-                $extras = [];
+                Span::add('warning.message', $th->getMessage());
+                Span::add('warning.code', $th->getCode());
+                Span::add('migration.id', $migration->getId());
+                Span::add('migration.source', (string) $migration->getAttribute('source', ''));
+                Span::add('migration.destination', (string) $migration->getAttribute('destination', ''));
 
                 // Include source identifiers for Appwrite sources to make warning spans
                 // self-debuggable. Never include the apiKey or any other secret.
                 if ($migration->getAttribute('source') === SourceAppwrite::getName()) {
-                    $credentials = $migration->getAttribute('credentials', []) ?? [];
-                    $extras['source_project_id'] = $credentials['projectId'] ?? '';
-                    $extras['source_endpoint'] = $credentials['endpoint'] ?? '';
+                    Span::add('migration.source_project_id', (string) ($migration->getAttribute('credentials', [])['projectId'] ?? ''));
+                    Span::add('migration.source_endpoint', (string) ($migration->getAttribute('credentials', [])['endpoint'] ?? ''));
                 }
-
-                $this->reportWarning($th, $migration, $extras);
             }
         } finally {
             try {
@@ -865,9 +866,12 @@ class Migrations extends Action
 
         $valid = \is_string($userInternalId) || (\is_int($userInternalId) && $userInternalId > 0);
         if (!$valid) {
-            $error = new \UnexpectedValueException('Invalid initiating user sequence for export migration.');
-            Console::error($error->getMessage() . ' Migration: ' . $migration->getId());
-            $this->reportWarning($error, $migration);
+            Console::error('Invalid initiating user sequence for export migration. Migration: ' . $migration->getId());
+            Span::add('warning.message', 'Invalid initiating user sequence for export migration.');
+            Span::add('warning.code', 0);
+            Span::add('migration.id', $migration->getId());
+            Span::add('migration.source', (string) $migration->getAttribute('source', ''));
+            Span::add('migration.destination', (string) $migration->getAttribute('destination', ''));
             return new Document([]);
         }
 
@@ -876,9 +880,12 @@ class Migrations extends Action
         ]);
 
         if ($user->isEmpty()) {
-            $error = new \RuntimeException('Initiating user not found for export migration.');
-            Console::error($error->getMessage() . ' Migration: ' . $migration->getId());
-            $this->reportWarning($error, $migration);
+            Console::error('Initiating user not found for export migration. Migration: ' . $migration->getId());
+            Span::add('warning.message', 'Initiating user not found for export migration.');
+            Span::add('warning.code', 0);
+            Span::add('migration.id', $migration->getId());
+            Span::add('migration.source', (string) $migration->getAttribute('source', ''));
+            Span::add('migration.destination', (string) $migration->getAttribute('destination', ''));
         }
 
         return $user;
@@ -910,24 +917,11 @@ class Migrations extends Action
             );
         } catch (\Throwable $error) {
             Console::error('Failed to send the export notification for migration ' . $migration->getId() . ': ' . $error->getMessage());
-            $this->reportWarning($error, $migration);
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $extras
-     */
-    protected function reportWarning(\Throwable $error, Document $migration, array $extras = []): void
-    {
-        Span::add('warning.message', $error->getMessage());
-        Span::add('warning.code', $error->getCode());
-        Span::add('migration.id', $migration->getId());
-        Span::add('migration.source', $migration->getAttribute('source', ''));
-        Span::add('migration.destination', $migration->getAttribute('destination', ''));
-        foreach ($extras as $key => $value) {
-            if (\is_scalar($value) || $value === null) {
-                Span::add('migration.' . $key, $value);
-            }
+            Span::add('warning.message', $error->getMessage());
+            Span::add('warning.code', $error->getCode());
+            Span::add('migration.id', $migration->getId());
+            Span::add('migration.source', (string) $migration->getAttribute('source', ''));
+            Span::add('migration.destination', (string) $migration->getAttribute('destination', ''));
         }
     }
 

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -44,6 +44,7 @@ use Utopia\Migration\Sources\Supabase;
 use Utopia\Migration\Transfer;
 use Utopia\Platform\Action;
 use Utopia\Queue\Message;
+use Utopia\Span\Span;
 use Utopia\Storage\Device;
 use Utopia\System\System;
 use Utopia\Validator\Hostname;
@@ -74,11 +75,6 @@ class Migrations extends Action
      */
     protected array $sourceReport = [];
 
-    /**
-     * @var callable|null
-     */
-    protected $logError = null;
-
     public static function getName(): string
     {
         return 'migrations';
@@ -97,7 +93,6 @@ class Migrations extends Action
             ->inject('dbForPlatform')
             ->inject('getDatabasesDB')
             ->inject('getProjectDB')
-            ->inject('logError')
             ->inject('queueForRealtime')
             ->inject('deviceForMigrations')
             ->inject('deviceForFiles')
@@ -119,7 +114,6 @@ class Migrations extends Action
         Database $dbForPlatform,
         callable $getDatabasesDB,
         callable $getProjectDB,
-        callable $logError,
         Realtime $queueForRealtime,
         Device $deviceForMigrations,
         Device $deviceForFiles,
@@ -154,7 +148,6 @@ class Migrations extends Action
         $this->dbForProject = $dbForProject;
         $this->dbForPlatform = $dbForPlatform;
         $this->project = $project;
-        $this->logError = $logError;
 
         $platform = $migrationMessage->platform ?: Config::getParam('platform', []);
 
@@ -172,7 +165,6 @@ class Migrations extends Action
             $this->dbForProject = null;
             $this->dbForPlatform = null;
             $this->project = null;
-            $this->logError = null;
             $this->deviceForMigrations = null;
             $this->deviceForFiles = null;
             $this->plan = [];
@@ -588,7 +580,7 @@ class Migrations extends Action
 
             // Mirror general.php's HTTP-error pattern: typed AppwriteException uses its
             // registry-driven isPublishable() flag; library-thrown Migration\Exception is
-            // always user-facing; anything else is unknown and surfaced to Sentry.
+            // always user-facing; anything else is unknown and recorded as a warning.
             if ($th instanceof Exception) {
                 $publish = $th->isPublishable();
             } elseif ($th instanceof MigrationException) {
@@ -598,21 +590,17 @@ class Migrations extends Action
             }
 
             if ($publish) {
-                $extras = [
-                    'migrationId' => $migration->getId(),
-                    'source' => $migration->getAttribute('source') ?? '',
-                    'destination' => $migration->getAttribute('destination') ?? '',
-                ];
+                $extras = [];
 
-                // Include source identifiers for Appwrite sources to make Sentry events
+                // Include source identifiers for Appwrite sources to make warning spans
                 // self-debuggable. Never include the apiKey or any other secret.
                 if ($migration->getAttribute('source') === SourceAppwrite::getName()) {
                     $credentials = $migration->getAttribute('credentials', []) ?? [];
-                    $extras['sourceProjectId'] = $credentials['projectId'] ?? '';
-                    $extras['sourceEndpoint'] = $credentials['endpoint'] ?? '';
+                    $extras['source_project_id'] = $credentials['projectId'] ?? '';
+                    $extras['source_endpoint'] = $credentials['endpoint'] ?? '';
                 }
 
-                $this->reportError($th, $migration, $extras);
+                $this->reportWarning($th, $migration, $extras);
             }
         } finally {
             try {
@@ -879,7 +867,7 @@ class Migrations extends Action
         if (!$valid) {
             $error = new \UnexpectedValueException('Invalid initiating user sequence for export migration.');
             Console::error($error->getMessage() . ' Migration: ' . $migration->getId());
-            $this->reportError($error, $migration);
+            $this->reportWarning($error, $migration);
             return new Document([]);
         }
 
@@ -890,7 +878,7 @@ class Migrations extends Action
         if ($user->isEmpty()) {
             $error = new \RuntimeException('Initiating user not found for export migration.');
             Console::error($error->getMessage() . ' Migration: ' . $migration->getId());
-            $this->reportError($error, $migration);
+            $this->reportWarning($error, $migration);
         }
 
         return $user;
@@ -922,33 +910,24 @@ class Migrations extends Action
             );
         } catch (\Throwable $error) {
             Console::error('Failed to send the export notification for migration ' . $migration->getId() . ': ' . $error->getMessage());
-            $this->reportError($error, $migration);
+            $this->reportWarning($error, $migration);
         }
     }
 
     /**
      * @param array<string, mixed> $extras
      */
-    protected function reportError(\Throwable $error, Document $migration, array $extras = []): void
+    protected function reportWarning(\Throwable $error, Document $migration, array $extras = []): void
     {
-        if (!\is_callable($this->logError)) {
-            return;
-        }
-
-        try {
-            ($this->logError)(
-                $error,
-                'appwrite-worker',
-                'appwrite-queue-' . self::getName(),
-                [
-                    'migrationId' => $migration->getId(),
-                    'source' => $migration->getAttribute('source', ''),
-                    'destination' => $migration->getAttribute('destination', ''),
-                    ...$extras,
-                ]
-            );
-        } catch (\Throwable $loggingError) {
-            Console::error('Failed to report the migration error: ' . $loggingError->getMessage());
+        Span::add('warning.message', $error->getMessage());
+        Span::add('warning.code', $error->getCode());
+        Span::add('migration.id', $migration->getId());
+        Span::add('migration.source', $migration->getAttribute('source', ''));
+        Span::add('migration.destination', $migration->getAttribute('destination', ''));
+        foreach ($extras as $key => $value) {
+            if (\is_scalar($value) || $value === null) {
+                Span::add('migration.' . $key, $value);
+            }
         }
     }
 

--- a/tests/unit/Migration/MigrationsWorkerExportTest.php
+++ b/tests/unit/Migration/MigrationsWorkerExportTest.php
@@ -244,13 +244,13 @@ final class MigrationsWorkerExportTest extends TestCase
         ]));
     }
 
-    public function testNotificationAndLoggerFailuresDoNotEscape(): void
+    public function testNotificationFailureIsReportedAsWarning(): void
     {
-        $reported = 0;
+        \Utopia\Span\Span::setStorage(new \Utopia\Span\Storage\Memory());
+        $span = \Utopia\Span\Span::init('worker.migrations');
         $worker = new class () extends Migrations {
-            public function notify(Document $migration, MailPublisher $publisherForMails, callable $logError): void
+            public function notify(Document $migration, MailPublisher $publisherForMails): void
             {
-                $this->logError = $logError;
                 $this->notifyExport(
                     migration: $migration,
                     success: true,
@@ -284,13 +284,12 @@ final class MigrationsWorkerExportTest extends TestCase
                 'destination' => DestinationJSON::getName(),
             ]),
             $this->createStub(MailPublisher::class),
-            function () use (&$reported): void {
-                $reported++;
-                throw new \RuntimeException('Logger unavailable');
-            }
         );
 
-        $this->assertSame(1, $reported);
+        \Utopia\Span\Span::setStorage(null);
+        $this->assertSame('Mail unavailable', $span->get('warning.message'));
+        $this->assertSame('migration-id', $span->get('migration.id'));
+        $this->assertNull($span->getError());
     }
 
     public function testArtifactFinalizationFailureMarksMigrationFailed(): void
@@ -320,8 +319,6 @@ final class MigrationsWorkerExportTest extends TestCase
                     '$id' => 'project-id',
                     '$sequence' => 1,
                 ]);
-                $this->logError = static function (): void {
-                };
 
                 $this->processMigration(
                     $migration,

--- a/tests/unit/Migration/MigrationsWorkerExportTest.php
+++ b/tests/unit/Migration/MigrationsWorkerExportTest.php
@@ -247,49 +247,52 @@ final class MigrationsWorkerExportTest extends TestCase
     public function testNotificationFailureIsReportedAsWarning(): void
     {
         \Utopia\Span\Span::setStorage(new \Utopia\Span\Storage\Memory());
-        $span = \Utopia\Span\Span::init('worker.migrations');
-        $worker = new class () extends Migrations {
-            public function notify(Document $migration, MailPublisher $publisherForMails): void
-            {
-                $this->notifyExport(
-                    migration: $migration,
-                    success: true,
-                    project: new Document([]),
-                    user: new Document([]),
-                    options: ['notify' => true],
-                    publisherForMails: $publisherForMails,
-                    platform: [],
-                );
-            }
+        try {
+            $span = \Utopia\Span\Span::init('worker.migrations');
+            $worker = new class () extends Migrations {
+                public function notify(Document $migration, MailPublisher $publisherForMails): void
+                {
+                    $this->notifyExport(
+                        migration: $migration,
+                        success: true,
+                        project: new Document([]),
+                        user: new Document([]),
+                        options: ['notify' => true],
+                        publisherForMails: $publisherForMails,
+                        platform: [],
+                    );
+                }
 
-            protected function sendExportEmail(
-                bool $success,
-                Document $project,
-                Document $user,
-                array $options,
-                MailPublisher $publisherForMails,
-                array $platform,
-                string $exportType = 'CSV',
-                string $downloadUrl = '',
-                float $sizeMB = 0.0,
-            ): void {
-                throw new \RuntimeException('Mail unavailable');
-            }
-        };
+                protected function sendExportEmail(
+                    bool $success,
+                    Document $project,
+                    Document $user,
+                    array $options,
+                    MailPublisher $publisherForMails,
+                    array $platform,
+                    string $exportType = 'CSV',
+                    string $downloadUrl = '',
+                    float $sizeMB = 0.0,
+                ): void {
+                    throw new \RuntimeException('Mail unavailable');
+                }
+            };
 
-        $worker->notify(
-            new Document([
-                '$id' => 'migration-id',
-                'source' => 'Appwrite',
-                'destination' => DestinationJSON::getName(),
-            ]),
-            $this->createStub(MailPublisher::class),
-        );
+            $worker->notify(
+                new Document([
+                    '$id' => 'migration-id',
+                    'source' => 'Appwrite',
+                    'destination' => DestinationJSON::getName(),
+                ]),
+                $this->createStub(MailPublisher::class),
+            );
 
-        \Utopia\Span\Span::setStorage(null);
-        $this->assertSame('Mail unavailable', $span->get('warning.message'));
-        $this->assertSame('migration-id', $span->get('migration.id'));
-        $this->assertNull($span->getError());
+            $this->assertSame('Mail unavailable', $span->get('warning.message'));
+            $this->assertSame('migration-id', $span->get('migration.id'));
+            $this->assertNull($span->getError());
+        } finally {
+            \Utopia\Span\Span::setStorage(null);
+        }
     }
 
     public function testArtifactFinalizationFailureMarksMigrationFailed(): void

--- a/tests/unit/Migration/MigrationsWorkerExportTest.php
+++ b/tests/unit/Migration/MigrationsWorkerExportTest.php
@@ -289,7 +289,7 @@ final class MigrationsWorkerExportTest extends TestCase
 
             $this->assertSame('Mail unavailable', $span->get('warning.message'));
             $this->assertSame('migration-id', $span->get('migration.id'));
-            $this->assertNull($span->getError());
+            $this->assertNotInstanceOf(\Throwable::class, $span->getError());
         } finally {
             \Utopia\Span\Span::setStorage(null);
         }

--- a/tests/unit/Platform/Workers/MigrationsTest.php
+++ b/tests/unit/Platform/Workers/MigrationsTest.php
@@ -325,8 +325,6 @@ final class MigrationsTest extends TestCase
                 Authorization $authorization,
             ): void {
                 $this->project = $project;
-                $this->logError = static function (): void {
-                };
 
                 $this->processMigration(
                     $migration,


### PR DESCRIPTION
## What does this PR do?

Remove `logError` callback injection from CLI tasks and migration workers. Global CLI/worker error handlers export terminal failures once; recovered migration and embedding failures attach warning attributes using `Span::add()`. The sampler exports warning listener spans and marks recovered failures as warnings without attaching a Throwable or changing successful HTTP responses into Sentry errors. Partial embedding responses also expose the existing error count on the span.

CLI success now finishes its operation span, and worker errors before project/span initialization still get an error span. Pagination read failures propagate instead of potentially reprocessing the previous page; `skipValidation()` restores validation on both success and failure.

Realtime and presence reporting keep their existing handling for this first pass.

## Test Plan

- Existing migration tests: 12 tests / 84 assertions pass locally and in the Swoole Docker runtime.
- Actual CLI entrypoint in Docker: `version` produces one success span; an unknown task produces one terminal error span and exits 1.
- Manual sampler/pagination drill: recovered listener warning is exported without an exception; terminal error retains error severity; next listener has no stale warning; failed second page stops traversal and restores database validation. Reverting the sampler and pagination hunks fails both checks; restoring them passes.
- Pint and targeted PHPStan pass for all changed files.

No new HTTP/queue end-to-end drill or staging deployment has been performed. Existing migration HTTP E2E remains a CI gate; partial embedding warning behavior has not been exercised against a live embedding backend.

## Related PRs and Issues

Cloud follow-up: https://github.com/appwrite-labs/cloud/pull/5670 (held while this CE change goes first). Cloud overrides `Migrations::action()`: remove its logger parameter and forwarded argument when updating its server-ce dependency. Do not bump Cloud to this CE commit without that coordinated signature update.
