### PR TITLE
Remove unused OpenAPI operation extensions

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5465,16 +5465,16 @@
     "packages-dev": [
         {
             "name": "appwrite/sdk-generator",
-            "version": "4.7.6",
+            "version": "4.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-generator.git",
-                "reference": "3a6e28f03ccdeadae79c6de5ec5c8a652a094226"
+                "reference": "0f1b33dc784d8a2243555464e3543c01c0f2393b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/3a6e28f03ccdeadae79c6de5ec5c8a652a094226",
-                "reference": "3a6e28f03ccdeadae79c6de5ec5c8a652a094226",
+                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/0f1b33dc784d8a2243555464e3543c01c0f2393b",
+                "reference": "0f1b33dc784d8a2243555464e3543c01c0f2393b",
                 "shasum": ""
             },
             "require": {
@@ -5511,9 +5511,9 @@
             "description": "SDK generator for Appwrite APIs across multiple programming languages and platforms",
             "support": {
                 "issues": "https://github.com/appwrite/sdk-generator/issues",
-                "source": "https://github.com/appwrite/sdk-generator/tree/4.7.6"
+                "source": "https://github.com/appwrite/sdk-generator/tree/4.7.8"
             },
-            "time": "2026-08-31T20:15:18+00:00"
+            "time": "2026-09-05T14:37:38+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -8545,16 +8545,16 @@
         },
         {
             "name": "utopia-php/openapi",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/openapi.git",
-                "reference": "d74fe62fcb16f810986ad91a2727604e5f83e63e"
+                "reference": "725109d69e298ae8d88f1ffc05f6d86624233abd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/d74fe62fcb16f810986ad91a2727604e5f83e63e",
-                "reference": "d74fe62fcb16f810986ad91a2727604e5f83e63e",
+                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/725109d69e298ae8d88f1ffc05f6d86624233abd",
+                "reference": "725109d69e298ae8d88f1ffc05f6d86624233abd",
                 "shasum": ""
             },
             "require": {
@@ -8579,9 +8579,9 @@
             "description": "Framework-independent OpenAPI 2.0, 3.0, and 3.1 parser with an immutable canonical model",
             "support": {
                 "issues": "https://github.com/utopia-php/openapi/issues",
-                "source": "https://github.com/utopia-php/openapi/tree/0.2.0"
+                "source": "https://github.com/utopia-php/openapi/tree/0.2.1"
             },
-            "time": "2026-08-21T04:56:47+00:00"
+            "time": "2026-09-04T16:56:24+00:00"
         }
     ],
     "aliases": [],

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -290,10 +290,6 @@ class OpenAPI3 extends Format
                 ],
             ];
 
-            if ($sdk->getDescriptionFilePath() !== null) {
-                $temp['x-appwrite']['edit'] = 'https://github.com/appwrite/appwrite/edit/master' . $sdk->getDescription();
-            }
-
             if ($sdk->getDeprecated()) {
                 $temp['x-appwrite']['deprecated'] = [
                     'since' => $sdk->getDeprecated()->getSince(),

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -279,7 +279,6 @@ class OpenAPI3 extends Format
                 'deprecated' => $sdk->isDeprecated(),
                 'x-appwrite' => [ // Appwrite related metadata
                     'group' => $sdk->getGroup(),
-                    'cookies' => $route->getLabel('sdk.cookies', false),
                     'demo' => \strtolower($namespace) . '/' . Template::fromCamelCaseToDash($methodName) . '.md',
                     'rate-limit' => $route->getLabel('abuse-limit', 0),
                     'rate-time' => $route->getLabel('abuse-time', 3600),


### PR DESCRIPTION
## What does this PR do?

Removes two unused fields from generated OpenAPI 3 operations:

- `x-appwrite.cookies`, which was always `false`, had no route overrides, and had no consumer
- `x-appwrite.edit`, whose source-edit URLs are no longer consumed by SDK Generator or the documentation API explorer

It also updates SDK Generator to 4.7.8 and `utopia-php/openapi` to 0.2.1, completing the consumer rollout for the merged `x-appwrite.type` removal.

Related to [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards), appwrite/sdk-generator#1871, and #13484.

## Validation

- `composer validate --no-check-publish`
- `composer lint src/Appwrite/SDK/Specification/Format/OpenAPI3.php`
- generated latest client, server, and console specifications
- generated every configured client, server, console, and static SDK example successfully using SDK Generator 4.7.8
- confirmed generated specifications contain no `x-appwrite.type`
- confirmed specification parity after removing only the targeted metadata:
  - `cookies`: client 152, server 563, console 621 fields removed; every value was `false`
  - `edit`: client 147, server 385, console 425 fields removed
