### PR TITLE
Remove x-appwrite.edit from OpenAPI specifications

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -291,10 +291,6 @@ class OpenAPI3 extends Format
                 ],
             ];
 
-            if ($sdk->getDescriptionFilePath() !== null) {
-                $temp['x-appwrite']['edit'] = 'https://github.com/appwrite/appwrite/edit/master' . $sdk->getDescription();
-            }
-
             if ($sdk->getDeprecated()) {
                 $temp['x-appwrite']['deprecated'] = [
                     'since' => $sdk->getDeprecated()->getSince(),


### PR DESCRIPTION
## What does this PR do?

Stops emitting the unused `x-appwrite.edit` source-edit URL from generated OpenAPI 3 operations. Neither SDK Generator nor the current documentation API explorer consumes this field.

Related to [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards).

## Validation

- `composer lint src/Appwrite/SDK/Specification/Format/OpenAPI3.php`
- generated latest client, server, and console specifications
- confirmed the generated specifications differ only by removal of `x-appwrite.edit`:
  - client: 147 fields removed
  - server: 385 fields removed
  - console: 425 fields removed