### PR TITLE
fix: update base image to 2.0.4 for libcurl shutdown cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN composer install --ignore-platform-reqs --optimize-autoloader \
     --no-plugins --no-scripts --prefer-dist \
     `if [ "$TESTING" != "true" ]; then echo "--no-dev"; fi`
 
-FROM appwrite/base:2.0.0 AS base
+FROM appwrite/base:2.0.4 AS base
 
 LABEL maintainer="team@appwrite.io"
 
@@ -118,7 +118,7 @@ EXPOSE 80
 
 CMD [ "php", "app/http.php" ]
 
-FROM appwrite/base:2.0.0-xdebug AS xdebug
+FROM appwrite/base:2.0.4-xdebug AS xdebug
 
 FROM base AS development
 
@@ -128,7 +128,7 @@ RUN printf 'opcache.validate_timestamps=1\nopcache.revalidate_freq=0\n' > /usr/l
 COPY ./docs /usr/src/code/docs
 COPY ./dev /usr/src/code/dev
 
-# appwrite/base:2.0.0 ships without XDebug, so it cannot reach production or
+# appwrite/base:2.0.4 ships without XDebug, so it cannot reach production or
 # Cloud. The -xdebug tag is the same build with the extension; mounting it
 # rather than copying keeps xdebug.so out of every layer unless DEBUG asked
 # for it, and guarantees an ABI match because both tags are one base build.


### PR DESCRIPTION
Update the production and XDebug base images from 2.0.0 to 2.0.4. The new base requires libcurl 8.22.0, which fixes retained TLS shutdown connections in the socket-action API used by Swoole's curl hook. This brings the upstream socket/memory leak fix into Appwrite without changing its HTTP transport or connection pooling.

Also includes the intervening base-image PHP and extension dependency updates. Production and development use matching base versions.

Base release: https://github.com/appwrite/docker-base/releases/tag/2.0.4 (merged https://github.com/appwrite/docker-base/pull/102).

Validation: base-image CI passed on AMD64 and ARM64. The tested base delivered 2,400/2,400 synthetic Sentry events without exporter errors or accumulating descriptors, and 400 keep-alive requests used one TCP connection. Appwrite production and DEBUG=true development images both build against the released 2.0.4 tags. Production loads PHP 8.5.10, Swoole 6.2.2, and libcurl 8.22.0 with XDebug absent; the debug image loads XDebug successfully. The production image's unchanged Span bootstrap delivered 400/400 synthetic Sentry events with zero exporter errors, 9 final FDs, and zero CLOSE_WAIT sockets. Appwrite CI is running. Staging and production deployment have not been performed.
