### PR TITLE
Support 2.0.x spec generation

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -12,7 +12,6 @@ on:
         required: true
         options:
           - "2.0.x"
-          - "1.9.x"
           - "1.8.x"
           - "1.7.x"
           - "1.6.x"

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -12,6 +12,7 @@ on:
         required: true
         options:
           - "2.0.x"
+          - "1.9.x"
           - "1.8.x"
           - "1.7.x"
           - "1.6.x"

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -11,6 +11,8 @@ on:
         description: "Appwrite version to generate specs for"
         required: true
         options:
+          - "2.0.x"
+          - "1.9.x"
           - "1.8.x"
           - "1.7.x"
           - "1.6.x"

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -146,6 +146,7 @@ class SDKs extends Action
                 '1.7.x',
                 '1.8.x',
                 '1.9.x',
+                '2.0.x',
                 'latest',
             ])) {
                 throw new \Exception('Unknown version given');


### PR DESCRIPTION
## What does this PR do?

Adds `2.0.x` to the SDK example generator and specs workflow now that Appwrite 2.0.0 is released.

## Validation

- `php -l src/Appwrite/Platform/Tasks/SDKs.php`
- generated all configured SDK examples with `--version=2.0.x`

Related to [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards).