### PR TITLE
fix: surface migration report errors and preserve underlying exception (#13477)

### DIFF
--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
@@ -68,9 +68,14 @@ class Get extends Action
             $appwrite = new AppwriteSource($projectID, $endpoint, $key, $getDatabasesDB);
             $report = $appwrite->report($resources);
         } catch (\Throwable $e) {
+            $message = !empty($e->getMessage())
+                ? 'Failed to generate migration report: ' . $e->getMessage()
+                : 'Unable to connect to the migration source. Please verify your credentials and ensure the source is reachable from this server. Check for network restrictions such as firewalls, IP allowlists, or outbound connectivity limits.';
+
             throw new Exception(
-                Exception::MIGRATION_PROVIDER_ERROR,
-                'Unable to connect to the migration source. Please verify your credentials and ensure the source is reachable from this server. Check for network restrictions such as firewalls, IP allowlists, or outbound connectivity limits.'
+                type: Exception::MIGRATION_PROVIDER_ERROR,
+                message: $message,
+                previous: $e
             );
         }
 

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
@@ -65,7 +65,7 @@ class Get extends Action
         callable $getDatabasesDB
     ): void {
         try {
-            $appwrite = new AppwriteSource($projectID, $endpoint, $key, $getDatabasesDB);
+            $appwrite = $this->getSource($projectID, $endpoint, $key, $getDatabasesDB);
             $report = $appwrite->report($resources);
         } catch (\Throwable $e) {
             $message = !empty($e->getMessage())
@@ -82,5 +82,10 @@ class Get extends Action
         $response
             ->setStatusCode(Response::STATUS_CODE_OK)
             ->dynamic(new Document($report), Response::MODEL_MIGRATION_REPORT);
+    }
+
+    protected function getSource(string $projectID, string $endpoint, string $key, callable $getDatabasesDB): AppwriteSource
+    {
+        return new AppwriteSource($projectID, $endpoint, $key, $getDatabasesDB);
     }
 }

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Firebase/Report/Get.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Firebase/Report/Get.php
@@ -68,9 +68,14 @@ class Get extends Action
             $firebase = new Firebase($serviceAccount);
             $report = $firebase->report($resources);
         } catch (\Throwable $e) {
+            $message = !empty($e->getMessage())
+                ? 'Failed to generate migration report: ' . $e->getMessage()
+                : 'Unable to connect to the migration source. Please verify your credentials and ensure the source is reachable from this server. Check for network restrictions such as firewalls, IP allowlists, or outbound connectivity limits.';
+
             throw new Exception(
-                Exception::MIGRATION_PROVIDER_ERROR,
-                'Unable to connect to the migration source. Please verify your credentials and ensure the source is reachable from this server. Check for network restrictions such as firewalls, IP allowlists, or outbound connectivity limits.'
+                type: Exception::MIGRATION_PROVIDER_ERROR,
+                message: $message,
+                previous: $e
             );
         }
 

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/NHost/Report/Get.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/NHost/Report/Get.php
@@ -75,9 +75,14 @@ class Get extends Action
             $nhost = new NHost($subdomain, $region, $adminSecret, $database, $username, $password, $port);
             $report = $nhost->report($resources);
         } catch (\Throwable $e) {
+            $message = !empty($e->getMessage())
+                ? 'Failed to generate migration report: ' . $e->getMessage()
+                : 'Unable to connect to the migration source. Please verify your credentials and ensure the source is reachable from this server. Check for network restrictions such as firewalls, IP allowlists, or outbound connectivity limits.';
+
             throw new Exception(
-                Exception::MIGRATION_PROVIDER_ERROR,
-                'Unable to connect to the migration source. Please verify your credentials and ensure the source is reachable from this server. Check for network restrictions such as firewalls, IP allowlists, or outbound connectivity limits.'
+                type: Exception::MIGRATION_PROVIDER_ERROR,
+                message: $message,
+                previous: $e
             );
         }
 

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Supabase/Report/Get.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Supabase/Report/Get.php
@@ -74,9 +74,14 @@ class Get extends Action
             $supabase = new Supabase($endpoint, $apiKey, $databaseHost, 'postgres', $username, $password, $port);
             $report = $supabase->report($resources);
         } catch (\Throwable $e) {
+            $message = !empty($e->getMessage())
+                ? 'Failed to generate migration report: ' . $e->getMessage()
+                : 'Unable to connect to the migration source. Please verify your credentials and ensure the source is reachable from this server. Check for network restrictions such as firewalls, IP allowlists, or outbound connectivity limits.';
+
             throw new Exception(
-                Exception::MIGRATION_PROVIDER_ERROR,
-                'Unable to connect to the migration source. Please verify your credentials and ensure the source is reachable from this server. Check for network restrictions such as firewalls, IP allowlists, or outbound connectivity limits.'
+                type: Exception::MIGRATION_PROVIDER_ERROR,
+                message: $message,
+                previous: $e
             );
         }
 

--- a/tests/unit/Platform/Modules/Migrations/Appwrite/Report/GetTest.php
+++ b/tests/unit/Platform/Modules/Migrations/Appwrite/Report/GetTest.php
@@ -35,6 +35,7 @@ namespace Tests\Unit\Platform\Modules\Migrations\Appwrite\Report {
     use Appwrite\Platform\Modules\Migrations\Http\Migrations\Appwrite\Report\Get;
     use Appwrite\Utopia\Response;
     use PHPUnit\Framework\TestCase;
+    use Utopia\Migration\Sources\Appwrite as AppwriteSource;
 
     final class GetTest extends TestCase
     {
@@ -64,31 +65,29 @@ namespace Tests\Unit\Platform\Modules\Migrations\Appwrite\Report {
         public function testGetAppwriteReportFallbackMessageWhenExceptionMessageIsEmpty(): void
         {
             $action = new class () extends Get {
-                public function throwEmptyException(Response $response): void
+                protected function getSource(string $projectID, string $endpoint, string $key, callable $getDatabasesDB): AppwriteSource
                 {
-                    try {
-                        throw new \Exception('');
-                    } catch (\Throwable $e) {
-                        $message = !empty($e->getMessage())
-                            ? 'Failed to generate migration report: ' . $e->getMessage()
-                            : 'Unable to connect to the migration source. Please verify your credentials and ensure the source is reachable from this server. Check for network restrictions such as firewalls, IP allowlists, or outbound connectivity limits.';
-
-                        throw new Exception(
-                            type: Exception::MIGRATION_PROVIDER_ERROR,
-                            message: $message,
-                            previous: $e
-                        );
-                    }
+                    throw new \Exception('');
                 }
             };
 
             try {
-                $action->throwEmptyException($this->createMock(Response::class));
+                $action->action(
+                    resources: ['databases'],
+                    endpoint: 'http://localhost/v1',
+                    projectID: 'dummy-project',
+                    key: 'dummy-key',
+                    response: $this->createMock(Response::class),
+                    getDatabasesDB: fn () => null
+                );
                 $this->fail('Expected Exception was not thrown');
             } catch (Exception $e) {
                 $this->assertSame(Exception::MIGRATION_PROVIDER_ERROR, $e->getType());
                 $this->assertNotNull($e->getPrevious());
-                $this->assertStringStartsWith('Unable to connect to the migration source.', $e->getMessage());
+                $this->assertSame(
+                    'Unable to connect to the migration source. Please verify your credentials and ensure the source is reachable from this server. Check for network restrictions such as firewalls, IP allowlists, or outbound connectivity limits.',
+                    $e->getMessage()
+                );
             }
         }
     }

--- a/tests/unit/Platform/Modules/Migrations/Appwrite/Report/GetTest.php
+++ b/tests/unit/Platform/Modules/Migrations/Appwrite/Report/GetTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swoole\Http {
+    if (!\class_exists(Response::class, false)) {
+        class Response
+        {
+        }
+    }
+}
+
+namespace Swoole {
+    if (!\class_exists(Timer::class, false)) {
+        class Timer
+        {
+            public static function clearAll(): void
+            {
+            }
+        }
+    }
+    if (!\class_exists(Event::class, false)) {
+        class Event
+        {
+            public static function wait(): void
+            {
+            }
+        }
+    }
+}
+
+namespace Tests\Unit\Platform\Modules\Migrations\Appwrite\Report {
+
+    use Appwrite\Extend\Exception;
+    use Appwrite\Platform\Modules\Migrations\Http\Migrations\Appwrite\Report\Get;
+    use Appwrite\Utopia\Response;
+    use PHPUnit\Framework\TestCase;
+
+    final class GetTest extends TestCase
+    {
+        public function testGetAppwriteReportThrowsExceptionWithPreviousAndMessage(): void
+        {
+            $action = new Get();
+            $response = $this->createMock(Response::class);
+
+            try {
+                // Calling action with invalid/unreachable endpoint triggers an exception in report()
+                $action->action(
+                    resources: ['databases'],
+                    endpoint: 'http://localhost:99999/v1',
+                    projectID: 'dummy-project',
+                    key: 'dummy-key',
+                    response: $response,
+                    getDatabasesDB: fn () => null
+                );
+                $this->fail('Expected Exception was not thrown');
+            } catch (Exception $e) {
+                $this->assertSame(Exception::MIGRATION_PROVIDER_ERROR, $e->getType());
+                $this->assertNotNull($e->getPrevious());
+                $this->assertStringStartsWith('Failed to generate migration report:', $e->getMessage());
+            }
+        }
+
+        public function testGetAppwriteReportFallbackMessageWhenExceptionMessageIsEmpty(): void
+        {
+            $action = new class () extends Get {
+                public function throwEmptyException(Response $response): void
+                {
+                    try {
+                        throw new \Exception('');
+                    } catch (\Throwable $e) {
+                        $message = !empty($e->getMessage())
+                            ? 'Failed to generate migration report: ' . $e->getMessage()
+                            : 'Unable to connect to the migration source. Please verify your credentials and ensure the source is reachable from this server. Check for network restrictions such as firewalls, IP allowlists, or outbound connectivity limits.';
+
+                        throw new Exception(
+                            type: Exception::MIGRATION_PROVIDER_ERROR,
+                            message: $message,
+                            previous: $e
+                        );
+                    }
+                }
+            };
+
+            try {
+                $action->throwEmptyException($this->createMock(Response::class));
+                $this->fail('Expected Exception was not thrown');
+            } catch (Exception $e) {
+                $this->assertSame(Exception::MIGRATION_PROVIDER_ERROR, $e->getType());
+                $this->assertNotNull($e->getPrevious());
+                $this->assertStringStartsWith('Unable to connect to the migration source.', $e->getMessage());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

During migration report generation (e.g. self-hosted Appwrite migrations, Supabase, NHost, and Firebase), when an exception occurred while connecting to or inspecting resources (such as missing scopes, permissions, or schema incompatibilities like missing `policies`), the generic `catch (\Throwable $e)` block replaced the error message with a hardcoded connectivity error:
> *"Unable to connect to the migration source. Please verify your credentials and ensure the source is reachable from this server..."*

Furthermore, the original exception was dropped because `previous: $e` was omitted when constructing `Appwrite\Extend\Exception`. This masked the actual root cause from users and maintainers, and prevented error logging/tracing tools from recording the original exception stack trace.

This PR:
1. Surfaces the actual error message (`'Failed to generate migration report: ' . $e->getMessage()`) when an exception occurs during report generation across all migration providers (Appwrite, Firebase, NHost, Supabase), retaining the fallback connectivity guidance if the exception message is empty.
2. Passes `previous: $e` into `Appwrite\Extend\Exception` so the full stack trace and original exception chain are preserved.

## Test Plan

1. **Unit Tests**:
   - Added unit tests in `tests/unit/Platform/Modules/Migrations/Appwrite/Report/GetTest.php` testing report failure error handling.
   - Verified that `Exception::MIGRATION_PROVIDER_ERROR` is thrown, `getPrevious()` is preserved and not null, and `getMessage()` contains the error description (and tests fallback message when exception message is empty).
   - Executed PHPUnit:
     ```bash
     docker run --rm -v ${PWD}:/app -w /app composer:latest vendor/bin/phpunit tests/unit/Platform/Modules/Migrations/Appwrite/Report/GetTest.php
     ```
     Result: All tests passed (OK, 2 tests, 6 assertions).

2. **Code Style & Formatting**:
   - Formatted and verified with Laravel Pint:
     ```bash
     docker run --rm -v ${PWD}:/app -w /app composer:latest vendor/bin/pint --test src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Firebase/Report/Get.php src/Appwrite/Platform/Modules/Migrations/Http/Migrations/NHost/Report/Get.php src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Supabase/Report/Get.php tests/unit/Platform/Modules/Migrations/Appwrite/Report/GetTest.php
     ```
     Result: PASS (5 files, PSR-12 compliant).

## Related PRs and Issues

- Fixes #13477

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
