### PR TITLE
chore: update runtimes for Dart 3.13 and Flutter 3.47

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -163,16 +163,16 @@
         },
         {
             "name": "appwrite/php-runtimes",
-            "version": "0.20.4",
+            "version": "0.20.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/runtimes.git",
-                "reference": "8af731ea29d81964b1e2015ff28ccbd586985460"
+                "reference": "239b65d2ab55aead6e64eca52c201268de21afd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/runtimes/zipball/8af731ea29d81964b1e2015ff28ccbd586985460",
-                "reference": "8af731ea29d81964b1e2015ff28ccbd586985460",
+                "url": "https://api.github.com/repos/appwrite/runtimes/zipball/239b65d2ab55aead6e64eca52c201268de21afd4",
+                "reference": "239b65d2ab55aead6e64eca52c201268de21afd4",
                 "shasum": ""
             },
             "require": {
@@ -212,9 +212,9 @@
             ],
             "support": {
                 "issues": "https://github.com/appwrite/runtimes/issues",
-                "source": "https://github.com/appwrite/runtimes/tree/0.20.4"
+                "source": "https://github.com/appwrite/runtimes/tree/0.20.5"
             },
-            "time": "2026-08-21T04:58:53+00:00"
+            "time": "2026-09-06T16:45:54+00:00"
         },
         {
             "name": "brick/math",


### PR DESCRIPTION
## What does this PR do?

Updates only `appwrite/php-runtimes` in `composer.lock` from `0.20.4` to `0.20.5`, consuming the Dart 3.13 and Flutter 3.47 registrations released in appwrite/runtimes#109.

- Locks source and dist to release commit `239b65d2ab55aead6e64eca52c201268de21afd4`.
- Keeps the existing `0.20.*` constraint and every other dependency unchanged.
- Runtime configuration, template runtime lists, and the Flutter Sites framework consume the registry dynamically. No API metadata, specs, SDKs, or default framework runtime changes are needed.

## Test Plan

- `composer update appwrite/php-runtimes --no-install --ignore-platform-reqs`: one package updated, no additions or removals.
- `composer validate`: passes with existing exact-version warnings for `utopia-php/platform` and `utopia-php/websocket`. Strict validation produces the same warnings on the unchanged baseline.
- Full decoded-lock comparison: only the target package changed among 92 production packages; all 46 development packages and other top-level metadata are unchanged.
- Fetched clean source checkouts at the exact locked references for php-runtimes, system, and config, without using an existing vendor autoloader. PHP checks passed for both runtime registry versions (`v2`/`v5`): new IDs, image/base/service metadata, allowlist inclusion and exclusion, and retained prior versions.
- Loaded the real CE PHP runtime/template/framework configuration using those locked sources: both versions propagate correctly, including Flutter Sites, without changing the existing Flutter default.
- `git diff --check`: passes. Independent source review found no issues.

Full Composer installation, unit/E2E suites, and container build/execution smoke tests were not run. Registry/config checks do not establish successful deployment or execution.

## Related PRs and Issues

- https://github.com/appwrite/runtimes/pull/109
- https://github.com/appwrite/runtimes/releases/tag/0.20.5

## Checklist

- [x] Read the contributing guidelines and AGENTS.md.
- [x] API metadata/spec/example updates are not applicable to this lockfile-only change.