### PR TITLE
feat(sdk): support PDF response content type

### DIFF
--- a/src/Appwrite/SDK/ContentType.php
+++ b/src/Appwrite/SDK/ContentType.php
@@ -12,5 +12,6 @@ enum ContentType: string
     case MULTIPART = 'multipart/form-data';
     case HTML = 'text/html';
     case TEXT = 'text/plain';
+    case PDF = 'application/pdf';
     case ANY = '*/*';
 }

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -45,6 +45,7 @@ use Appwrite\Utopia\Response\Model\UsageDataPoint;
 use Appwrite\Utopia\Response\Model\UsageProject;
 use Appwrite\Utopia\Response\Model\User;
 use Appwrite\Utopia\Response\Model\Webhook;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Utopia\Database\Database;
 use Utopia\Database\Validator\Key;
@@ -977,18 +978,27 @@ final class FormatTest extends TestCase
         $this->assertSame(['application/json'], $openApiMethod['x-appwrite']['produces']);
     }
 
-    public function testBinaryResponsesEmitResponseContent(): void
+    public static function binaryResponseTypes(): array
+    {
+        return [
+            'PNG image' => [ContentType::IMAGE_PNG, 'image/png'],
+            'PDF document' => [ContentType::PDF, 'application/pdf'],
+        ];
+    }
+
+    #[DataProvider('binaryResponseTypes')]
+    public function testBinaryResponsesEmitResponseContent(ContentType $contentType, string $mediaType): void
     {
         Method::$processed = [];
         Method::$errors = [];
 
-        $route = (new Route('GET', '/v1/tests/icon'))
-            ->desc('Get test icon')
+        $route = (new Route('GET', '/v1/tests/file'))
+            ->desc('Get test file')
             ->label('sdk', new Method(
                 namespace: 'test',
                 group: null,
-                name: 'getTestIcon',
-                description: 'Get test icon.',
+                name: 'getTestFile',
+                description: 'Get test file.',
                 auth: [],
                 responses: [
                     new SDKResponse(
@@ -996,16 +1006,16 @@ final class FormatTest extends TestCase
                         model: Response::MODEL_NONE,
                     ),
                 ],
-                contentType: ContentType::IMAGE_PNG,
+                contentType: $contentType,
             ));
 
         $openApi = (new OpenAPI3(new Container(), [], [$route], [new NoneModel()], [], 0, 'console'))->parse();
 
-        $openApiMethod = $openApi['paths']['/tests/icon']['get'];
+        $openApiMethod = $openApi['paths']['/tests/file']['get'];
 
         $this->assertSame(
-            ['type' => 'string', 'format' => 'binary'],
-            $openApiMethod['responses']['200']['content']['image/png']['schema']
+            [$mediaType => ['schema' => ['type' => 'string', 'format' => 'binary']]],
+            $openApiMethod['responses']['200']['content']
         );
         $this->assertArrayNotHasKey('produces', $openApiMethod['x-appwrite']);
     }

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -978,12 +978,10 @@ final class FormatTest extends TestCase
         $this->assertSame(['application/json'], $openApiMethod['x-appwrite']['produces']);
     }
 
-    public static function binaryResponseTypes(): array
+    public static function binaryResponseTypes(): \Iterator
     {
-        return [
-            'PNG image' => [ContentType::IMAGE_PNG, 'image/png'],
-            'PDF document' => [ContentType::PDF, 'application/pdf'],
-        ];
+        yield 'PNG image' => [ContentType::IMAGE_PNG, 'image/png'];
+        yield 'PDF document' => [ContentType::PDF, 'application/pdf'];
     }
 
     #[DataProvider('binaryResponseTypes')]


### PR DESCRIPTION
## What does this PR do?

Adds `ContentType::PDF = 'application/pdf'` to the SDK metadata enum.

PDF endpoints can now declare `contentType: ContentType::PDF` with a `Response::MODEL_NONE` response. The existing OpenAPI generator emits the precise binary contract:

```yaml
responses:
  '200':
    description: File
    content:
      application/pdf:
        schema:
          type: string
          format: binary
```

This is needed for Cloud invoice download/view specifications, whose runtime responses are PDFs. Their older PaymentMethod/JSON metadata was masked by the removed `x-appwrite.type` override. A generic `ContentType::ANY` is compatible with binary inference, but `application/pdf` is the accurate permanent declaration.

This PR only adds the enum value and regression coverage. It does not modify endpoint runtime behavior, Cloud dependency pins, or Cloud invoice declarations. Cloud can adopt `ContentType::PDF` after updating its `server-ce` dependency.

## Tests

- Parameterized the existing binary-response specification test for PNG and PDF, asserting the exact response content map, including the media type and `string`/`binary` schema.
- Before adding the enum, the new PDF case fails with `Undefined constant Appwrite\SDK\ContentType::PDF`.
- `vendor/bin/phpunit tests/unit/SDK`: **34 tests, 172 assertions passed**.
- `composer lint src/Appwrite/SDK/ContentType.php tests/unit/SDK/Specification/FormatTest.php`: passed.
- `git diff --check`: passed.
