### PR TITLE
test(usage): wait for schema readiness before E2E queries

### DIFF
--- a/tests/e2e/Services/Usage/UsageCustomServerTest.php
+++ b/tests/e2e/Services/Usage/UsageCustomServerTest.php
@@ -17,7 +17,7 @@ final class UsageCustomServerTest extends Scope
 
     public function testListEventsReturnsRequestedEmptySeries(): void
     {
-        $this->skipUnlessUsageStatsEnabled();
+        $this->waitForUsageStats();
 
         $response = $this->call('/usage/events', [
             'metrics' => ['test.unknown.event'],
@@ -32,7 +32,7 @@ final class UsageCustomServerTest extends Scope
 
     public function testListGaugesReturnsEveryRequestedSeries(): void
     {
-        $this->skipUnlessUsageStatsEnabled();
+        $this->waitForUsageStats();
 
         $response = $this->call('/usage/gauges', [
             'metrics' => ['test.unknown.gauge', 'test.second.gauge'],
@@ -51,7 +51,7 @@ final class UsageCustomServerTest extends Scope
 
     public function testFlatEventAggregateNormalizesExplicitEndTime(): void
     {
-        $this->skipUnlessUsageStatsEnabled();
+        $this->waitForUsageStats();
 
         $response = $this->call('/usage/events', [
             'metrics' => ['test.unknown.event'],
@@ -64,7 +64,7 @@ final class UsageCustomServerTest extends Scope
 
     public function testUnknownMaxGaugeDoesNotFabricateZeroSeries(): void
     {
-        $this->skipUnlessUsageStatsEnabled();
+        $this->waitForUsageStats();
 
         $flat = $this->call('/usage/gauges', [
             'metrics' => ['test.unknown.max.gauge'],
@@ -84,7 +84,7 @@ final class UsageCustomServerTest extends Scope
 
     public function testInvalidFilterAttributeIsRejected(): void
     {
-        $this->skipUnlessUsageStatsEnabled();
+        $this->waitForUsageStats();
 
         $response = $this->call('/usage/events', [
             'metrics' => ['network.requests'],
@@ -98,7 +98,7 @@ final class UsageCustomServerTest extends Scope
 
     public function testStructuralFilterQueryIsRejected(): void
     {
-        $this->skipUnlessUsageStatsEnabled();
+        $this->waitForUsageStats();
 
         $response = $this->call('/usage/events', [
             'metrics' => ['network.requests'],
@@ -146,11 +146,25 @@ final class UsageCustomServerTest extends Scope
         $this->assertSame('general_unauthorized_scope', $response['body']['type']);
     }
 
-    private function skipUnlessUsageStatsEnabled(): void
+    private function waitForUsageStats(): void
     {
         if (System::getEnv('_APP_USAGE_STATS', 'enabled') === 'disabled') {
             $this->markTestSkipped('Usage stats are disabled on this stack');
         }
+
+        $project = $this->getProject();
+        $key = $this->getNewKey(['health.read']);
+
+        // HTTP health can pass while the ClickHouse usage schema is still initializing.
+        $this->assertEventually(function () use ($project, $key) {
+            $response = $this->client->call(Client::METHOD_GET, '/health/usage', [
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $project['$id'],
+                'x-appwrite-key' => $key,
+            ]);
+
+            $this->assertSame(200, $response['headers']['status-code'], 'Usage storage must be ready before testing usage queries');
+        }, 60_000, 500);
     }
 
     /** @param array<string, mixed> $parameters */


### PR DESCRIPTION
## Summary
- Wait for `/health/usage` before the six usage-query E2E tests run.
- Use the existing `assertEventually` helper (60-second timeout, 500ms polling) and reuse one `health.read` key across probes.
- Keep every query/validation assertion unchanged. Disabled-stats and missing-scope tests do not wait for storage.

## Root cause
[Failing PostgreSQL (dedicated) / Usage job](https://github.com/appwrite/appwrite/actions/runs/34049471879/job/101530532547?pr=13504)

All six failures were HTTP 503 instead of the expected 200/400. The API was serving requests while ClickHouse initialization was still retrying (`Usage schema setup failed. Retrying (1/2)...`). Usage routes correctly returned `general_usage_not_ready` during that window. HTTP `/health/version` readiness does not guarantee that the usage schema exists.

The usage health endpoint checks the event, gauge, and daily schema through the real storage connection. Polling it establishes the test prerequisite without retrying the requests/assertions under test, adding an unconditional sleep, or changing application startup behavior.

## Local E2E verification
Ran against an isolated Docker stack with dedicated PostgreSQL, Redis, ClickHouse 26.4.3, and the real API/worker. Source and locked Composer dependencies were from `main` at `6c9ce08306` plus this test-only change.

| Scenario | Result |
| --- | --- |
| Unmodified suite, storage ready | Pass: 8 tests, 1 expected disabled-mode skip |
| Unmodified suite, empty ClickHouse volume and startup delayed by 8 seconds | Reproduced all 6 CI failures (503 vs 200/400) |
| Fixed suite, delayed initial ClickHouse startup, PHPUnit | Pass; readiness probe waited ~11 seconds |
| Fixed suite, empty ClickHouse volume + 8-second delayed startup, four-process functional ParaTest | 3/3 passes, 8 tests each, 1 expected skip each |
| Fixed suite, warm stack, four-process functional ParaTest | 10/10 passes, 8 tests / 115 assertions / 1 expected skip each |
| ClickHouse permanently stopped, single affected test | Expected failure after the bounded wait (~63 seconds total), with `Usage storage must be ready before testing usage queries` |
| `_APP_USAGE_STATS=disabled` on API and test process, ClickHouse stopped | Pass: 8 tests / 27 assertions / 6 expected enabled-mode skips; disabled-mode and scope tests both execute |
| Restored enabled stack, full Usage suite | Pass: 8 tests / 85 assertions / 1 expected skip |
| Pint, PHP syntax, `git diff --check` | Pass |

Commands used for the suites:
```sh
docker compose -f /tmp/usage-compose.json exec -T appwrite test tests/e2e/Services/Usage

docker compose -f /tmp/usage-compose.json exec -T appwrite \
  vendor/bin/paratest --processes 4 --functional tests/e2e/Services/Usage \
  --exclude-group abuseEnabled --exclude-group screenshots --exclude-group antivirus
```

Cold-start verification used only disposable project-scoped containers/volumes: remove the test ClickHouse container/volume, restart the API, start ClickHouse after 8 seconds, and launch the suite as soon as API health passes. The baseline ran the unchanged test file from `HEAD`; the fixed runs used this branch. No production code was patched or mocked.

Local runtime: ARM64 PHP 8.5.9 (CI used PHP 8.5.10). The cached development image has MongoDB extension 2.3.3 rather than the lockfile's required 2.1.x, so dependency installation used `--ignore-platform-req=ext-mongodb`; MongoDB was not used in these PostgreSQL tests.
