### PR TITLE
test(proxy): isolate deployment archives in parallel tests

### DIFF
--- a/tests/e2e/Services/Proxy/ProxyHelpers.php
+++ b/tests/e2e/Services/Proxy/ProxyHelpers.php
@@ -263,15 +263,27 @@ trait ProxyHelpers
         $stderr = '';
 
         $folderPath = realpath(__DIR__ . '/../../../resources/sites') . "/$site";
-        $tarPath = "$folderPath/code.tar.gz";
+        // Parallel tests must not truncate an archive another upload is reading.
+        $tarPath = \sys_get_temp_dir() . '/appwrite-site-' . $site . '-' . \getmypid() . '-' . \uniqid('', true) . '.tar.gz';
 
-        Console::execute("cd $folderPath && tar --exclude code.tar.gz --exclude node_modules -czf code.tar.gz .", '', $stdout, $stderr);
+        Console::execute(
+            'tar --exclude code.tar.gz --exclude node_modules -czf ' . \escapeshellarg($tarPath) . ' -C ' . \escapeshellarg($folderPath) . ' .',
+            '',
+            $stdout,
+            $stderr
+        );
 
         if (filesize($tarPath) > 1024 * 1024 * 5) {
             throw new \Exception('Code package is too large. Use the chunked upload method instead.');
         }
 
-        return new CURLFile($tarPath, 'application/x-gzip', \basename($tarPath));
+        register_shutdown_function(static function () use ($tarPath) {
+            if (\is_file($tarPath)) {
+                @\unlink($tarPath);
+            }
+        });
+
+        return new CURLFile($tarPath, 'application/x-gzip', 'code.tar.gz');
     }
 
     private function packageFunction(string $function): CURLFile
@@ -280,14 +292,26 @@ trait ProxyHelpers
         $stderr = '';
 
         $folderPath = realpath(__DIR__ . '/../../../resources/functions') . "/$function";
-        $tarPath = "$folderPath/code.tar.gz";
+        // Parallel tests must not truncate an archive another upload is reading.
+        $tarPath = \sys_get_temp_dir() . '/appwrite-function-' . $function . '-' . \getmypid() . '-' . \uniqid('', true) . '.tar.gz';
 
-        Console::execute("cd $folderPath && tar --exclude code.tar.gz --exclude node_modules -czf code.tar.gz .", '', $stdout, $stderr);
+        Console::execute(
+            'tar --exclude code.tar.gz --exclude node_modules -czf ' . \escapeshellarg($tarPath) . ' -C ' . \escapeshellarg($folderPath) . ' .',
+            '',
+            $stdout,
+            $stderr
+        );
 
         if (filesize($tarPath) > 1024 * 1024 * 5) {
             throw new \Exception('Code package is too large. Use the chunked upload method instead.');
         }
 
-        return new CURLFile($tarPath, 'application/x-gzip', \basename($tarPath));
+        register_shutdown_function(static function () use ($tarPath) {
+            if (\is_file($tarPath)) {
+                @\unlink($tarPath);
+            }
+        });
+
+        return new CURLFile($tarPath, 'application/x-gzip', 'code.tar.gz');
     }
 }


### PR DESCRIPTION
## Summary
Fix the Proxy E2E archive race by giving each site/function package a unique temporary path, following the existing `SitesBase::packageSite` and `FunctionsBase::packageFunction` pattern.

- Keep archives outside shared fixture directories.
- Retain them through upload and remove them at process shutdown.
- Preserve the multipart filename `code.tar.gz`, archive exclusions, and size limit.
- No production changes, retries, longer timeouts, or weakened assertions.

## Root cause
[Failing Proxy job on #13506](https://github.com/appwrite/appwrite/actions/runs/34050518886/job/101533381378)

`ProxyConsoleClientTest::testCreateRedirectRule` waited for a deployment that had already failed. Its sidecar log identifies the actual failure:

```text
pre-job artifact processing failed: archive source.tar.gz is empty
```

CI runs Proxy with four-process functional ParaTest. Both Proxy classes use `ProxyHelpers`, whose packaging methods overwrote the same `tests/resources/sites/static/code.tar.gz` (and equivalent function archive). A second `tar` can truncate that file after the first caller packages it but before its `CURLFile` upload reads it. The resulting empty upload causes a real build failure, not slow deployment activation.

## Local E2E verification
Isolated dedicated-PostgreSQL Docker stack with the real API, worker, Redis, ClickHouse, DNS fixture, executor, orchestrator 2.1.0, and static/node build runtimes. Source baseline: `bd66764e20`.

| Check | Result |
| --- | --- |
| Unmodified full Proxy suite, normal four-process functional ParaTest | Pass: 34 tests / 902 assertions |
| Unmodified redirect tests, controlled concurrent archive truncation | Reproduced CI: 1 failure out of 2 tests, failed deployment, sidecar reports `archive source.tar.gz is empty` |
| Fixed redirect tests, identical controlled interleaving | Initial pass, then 3/3 repeat passes; 2 tests each |
| Fixed function-rule tests, same controlled interleaving | 3/3 passes; 2 tests each |
| Fixed full Proxy suite, normal four-process functional ParaTest | 3/3 passes: 34 tests each, 871 / 852 / 851 assertions; no skips |
| Temporary archive cleanup | Zero matching site/function archives remain after the runs |
| Pint, PHP syntax, `git diff --check` | Pass |

Full-suite command:
```sh
docker compose -f /tmp/proxy-compose.json exec -T appwrite \
  vendor/bin/paratest --processes 4 --functional tests/e2e/Services/Proxy \
  --exclude-group abuseEnabled --exclude-group screenshots --exclude-group antivirus
```

### Controlled reproduction
A temporary `tar` wrapper was placed on **only the test process's PATH**, not in the source tree or build runtimes. It forces the problematic interleaving:
1. The first packaging process finishes its archive, then waits.
2. The second truncates its output archive and pauses for two seconds before writing it.
3. The first returns to the real upload while the second output is empty.

Both the baseline and fix ran `--processes 2 --functional --filter=testCreateRedirectRule` through the real API/build pipeline. The baseline shares the path and fails with the exact CI sidecar error. The fix uses different paths, so the first archive stays intact. Function-rule verification used `--filter=testCreateFunctionRule`. Normal full-suite verification ran without the wrapper.

Local runtime: ARM64 PHP 8.5.9; CI used PHP 8.5.10. Locked dependencies were installed with `--ignore-platform-req=ext-mongodb` because the cached development image contains MongoDB extension 2.3.3 instead of 2.1.x. MongoDB was not used for these PostgreSQL tests.
