### PR TITLE
fix(functions): rebind generated branch domain on deployment activation

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -661,6 +661,9 @@ class Jobs extends Action
             'deploymentCreatedAt' => $deployment->getCreatedAt(),
         ]));
 
+        $branch = $deployment->getAttribute('providerBranch', '');
+        $branches = $branch === '' ? [''] : ['', $branch];
+
         $dbForPlatform->forEach('rules', function (Document $rule) use ($dbForPlatform, $deployment, $bus) {
             $rule = $dbForPlatform->updateDocument('rules', $rule->getId(), new Document([
                 'deploymentId' => $deployment->getId(),
@@ -673,7 +676,7 @@ class Jobs extends Action
             Query::equal('deploymentResourceInternalId', [$resource->getSequence()]),
             Query::equal('deploymentResourceType', [$resource->getCollection() === 'sites' ? 'site' : 'function']),
             Query::equal('trigger', ['manual']),
-            Query::equal('deploymentVcsProviderBranch', ['']),
+            Query::equal('deploymentVcsProviderBranch', $branches),
         ]);
     }
 

--- a/tests/unit/Platform/Modules/Functions/Workers/ActivateRulesTest.php
+++ b/tests/unit/Platform/Modules/Functions/Workers/ActivateRulesTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform\Modules\Functions\Workers;
+
+use Appwrite\Platform\Modules\Functions\Workers\Jobs;
+use PHPUnit\Framework\TestCase;
+use Utopia\Bus\Bus;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Query;
+
+final class ActivateRulesTest extends TestCase
+{
+    public function testActivateRebindsGeneratedBranchDomain(): void
+    {
+        $captured = [];
+        $dbForPlatform = $this->platformDatabaseCapturing($captured);
+
+        $this->activate($dbForPlatform, deploymentBranch: 'main');
+
+        $branchQuery = $this->queryFor($captured, 'deploymentVcsProviderBranch');
+        $this->assertNotNull($branchQuery);
+        $this->assertSame(['', 'main'], $branchQuery->getValues());
+
+        $resourceType = $this->queryFor($captured, 'deploymentResourceType');
+        $this->assertNotNull($resourceType);
+        $this->assertSame(['function'], $resourceType->getValues());
+    }
+
+    public function testActivateOfNonVcsDeploymentOnlyTouchesBranchAgnosticRules(): void
+    {
+        $captured = [];
+        $dbForPlatform = $this->platformDatabaseCapturing($captured);
+
+        $this->activate($dbForPlatform, deploymentBranch: '');
+
+        $branchQuery = $this->queryFor($captured, 'deploymentVcsProviderBranch');
+        $this->assertNotNull($branchQuery);
+        $this->assertSame([''], $branchQuery->getValues());
+    }
+
+    public function testActivateRepointsMatchedRuleAtTheNewDeployment(): void
+    {
+        $updated = [];
+        $dispatched = 0;
+
+        $dbForPlatform = $this->createStub(Database::class);
+        $dbForPlatform->method('forEach')->willReturnCallback(
+            function (string $collection, callable $callback): void {
+                $callback(new Document(['$id' => 'rule-branch', 'deploymentId' => '']));
+            }
+        );
+        $dbForPlatform->method('updateDocument')->willReturnCallback(
+            function (string $collection, string $id, Document $data) use (&$updated): Document {
+                $updated[$id] = $data->getAttribute('deploymentId');
+
+                return new Document(['$id' => $id, ...$data->getArrayCopy()]);
+            }
+        );
+
+        $bus = $this->createStub(Bus::class);
+        $bus->method('dispatch')->willReturnCallback(function () use (&$dispatched) {
+            $dispatched++;
+
+            return;
+        });
+
+        $this->activate($dbForPlatform, deploymentBranch: 'main', bus: $bus);
+
+        $this->assertArrayHasKey('rule-branch', $updated);
+        $this->assertSame('dep-active', $updated['rule-branch']);
+        $this->assertSame(1, $dispatched);
+    }
+
+    private function activate(Database $dbForPlatform, string $deploymentBranch, ?Bus $bus = null): void
+    {
+        $resource = new Document([
+            '$id' => 'func-1',
+            '$sequence' => '100',
+            '$collection' => 'functions',
+        ]);
+
+        $dbForProject = $this->createStub(Database::class);
+        $dbForProject->method('updateDocument')->willReturn($resource);
+
+        $project = new Document(['$id' => 'project-1', '$sequence' => '7']);
+        $deployment = new Document([
+            '$id' => 'dep-active',
+            '$sequence' => '55',
+            'providerBranch' => $deploymentBranch,
+        ]);
+
+        (new ActivateRulesTestJobs())->exposeActivate(
+            $dbForProject,
+            $dbForPlatform,
+            $project,
+            $resource,
+            $deployment,
+            $bus ?? $this->createStub(Bus::class),
+        );
+    }
+
+    /**
+     * @param array<Query> $captured
+     */
+    private function platformDatabaseCapturing(array &$captured): Database
+    {
+        $dbForPlatform = $this->createStub(Database::class);
+        $dbForPlatform->method('forEach')->willReturnCallback(
+            function (string $collection, callable $callback, array $queries = []) use (&$captured): void {
+                $captured = $queries;
+            }
+        );
+
+        return $dbForPlatform;
+    }
+
+    /**
+     * @param array<Query> $queries
+     */
+    private function queryFor(array $queries, string $attribute): ?Query
+    {
+        foreach ($queries as $query) {
+            if ($query->getMethod() === Query::TYPE_EQUAL && $query->getAttribute() === $attribute) {
+                return $query;
+            }
+        }
+
+        return null;
+    }
+}
+
+final class ActivateRulesTestJobs extends Jobs
+{
+    public function exposeActivate(
+        Database $dbForProject,
+        Database $dbForPlatform,
+        Document $project,
+        Document $resource,
+        Document $deployment,
+        Bus $bus,
+    ): void {
+        $this->activate($dbForProject, $dbForPlatform, $project, $resource, $deployment, $bus);
+    }
+}

--- a/tests/unit/Platform/Modules/Functions/Workers/ActivateRulesTest.php
+++ b/tests/unit/Platform/Modules/Functions/Workers/ActivateRulesTest.php
@@ -21,11 +21,11 @@ final class ActivateRulesTest extends TestCase
         $this->activate($dbForPlatform, deploymentBranch: 'main');
 
         $branchQuery = $this->queryFor($captured, 'deploymentVcsProviderBranch');
-        $this->assertNotNull($branchQuery);
+        $this->assertInstanceOf(\Utopia\Database\Query::class, $branchQuery);
         $this->assertSame(['', 'main'], $branchQuery->getValues());
 
         $resourceType = $this->queryFor($captured, 'deploymentResourceType');
-        $this->assertNotNull($resourceType);
+        $this->assertInstanceOf(\Utopia\Database\Query::class, $resourceType);
         $this->assertSame(['function'], $resourceType->getValues());
     }
 
@@ -37,7 +37,7 @@ final class ActivateRulesTest extends TestCase
         $this->activate($dbForPlatform, deploymentBranch: '');
 
         $branchQuery = $this->queryFor($captured, 'deploymentVcsProviderBranch');
-        $this->assertNotNull($branchQuery);
+        $this->assertInstanceOf(\Utopia\Database\Query::class, $branchQuery);
         $this->assertSame([''], $branchQuery->getValues());
     }
 
@@ -61,10 +61,8 @@ final class ActivateRulesTest extends TestCase
         );
 
         $bus = $this->createStub(Bus::class);
-        $bus->method('dispatch')->willReturnCallback(function () use (&$dispatched) {
+        $bus->method('dispatch')->willReturnCallback(function () use (&$dispatched): void {
             $dispatched++;
-
-            return;
         });
 
         $this->activate($dbForPlatform, deploymentBranch: 'main', bus: $bus);


### PR DESCRIPTION
## What

When a Git-connected **function** activates a deployment, the worker now also repoints the generated *"Deployed from `<branch>`"* domain (the branch-scoped rule) at that deployment — not only the branch-agnostic custom / per-deployment domains.

## Problem

Reported from Cloud (region `sfo`, `*.appwrite.network`):

> When connecting a Git repo to a Function, if the **first** deployment fails to build, the auto-generated branch domain (`<hash>.appwrite.network`, *Deployed from main*) stays permanently on `404 router_rule_not_found` — even after a later deployment builds successfully and becomes **Active**. Adding a new custom domain resolves instantly (`200`, `x-edge-rule-cache: hit`).

The edge router is innocent here: the stuck domain returns `x-edge-rule-cache: miss`, so the edge queries Cloud fresh every time and Cloud has no rule bound to a deployment for that host. There is no negative caching at the edge — it faithfully relays Cloud's 404.

## Root cause

A function's generated branch domain is a `rules` document with:

- `trigger = 'manual'`
- `deploymentVcsProviderBranch = '<branch>'` (e.g. `main`)
- `deploymentId = ''` when it is created before any successful build (the classic trigger being an initial build failure, but also the ordinary first-deploy race)

On a successful, auto-activated build, `Functions\Workers\Jobs::activate()` walks the resource's manual rules and stamps the new `deploymentId` onto them — but its query filtered `deploymentVcsProviderBranch => ['']`, i.e. **only branch-agnostic rules**. The branch-scoped generated domain never matched, so its `deploymentId` stayed empty and the host kept 404ing.

A manually added custom domain works because it is created *after* a deployment is live (so it is born already bound) and typically carries an empty branch — exactly the rows `activate()` already handled.

## Fix

Include the activating deployment's own `providerBranch` in the rebind query:

```php
$branch = $deployment->getAttribute('providerBranch', '');
$branches = $branch === '' ? [''] : ['', $branch];
// ...
Query::equal('deploymentVcsProviderBranch', $branches),
```

- VCS deployment from `main` → rebinds `['', 'main']`: branch-agnostic domains **and** the `Deployed from main` domain.
- Non-VCS / manual deployment (`branch = ''`) → unchanged (`['']`), so a domain for some other branch is never dragged onto it.

The rebind stays gated on activation (`activate === true`), matching the reported expectation that the branch domain should follow the deployment that becomes **Active**.

## Tests

`tests/unit/Platform/Modules/Functions/Workers/ActivateRulesTest.php`:

- `testActivateRebindsGeneratedBranchDomain` — a VCS deployment scopes the rebind to `['', 'main']` for `function` rules.
- `testActivateOfNonVcsDeploymentOnlyTouchesBranchAgnosticRules` — a branchless deployment stays scoped to `['']`.
- `testActivateRepointsMatchedRuleAtTheNewDeployment` — a matched rule's persisted `deploymentId` is set to the activating deployment and a `RuleUpdated` event is emitted.

`composer format`, `composer lint`, and `composer analyze` pass on the changed files.

## Notes / follow-ups

- This fixes forward: **new** activations rebind correctly. Domains already orphaned in production need a one-off backfill — the existing `PatchBackfillRuleDeploymentIds` task only matches synthetic `<type>:<resourceId>` deploymentIds via `Query::contains('deploymentId', [':'])`, not these empty-string ones, so it won't catch them as-is.
- Cloud ships an `activate()` override (`src/Appwrite/Cloud/Platform/Workers/Jobs.php`) carrying the same `deploymentVcsProviderBranch => ['']` filter; it needs the identical change to take effect on Cloud.