### PR TITLE
fix: allow System 0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
         "utopia-php/servers": "0.4.*",
         "utopia-php/registry": "0.5.*",
         "utopia-php/storage": "^4.0",
-        "utopia-php/system": "0.10.*",
+        "utopia-php/system": "^0.10 || ^0.11",
         "utopia-php/telemetry": "^0.4",
         "utopia-php/user-agent": "0.1.*",
         "mustangostang/spyc": "0.6.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1894661a7a85782143bcf13ad458427d",
+    "content-hash": "e01715f2fe81b1e435e075ad4fa9e099",
     "packages": [
         {
             "name": "adhocore/jwt",


### PR DESCRIPTION
Allow Cloud to require System 0.11 directly for its cgroup-aware memory capacity API. CE currently restricts consumers to `0.10.*`, forcing a version alias even though System 0.11 retains the existing API.

Accept `^0.10 || ^0.11`. Refresh the lockfile hash while retaining every locked package version; adopting 0.11 in CE itself is not required for this compatibility change.

Validation: Composer lock resolution passes with no package version changes (`--no-install --no-scripts --ignore-platform-reqs` on macOS). No runtime code changes or E2E run. Supports appwrite-labs/cloud#5687; Utopia HTTP and PHP Runtimes also need compatible releases before Cloud's complete graph resolves on 0.11.
