### PR TITLE
feat: support capacitor:// as an allowed origin

### DIFF
--- a/src/Appwrite/Network/Platform.php
+++ b/src/Appwrite/Network/Platform.php
@@ -26,6 +26,7 @@ class Platform
     public const SCHEME_WINDOWS = 'appwrite-windows';
     public const SCHEME_LINUX = 'appwrite-linux';
     public const SCHEME_TAURI = 'tauri';
+    public const SCHEME_CAPACITOR = 'capacitor';
 
     public const string LOOPBACK_HOSTNAME = 'localhost';
 
@@ -70,6 +71,7 @@ class Platform
         self::SCHEME_SAFARI_EXTENSION => 'Web (Safari Extension)',
         self::SCHEME_EDGE_EXTENSION => 'Web (Edge Extension)',
         self::SCHEME_TAURI => 'Web (Tauri)',
+        self::SCHEME_CAPACITOR => 'Web (Capacitor)',
     ];
 
     /**

--- a/src/Appwrite/Network/Validator/Origin.php
+++ b/src/Appwrite/Network/Validator/Origin.php
@@ -70,6 +70,7 @@ class Origin extends Validator
             Platform::SCHEME_SAFARI_EXTENSION,
             Platform::SCHEME_EDGE_EXTENSION,
             Platform::SCHEME_TAURI,
+            Platform::SCHEME_CAPACITOR,
         ];
         if (in_array($this->scheme, $webPlatforms, true)) {
             $validator = new Hostname($this->allowedHostnames);

--- a/tests/unit/Network/CorsTest.php
+++ b/tests/unit/Network/CorsTest.php
@@ -115,6 +115,22 @@ final class CorsTest extends TestCase
         $this->assertSame('https://example.com', $result[Cors::HEADER_ALLOW_ORIGIN]);
     }
 
+    public function testNonHttpSchemeOriginIsMatchedByHost(): void
+    {
+        $cors = new Cors(
+            allowedHosts: ['app.example.com'],
+            allowedMethods: ['POST'],
+            allowedHeaders: ['X-Test'],
+            exposedHeaders: [],
+            allowCredentials: true
+        );
+
+        /* Webview origins such as Capacitor's carry a custom scheme, see Platform::SCHEME_CAPACITOR */
+        $result = $cors->headers('capacitor://app.example.com');
+
+        $this->assertSame('capacitor://app.example.com', $result[Cors::HEADER_ALLOW_ORIGIN]);
+    }
+
     public function testOriginIsLowercasedForMatching(): void
     {
         $cors = new Cors(

--- a/tests/unit/Network/Validators/OriginTest.php
+++ b/tests/unit/Network/Validators/OriginTest.php
@@ -79,6 +79,11 @@ final class OriginTest extends TestCase
         $this->assertEquals(false, $validator->isValid('tauri://example.com'));
         $this->assertSame('Invalid Origin. Register your new client (example.com) as a new Web (Tauri) platform on your project console dashboard', $validator->getDescription());
 
+        $this->assertEquals(true, $validator->isValid('capacitor://localhost'));
+        $this->assertEquals(true, $validator->isValid('capacitor://appwrite.io'));
+        $this->assertEquals(false, $validator->isValid('capacitor://example.com'));
+        $this->assertSame('Invalid Origin. Register your new client (example.com) as a new Web (Capacitor) platform on your project console dashboard', $validator->getDescription());
+
         $this->assertEquals(false, $validator->isValid('random-scheme://localhost'));
         $this->assertSame('Invalid Scheme. The scheme used (random-scheme) in the Origin (random-scheme://localhost) is not supported. If you are using a custom scheme, please change it to `appwrite-callback-<PROJECT_ID>`', $validator->getDescription());
     }


### PR DESCRIPTION
## What does this PR do?

Adds `capacitor` to the schemes Appwrite recognises as web platforms, so origins such as `capacitor://app.tycko.cz` are accepted.

Capacitor's iOS webview serves the app from `capacitor://<hostname>` — `capacitor://localhost` by default, or the configured `server.hostname`. Appwrite did not know the scheme, so `Origin` skipped hostname matching and fell through to the custom-scheme allow list, where `capacitor` is absent. Every request from a Capacitor iOS app was rejected with `Invalid Scheme. The scheme used (capacitor) ... is not supported`.

The origin is now matched by host against the project's registered Web platform hostnames, exactly like `tauri://` and the browser-extension schemes. `capacitor://app.tycko.cz` is accepted once `app.tycko.cz` is registered as a Web platform, and nothing else is — an unregistered host still fails.

`Cors` already matched by host regardless of scheme, so it needed no change; a test pins that behaviour.

## Test Plan

`vendor/bin/phpunit tests/unit/Network/CorsTest.php tests/unit/Network/Validators/OriginTest.php` — 23 tests, 135 assertions, passing.

Added coverage:
- `capacitor://localhost` and `capacitor://appwrite.io` are valid against a matching allow list.
- `capacitor://example.com` is rejected, with the `Web (Capacitor)` platform hint in the error.
- `Cors::headers()` echoes `capacitor://app.example.com` when `app.example.com` is allowed.

## Related PRs and Issues

Reported by a customer using Capacitor with a custom `server.hostname` (`capacitor://app.tycko.cz`).

## Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)