### PR TITLE
perf: deduplicate wildcard patterns before expanding events

### DIFF
--- a/src/Appwrite/Event/Event.php
+++ b/src/Appwrite/Event/Event.php
@@ -562,6 +562,9 @@ class Event
         foreach ($patterns as $eventPattern) {
             $events[] = \str_replace($paramKeys, $paramValues, $eventPattern);
             $events[] = \str_replace($paramKeys, '*', $eventPattern);
+            // Several permutations produce the same wildcard pattern. Deduplicate
+            // before substituting values, preserving the first occurrence order.
+            $wildcards = [];
             foreach ($paramKeys as $key) {
                 foreach ($paramKeys as $current) {
                     if ($subSubResource) {
@@ -569,20 +572,21 @@ class Event
                             if ($subCurrent === $current || $subCurrent === $key) {
                                 continue;
                             }
-                            $filtered1 = \array_filter($paramKeys, fn (string $k) => $k === $subCurrent);
-                            $events[] = \str_replace($paramKeys, $paramValues, \str_replace($filtered1, '*', $eventPattern));
-                            $filtered2 = \array_filter($paramKeys, fn (string $k) => $k === $current);
-                            $events[] = \str_replace($paramKeys, $paramValues, \str_replace($filtered2, '*', \str_replace($filtered1, '*', $eventPattern)));
-                            $events[] = \str_replace($paramKeys, $paramValues, \str_replace($filtered2, '*', $eventPattern));
+                            $wildcard = \str_replace(\is_string($subCurrent) ? $subCurrent : [], '*', $eventPattern);
+                            $wildcards[$wildcard] = true;
+                            $wildcards[\str_replace(\is_string($current) ? $current : [], '*', $wildcard)] = true;
+                            $wildcards[\str_replace(\is_string($current) ? $current : [], '*', $eventPattern)] = true;
                         }
                     } else {
                         if ($current === $key) {
                             continue;
                         }
-                        $filtered = \array_filter($paramKeys, fn (string $k) => $k === $current);
-                        $events[] = \str_replace($paramKeys, $paramValues, \str_replace($filtered, '*', $eventPattern));
+                        $wildcards[\str_replace(\is_string($current) ? $current : [], '*', $eventPattern)] = true;
                     }
                 }
+            }
+            foreach ($wildcards as $wildcard => $_) {
+                $events[] = \str_replace($paramKeys, $paramValues, $wildcard);
             }
         }
 

--- a/tests/unit/Event/EventTest.php
+++ b/tests/unit/Event/EventTest.php
@@ -160,6 +160,42 @@ final class EventTest extends TestCase
         }
     }
 
+    public function testWildcardDeduplicationPreservesDeliveryOrder(): void
+    {
+        $events = Event::generateEvents(
+            'databases.[databaseId].collections.[collectionId].documents.[documentId].create',
+            ['databaseId' => 'db', 'collectionId' => 'col', 'documentId' => 'doc'],
+            new Document(['type' => 'documentsdb']),
+        );
+
+        // Realtime derives its target from events[0]. Keep the concrete event
+        // first and preserve the wildcard and parent event delivery order.
+        $this->assertSame([
+            'documentsdb.db.collections.col.documents.doc.create',
+            'documentsdb.*.collections.*.documents.*.create',
+            'documentsdb.db.collections.*.documents.doc.create',
+            'documentsdb.*.collections.*.documents.doc.create',
+            'documentsdb.*.collections.col.documents.doc.create',
+            'documentsdb.db.collections.col.documents.*.create',
+            'documentsdb.*.collections.col.documents.*.create',
+            'documentsdb.db.collections.*.documents.*.create',
+            'documentsdb.db.collections.col.documents.doc',
+            'documentsdb.*.collections.*.documents.*',
+            'documentsdb.db.collections.*.documents.doc',
+            'documentsdb.*.collections.*.documents.doc',
+            'documentsdb.*.collections.col.documents.doc',
+            'documentsdb.db.collections.col.documents.*',
+            'documentsdb.*.collections.col.documents.*',
+            'documentsdb.db.collections.*.documents.*',
+            'documentsdb.db.collections.col',
+            'documentsdb.*.collections.*',
+            'documentsdb.db.collections.*',
+            'documentsdb.*.collections.col',
+            'documentsdb.db',
+            'documentsdb.*',
+        ], $events);
+    }
+
     public function testGenerateMirrorEvents(): void
     {
         $legacyDatabase = new Document(['type' => 'legacy']);


### PR DESCRIPTION
## What does this PR do?

Database event expansion repeatedly builds identical wildcard combinations, substitutes every parameter into each copy, and only then discards duplicates. Deduplicate intermediate wildcard patterns before substitution and replace repeated parameter-name filtering with equivalent direct substitutions. Preserve concrete-event-first ordering, wildcard and parent event order, database aliases, and numeric-key behavior.

This path appeared in both API shutdown and realtime delivery during live Cloud sampling with php-fast-profile. It accounted for 90 samples, or 3.48% after excluding scheduler/start leaf samples. These are wall-clock PHP stack samples, not on-CPU measurements.

Local PHP 8.5.9 benchmark: median of seven alternating before/after rounds, 5,000 calls per round:

| Event expansion | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Three-level database event with legacy aliases | 411.27 ms | 151.25 ms | 63.2% |
| Three-level documentsdb event | 385.25 ms | 110.38 ms | 71.3% |

These improvements apply to event expansion, not total pod CPU. No production change has been deployed.

## Test Plan

- Added an exact ordered-event regression, including the concrete first event used to derive the realtime target.
- Event unit directory on current main plus this patch: 13 tests, 278 assertions passed. Used PHP 8.5.9, existing local dependencies, and the current local queue package to supply main's new Synchronous interface.
- Pint passed for both changed files; git diff --check passed.
- 3,000 differential cases matched the original output exactly, including ordering: parameter permutations, extra/numeric parameters, wildcard/empty/overlapping values, and legacy/tablesdb/documentsdb/vectorsdb contexts.
- Compatibility tests pass both implementations; the before/after benchmark demonstrates the performance improvement.
- No E2E or production rollout validation was run for this local string-generation change.

## Related PRs and Issues

Cloud consumes this shared implementation through appwrite/server-ce and will need a dependency update after merge.

## Checklist

- [x] Read the contributing guidelines.
- [x] No API metadata changes; generated specs and example docs are unchanged.
