### PR TITLE
fix: remove x-appwrite.produces from OpenAPI responses

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -545,20 +545,6 @@ class OpenAPI3 extends Format
                 }
             }
 
-            // No response declares content (e.g. 204 No content): keep the produced
-            // content type available for SDK generation.
-            $hasResponseContent = false;
-            foreach ($temp['responses'] as $responseData) {
-                if (isset($responseData['content'])) {
-                    $hasResponseContent = true;
-                    break;
-                }
-            }
-
-            if (!$hasResponseContent && $produces !== '') {
-                $temp['x-appwrite']['produces'] = [$produces];
-            }
-
             if (!empty($scope)) {
                 $securities = [($sdk->getLocationAuth()[0] ?? 'Project') => []];
 

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -947,7 +947,7 @@ final class FormatTest extends TestCase
 
     }
 
-    public function testNoContentMethodsKeepProducesMetadata(): void
+    public function testNoContentMethodsOmitProducesMetadata(): void
     {
         Method::$processed = [];
         Method::$errors = [];
@@ -975,7 +975,7 @@ final class FormatTest extends TestCase
         $openApiMethod = $openApi['paths']['/tests/{testId}']['delete'];
 
         $this->assertArrayNotHasKey('content', $openApiMethod['responses']['204']);
-        $this->assertSame(['application/json'], $openApiMethod['x-appwrite']['produces']);
+        $this->assertArrayNotHasKey('produces', $openApiMethod['x-appwrite']);
     }
 
     public static function binaryResponseTypes(): \Iterator


### PR DESCRIPTION
# Stop emitting x-appwrite.produces

CLO-4377: https://linear.app/appwrite/issue/CLO-4377/openapi3-standards

PR 1/4. Follow-ups: [Cloud promotion — pending PR URL], [canonical specs — pending PR URL], [SDK generator #1888](https://github.com/appwrite/sdk-generator/pull/1888).

## Spec change
Actual Appwrite CLI output for `DELETE /sites/{siteId}/logs/{logId}` (`sitesDeleteLog`), before → after (excerpt):
```diff
 "responses": {
     "204": {
         "description": "No content"
     }
 },
 "x-appwrite": {
-    "produces": ["application/json"],
     ...
 }
```
No response body is invented for 204. Explicit JSON, text and binary response content is unchanged. Current Appwrite main emits OpenAPI3 only; no historical Swagger2 documents or producer were rewritten.

## Validation
- Ran `php app/cli.php specs --version=2.0.x --mode=normal --git=no` and the `latest` equivalent, before and after, from the same Appwrite base.
- Each actual CE document has exactly two extension deletions (`sitesDeleteLog`, `vcsUpdateExternalDeployments`); every other parsed JSON value is identical. This is CE, not Cloud: the published Cloud document has 49 extension-bearing operations.
- Both before/after documents pass swagger-parser validation; after document passes reference validation.
- `php -l` and `composer lint src/Appwrite/SDK/Specification/Format/OpenAPI3.php` pass.
- No new unit tests.

## Rollout
After merge, record the real published Appwrite merge SHA A. Cloud must promote its server-ce lock to A (or a reviewed descendant), then regenerate canonical specs with Cloud overrides. Generator release waits for publication. Rust downstream changes are an intentional breaking correction and are documented in PR 4.

## Captured validation output

Actual command-output excerpts rendered locally and captured with Chromium. These are test-log screenshots, not live browser UI/e2e screenshots. Local configuration paths are excluded by selecting the public stdout excerpt; result text is unchanged.

![Captured command output](https://github.com/user-attachments/assets/9fc35012-8bc8-481f-9a7a-49626d70107f)

<!-- Publication handoff: upload the PNG attachment, then replace the local image reference above with its hosted attachment URL before submitting this PR body. -->

Revalidated after rebasing onto Appwrite main `5070d71d6cdf7b7c1c2d5796949480a17a238a66`; prepared commit `0f40cfa24cbdd084c3371c6c5a14f00ecaecce8a`. Both 2.0.x/latest before/after pairs still differ only by the two extension deletions and validate cleanly.


