### PR TITLE
fix(messaging): decrypt email attachments before sending

### DIFF
--- a/src/Appwrite/OpenSSL/OpenSSL.php
+++ b/src/Appwrite/OpenSSL/OpenSSL.php
@@ -32,7 +32,7 @@ class OpenSSL
      * @param string $tag
      * @param string $aad
      *
-     * @return string
+     * @return string|false
      */
     public static function decrypt($data, $method, $password, $options = 1, $iv = '', $tag = '', $aad = '')
     {

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -139,7 +139,15 @@ class Messaging extends Action
 
                     throw $e;
                 } finally {
-                    $this->getLocalDevice($project)->delete($attachmentsPath, true);
+                    // Decrypted plaintext must not linger. A failed delete and an absent directory both come
+                    // back false, so only a directory that is still there after the attempt is worth
+                    // reporting; throwing here would bury whatever the send itself threw.
+                    $deviceForLocal = $this->getLocalDevice($project);
+                    $deviceForLocal->delete($attachmentsPath, true);
+
+                    if ($deviceForLocal->exists($attachmentsPath)) {
+                        Span::add('message.attachments_cleanup_failed', $attachmentsPath);
+                    }
                 }
                 break;
             default:

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -123,9 +123,8 @@ class Messaging extends Action
                 $messageId = $payload['messageId'];
                 $message = $dbForProject->getDocument('messages', $messageId);
 
-                // Attachments are materialised under here, decrypted, and the finally below reclaims them. The
-                // directory is unique to this job so a redelivery can never clear one a live job is still
-                // reading, and a bucket ID may not start with an underscore, so none can address it.
+                // Unique per job so a redelivery cannot reclaim a directory a live job is still
+                // reading; the underscore prefix is unreachable, as a bucket ID may not start with one.
                 $attachmentsPath = $this->getLocalDevice($project)->getPath('_attachments/' . ID::unique());
 
                 try {
@@ -164,7 +163,6 @@ class Messaging extends Action
         try {
             $message = $dbForProject->getDocument('messages', $messageId);
 
-            // A message that already reached a terminal status keeps it.
             if ($message->isEmpty() || \in_array($message->getAttribute('status'), [MessageStatus::SENT, MessageStatus::FAILED], true)) {
                 return;
             }
@@ -216,8 +214,7 @@ class Messaging extends Action
             return;
         }
 
-        // Built once for the whole send: every batch and every retry attempt rebuilds the provider message,
-        // and decrypting an attachment per rebuild would repeat the work up to a few hundred times.
+        // Hoisted out of buildMessage(), which every batch and every retry attempt calls.
         $attachments = $providerType === MESSAGE_TYPE_EMAIL
             ? $this->prepareAttachments($dbForProject, $message, $deviceForFiles, $project, $attachmentsPath)
             : [];
@@ -1058,7 +1055,9 @@ class Messaging extends Action
                 ? $source
                 : $decompressed;
 
-            $this->getLocalDevice($project)->write($target, new Stream($source), $contentType);
+            if (!$this->getLocalDevice($project)->write($target, new Stream($source), $contentType)) {
+                throw new \Exception('Failed to prepare attachment ' . $file->getId());
+            }
 
             $prepared[] = new Attachment($file->getAttribute('name'), $target, $contentType);
         }

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -5,7 +5,11 @@ namespace Appwrite\Platform\Workers;
 use Appwrite\Event\Message\Usage;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
 use Appwrite\Messaging\Status as MessageStatus;
+use Appwrite\OpenSSL\OpenSSL;
 use Appwrite\Usage\Context as UsageContext;
+use Utopia\Compression\Algorithms\GZIP;
+use Utopia\Compression\Algorithms\Zstd;
+use Utopia\Compression\Compression;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
@@ -41,6 +45,7 @@ use Utopia\Messaging\Messages\Push;
 use Utopia\Messaging\Messages\SMS;
 use Utopia\Messaging\Priority;
 use Utopia\Platform\Action;
+use Utopia\Psr7\Stream;
 use Utopia\Queue\Message;
 use Utopia\Span\Span;
 use Utopia\Storage\Device;
@@ -118,16 +123,23 @@ class Messaging extends Action
                 $messageId = $payload['messageId'];
                 $message = $dbForProject->getDocument('messages', $messageId);
 
+                // Attachments are materialised under here, decrypted, and the finally below reclaims them. The
+                // directory is unique to this job so a redelivery can never clear one a live job is still
+                // reading, and a bucket ID may not start with an underscore, so none can address it.
+                $attachmentsPath = $this->getLocalDevice($project)->getPath('_attachments/' . ID::unique());
+
                 try {
                     if ($message->isEmpty()) {
                         throw new \Exception('Message not found: ' . $messageId);
                     }
 
-                    $this->sendExternalMessage($dbForProject, $message, $deviceForFiles, $project, $publisherForUsage);
+                    $this->sendExternalMessage($dbForProject, $message, $deviceForFiles, $project, $publisherForUsage, $attachmentsPath);
                 } catch (\Throwable $e) {
                     $this->markFailed($dbForProject, $messageId, $e);
 
                     throw $e;
+                } finally {
+                    $this->getLocalDevice($project)->delete($attachmentsPath, true);
                 }
                 break;
             default:
@@ -144,7 +156,7 @@ class Messaging extends Action
         try {
             $message = $dbForProject->getDocument('messages', $messageId);
 
-            // Attachment cleanup runs after delivery and throws on its own; a terminal status must survive it.
+            // A message that already reached a terminal status keeps it.
             if ($message->isEmpty() || \in_array($message->getAttribute('status'), [MessageStatus::SENT, MessageStatus::FAILED], true)) {
                 return;
             }
@@ -163,7 +175,8 @@ class Messaging extends Action
         Document $message,
         Device $deviceForFiles,
         Document $project,
-        UsagePublisher $publisherForUsage
+        UsagePublisher $publisherForUsage,
+        string $attachmentsPath
     ): void {
         $status = $message->getAttribute('status');
 
@@ -194,6 +207,12 @@ class Messaging extends Action
             Span::add('message.skipped', 'no_enabled_provider');
             return;
         }
+
+        // Built once for the whole send: every batch and every retry attempt rebuilds the provider message,
+        // and decrypting an attachment per rebuild would repeat the work up to a few hundred times.
+        $attachments = $providerType === MESSAGE_TYPE_EMAIL
+            ? $this->prepareAttachments($dbForProject, $message, $deviceForFiles, $project, $attachmentsPath)
+            : [];
 
         /**
          * Resolved providers cached for the lifetime of this job, keyed by provider id.
@@ -243,9 +262,9 @@ class Messaging extends Action
                             $resolvedProviderType,
                             $adapter,
                             $dbForProject,
-                            $deviceForFiles,
                             $project,
-                            $publisherForUsage
+                            $publisherForUsage,
+                            $attachments
                         )
                     );
                 }
@@ -320,37 +339,6 @@ class Messaging extends Action
             'deliveredTotal' => $message->getAttribute('deliveredTotal'),
             'deliveredAt' => $message->getAttribute('deliveredAt'),
         ]));
-
-        // Delete any attachments that were downloaded to local storage
-        if ($providerType === MESSAGE_TYPE_EMAIL) {
-            if ($deviceForFiles->getType() === DeviceType::Local) {
-                return;
-            }
-
-            $data = $message->getAttribute('data');
-            $attachments = $data['attachments'] ?? [];
-
-            foreach ($attachments as $attachment) {
-                $bucketId = $attachment['bucketId'];
-                $fileId = $attachment['fileId'];
-
-                $bucket = $dbForProject->getDocument('buckets', $bucketId);
-                if ($bucket->isEmpty()) {
-                    throw new \Exception('Storage bucket with the requested ID could not be found');
-                }
-
-                $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
-                if ($file->isEmpty()) {
-                    throw new \Exception('Storage file with the requested ID could not be found');
-                }
-
-                $path = $file->getAttribute('path', '');
-
-                if ($this->getLocalDevice($project)->exists($path)) {
-                    $this->getLocalDevice($project)->delete($path);
-                }
-            }
-        }
     }
 
     /**
@@ -559,6 +547,7 @@ class Messaging extends Action
      * reports the original batch size so the caller's `failed = recipients - delivered` holds.
      *
      * @param array<string> $batch
+     * @param array<Attachment> $attachments
      * @return array{delivered: int, recipients: int, errors: array<string>}
      */
     private function sendBatch(
@@ -568,16 +557,16 @@ class Messaging extends Action
         string $providerType,
         EmailAdapter|SMSAdapter|PushAdapter $adapter,
         Database $dbForProject,
-        Device $deviceForFiles,
         Document $project,
-        UsagePublisher $publisherForUsage
+        UsagePublisher $publisherForUsage,
+        array $attachments
     ): array {
         $recipients = \count($batch);
 
         [
             'delivered' => $delivered,
             'errors' => $errors,
-        ] = $this->retrySend($batch, $message, $provider, $providerType, $adapter, $dbForProject, $deviceForFiles, $project);
+        ] = $this->retrySend($batch, $message, $provider, $providerType, $adapter, $dbForProject, $attachments);
 
         $failed = $recipients - $delivered;
 
@@ -622,6 +611,7 @@ class Messaging extends Action
      * adapter-agnostic and rely on exponential backoff alone.
      *
      * @param array<string> $batch
+     * @param array<Attachment> $attachments
      * @return array{delivered: int, errors: array<string>}
      */
     private function retrySend(
@@ -631,8 +621,7 @@ class Messaging extends Action
         string $providerType,
         EmailAdapter|SMSAdapter|PushAdapter $adapter,
         Database $dbForProject,
-        Device $deviceForFiles,
-        Document $project
+        array $attachments
     ): array {
         $delivered = 0;
         $errors = [];
@@ -645,7 +634,7 @@ class Messaging extends Action
 
             // Rebuild the provider message scoped to only the still-pending recipients so a partially-delivered
             // batch never re-sends to recipients that already succeeded on an earlier attempt.
-            $data = $this->buildMessage($pending, $message, $provider, $providerType, $dbForProject, $deviceForFiles, $project);
+            $data = $this->buildMessage($pending, $message, $provider, $providerType, $dbForProject, $attachments);
 
             $retry = [];
 
@@ -793,6 +782,7 @@ class Messaging extends Action
      * Build the provider-specific message for a set of recipients.
      *
      * @param array<string> $to
+     * @param array<Attachment> $attachments
      */
     private function buildMessage(
         array $to,
@@ -800,8 +790,7 @@ class Messaging extends Action
         Document $provider,
         string $providerType,
         Database $dbForProject,
-        Device $deviceForFiles,
-        Document $project
+        array $attachments
     ): Email|SMS|Push {
         $messageData = clone $message;
         $messageData->setAttribute('to', $to);
@@ -809,7 +798,7 @@ class Messaging extends Action
         $data = match ($providerType) {
             MESSAGE_TYPE_SMS => $this->buildSmsMessage($messageData, $provider),
             MESSAGE_TYPE_PUSH => $this->buildPushMessage($messageData),
-            MESSAGE_TYPE_EMAIL => $this->buildEmailMessage($dbForProject, $messageData, $provider, $deviceForFiles, $project),
+            MESSAGE_TYPE_EMAIL => $this->buildEmailMessage($dbForProject, $messageData, $provider, $attachments),
             default => throw new \Exception('Provider with the requested ID is of the incorrect type')
         };
 
@@ -973,12 +962,110 @@ class Messaging extends Action
         return $adapter;
     }
 
+    /**
+     * Materialise a message's attachments as files the adapters can read.
+     *
+     * Uploads are compressed and then encrypted, so a stored file is not what the recipient should get; both
+     * are undone here in reverse, as the storage read endpoints do. The plaintext is written under
+     * $directory and never back to the file's own path, which on a local install is the stored original.
+     *
+     * Bytes travel as a path rather than as Attachment content because Sendgrid and Mailgun read only
+     * getPath(), and content would otherwise stay resident for the whole fan-out.
+     *
+     * @return array<Attachment>
+     */
+    private function prepareAttachments(
+        Database $dbForProject,
+        Document $message,
+        Device $deviceForFiles,
+        Document $project,
+        string $directory
+    ): array {
+        $prepared = [];
+        $mimes = Config::getParam('storage-mimes');
+
+        foreach ($message->getAttribute('data', [])['attachments'] ?? [] as $attachment) {
+            $bucket = $dbForProject->getDocument('buckets', $attachment['bucketId']);
+            if ($bucket->isEmpty()) {
+                throw new \Exception('Storage bucket with the requested ID could not be found');
+            }
+
+            $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $attachment['fileId']);
+            if ($file->isEmpty()) {
+                throw new \Exception('Storage file with the requested ID could not be found');
+            }
+
+            $path = $file->getAttribute('path', '');
+            if (!$deviceForFiles->exists($path)) {
+                throw new \Exception('File not found in ' . $path);
+            }
+
+            $contentType = \in_array($file->getAttribute('mimeType'), $mimes)
+                ? $file->getAttribute('mimeType')
+                : 'text/plain';
+
+            $cipher = $file->getAttribute('openSSLCipher', '');
+            $algorithm = $file->getAttribute('algorithm', Compression::NONE);
+            $target = $directory . '/' . $bucket->getId() . '/' . $file->getId();
+
+            if (empty($cipher) && !\in_array($algorithm, [Compression::GZIP, Compression::ZSTD], true)) {
+                if ($deviceForFiles->getType() !== DeviceType::Local) {
+                    $deviceForFiles->copy($path, $target, $this->getLocalDevice($project));
+                    $path = $target;
+                }
+
+                $prepared[] = new Attachment($file->getAttribute('name'), $path, $contentType);
+                continue;
+            }
+
+            $source = (string) $deviceForFiles->read($path);
+
+            if (!empty($cipher)) {
+                $source = OpenSSL::decrypt(
+                    $source,
+                    $cipher,
+                    System::getEnv('_APP_OPENSSL_KEY_V' . $file->getAttribute('openSSLVersion')),
+                    0,
+                    \hex2bin($file->getAttribute('openSSLIV')),
+                    \hex2bin($file->getAttribute('openSSLTag'))
+                );
+
+                // A rotated or missing key leaves ciphertext no one can read, which must fail the send rather
+                // than reach a recipient.
+                if ($source === false) {
+                    throw new \Exception('Failed to decrypt attachment ' . $file->getId());
+                }
+            }
+
+            $decompressed = match ($algorithm) {
+                Compression::ZSTD => (new Zstd())->decompress($source),
+                Compression::GZIP => (new GZIP())->decompress($source),
+                default => $source,
+            };
+
+            // A decompressor reports failure as an empty string. Files stored above the read buffer before 1.5.0
+            // recorded an algorithm they were never compressed with, so their bytes are already what the
+            // recipient wants; the storage read endpoints fall back to them rather than failing the read.
+            $source = $decompressed === '' && (int) $file->getAttribute('sizeOriginal') > 0
+                ? $source
+                : $decompressed;
+
+            $this->getLocalDevice($project)->write($target, new Stream($source), $contentType);
+
+            $prepared[] = new Attachment($file->getAttribute('name'), $target, $contentType);
+        }
+
+        return $prepared;
+    }
+
+    /**
+     * @param array<Attachment> $attachments
+     */
     private function buildEmailMessage(
         Database $dbForProject,
         Document $message,
         Document $provider,
-        Device $deviceForFiles,
-        Document $project,
+        array $attachments,
     ): Email {
         $fromName = $provider['options']['fromName'] ?? null;
         $fromEmail = $provider['options']['fromEmail'] ?? null;
@@ -989,7 +1076,6 @@ class Messaging extends Action
         $bccTargets = $data['bcc'] ?? [];
         $cc = [];
         $bcc = [];
-        $attachments = $data['attachments'] ?? [];
 
         if (!empty($ccTargets)) {
             $ccTargets = $dbForProject->find('targets', [
@@ -1008,46 +1094,6 @@ class Messaging extends Action
             ]);
             foreach ($bccTargets as $bccTarget) {
                 $bcc[] = ['email' => $bccTarget['identifier']];
-            }
-        }
-
-        if (!empty($attachments)) {
-            foreach ($attachments as &$attachment) {
-                $bucketId = $attachment['bucketId'];
-                $fileId = $attachment['fileId'];
-
-                $bucket = $dbForProject->getDocument('buckets', $bucketId);
-                if ($bucket->isEmpty()) {
-                    throw new \Exception('Storage bucket with the requested ID could not be found');
-                }
-
-                $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
-                if ($file->isEmpty()) {
-                    throw new \Exception('Storage file with the requested ID could not be found');
-                }
-
-                $mimes = Config::getParam('storage-mimes');
-                $path = $file->getAttribute('path', '');
-
-                if (!$deviceForFiles->exists($path)) {
-                    throw new \Exception('File not found in ' . $path);
-                }
-
-                $contentType = 'text/plain';
-
-                if (\in_array($file->getAttribute('mimeType'), $mimes)) {
-                    $contentType = $file->getAttribute('mimeType');
-                }
-
-                if ($deviceForFiles->getType() !== DeviceType::Local) {
-                    $deviceForFiles->copy($path, $path, $this->getLocalDevice($project));
-                }
-
-                $attachment = new Attachment(
-                    $file->getAttribute('name'),
-                    $path,
-                    $contentType
-                );
             }
         }
 

--- a/tests/e2e/Services/Messaging/MessagingBase.php
+++ b/tests/e2e/Services/Messaging/MessagingBase.php
@@ -2259,6 +2259,146 @@ trait MessagingBase
         ];
     }
 
+    public function testSendEmailEncryptedAttachment(): void
+    {
+        $provider = $this->client->call(Client::METHOD_POST, '/messaging/providers/smtp', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'providerId' => ID::unique(),
+            'name' => 'Maildev',
+            'host' => System::getEnv('_APP_SMTP_HOST', 'maildev'),
+            'port' => (int) System::getEnv('_APP_SMTP_PORT', '1025'),
+            'username' => System::getEnv('_APP_SMTP_USERNAME', 'user'),
+            'password' => System::getEnv('_APP_SMTP_PASSWORD', 'password'),
+            'fromName' => 'Appwrite',
+            'fromEmail' => 'attachments@appwrite.io',
+            'enabled' => true,
+        ]);
+
+        $this->assertEquals(201, $provider['headers']['status-code']);
+
+        $bucket = $this->client->call(Client::METHOD_POST, '/storage/buckets', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'bucketId' => ID::unique(),
+            'name' => 'Attachments',
+            'encryption' => true,
+            'compression' => 'gzip',
+        ]);
+
+        $this->assertEquals(201, $bucket['headers']['status-code']);
+
+        $source = __DIR__ . '/../../../resources/csv/documents.csv';
+
+        $file = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucket['body']['$id'] . '/files', [
+            'content-type' => 'multipart/form-data',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'fileId' => ID::unique(),
+            'file' => new CURLFile(\realpath($source), 'text/csv', 'documents.csv'),
+        ]);
+
+        $this->assertEquals(201, $file['headers']['status-code']);
+
+        // Without this the delivered bytes could match simply because nothing was encrypted.
+        $this->assertTrue($file['body']['encryption']);
+
+        $topic = $this->client->call(Client::METHOD_POST, '/messaging/topics', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'topicId' => ID::unique(),
+            'name' => 'attachments',
+        ]);
+
+        $this->assertEquals(201, $topic['headers']['status-code']);
+
+        $user = $this->client->call(Client::METHOD_POST, '/users', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'userId' => ID::unique(),
+            'email' => \uniqid() . '@appwrite.io',
+            'password' => 'password',
+            'name' => 'Attachment User',
+        ]);
+
+        $this->assertEquals(201, $user['headers']['status-code']);
+
+        // Bound to this provider explicitly: an unbound target falls back to whichever email provider the
+        // project enabled first, which is not necessarily the one this test created.
+        $target = $this->client->call(Client::METHOD_POST, '/users/' . $user['body']['$id'] . '/targets', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'targetId' => ID::unique(),
+            'providerType' => 'email',
+            'providerId' => $provider['body']['$id'],
+            'identifier' => \uniqid() . '@appwrite.io',
+        ]);
+
+        $this->assertEquals(201, $target['headers']['status-code']);
+
+        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topic['body']['$id'] . '/subscribers', \array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'subscriberId' => ID::unique(),
+            'targetId' => $target['body']['$id'],
+        ]);
+
+        $this->assertEquals(201, $subscriber['headers']['status-code']);
+
+        $subject = 'Attachment ' . \uniqid();
+
+        $email = $this->client->call(Client::METHOD_POST, '/messaging/messages/email', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'messageId' => ID::unique(),
+            'topics' => [$topic['body']['$id']],
+            'subject' => $subject,
+            'content' => 'See attached',
+            'attachments' => [$bucket['body']['$id'] . ':' . $file['body']['$id']],
+        ]);
+
+        $this->assertEquals(201, $email['headers']['status-code']);
+
+        $messageId = $email['body']['$id'];
+        $this->assertEventually(function () use ($messageId) {
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $messageId, [
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+                'x-appwrite-key' => $this->getProject()['apiKey'],
+            ]);
+            $this->assertEquals(MessageStatus::SENT, $response['body']['status']);
+        }, 30000, 500);
+
+        // An SMTP send moves every recipient into BCC, so the delivered mail carries no To header to match on.
+        $mail = $this->getLastEmail(1, fn (array $mail) => $this->assertSame($subject, $mail['subject']));
+
+        $delivered = \file_get_contents(
+            'http://maildev:1080/email/' . $mail['id'] . '/attachment/' . $mail['attachments'][0]['generatedFileName']
+        );
+
+        $this->assertSame(\file_get_contents($source), $delivered);
+
+        $this->client->call(Client::METHOD_DELETE, '/messaging/providers/' . $provider['body']['$id'], [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ]);
+    }
+
     public function testUpdateEmail(): void
     {
         $params = $this->setupSentEmailData();

--- a/tests/e2e/Services/Messaging/MessagingBase.php
+++ b/tests/e2e/Services/Messaging/MessagingBase.php
@@ -2332,8 +2332,7 @@ trait MessagingBase
 
         $this->assertEquals(201, $user['headers']['status-code']);
 
-        // Bound to this provider explicitly: an unbound target falls back to whichever email provider the
-        // project enabled first, which is not necessarily the one this test created.
+        // Without providerId the target binds to whichever email provider the project enabled first.
         $target = $this->client->call(Client::METHOD_POST, '/users/' . $user['body']['$id'] . '/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],


### PR DESCRIPTION
## What does this PR do?

Fixes #9068 — an email attachment taken from a bucket with encryption enabled arrives as AES-128-GCM ciphertext, and the recipient cannot open it. The same applies to a bucket with `compression` set: the attachment arrives gzip/zstd-compressed.

**Root cause:** uploads are compressed and then encrypted (`Storage/.../Files/Create.php:381-408`), and every storage read endpoint undoes both before serving (`Files/View/Get.php:171-197` and its siblings). `Workers/Messaging.php` was the only consumer of stored bytes in the messaging pipeline that skipped that step — it passed `$file->getAttribute('path')` straight to `new Attachment(...)`, so the adapter read the stored bytes off disk verbatim. Push images are unaffected: they go through a pre-signed URL that hits the `/push` endpoint, which does decrypt.

**Changes:**

- **`prepareAttachments()`** decrypts and then decompresses each attachment, writing the result to a job-unique directory under the project's local uploads root (`_attachments/<uid>/<bucketId>/<fileId>`). A bucket ID may not start with an underscore (`Validator/Key.php:52-55`), so the directory cannot collide with a stored bucket.
- **It runs once per message**, in `sendExternalMessage()` before the `batch()` fan-out, instead of once per batch per retry attempt inside `buildEmailMessage()` (100–500 times for a 5000-recipient SES send). The prepared `array<Attachment>` is threaded down `sendBatch → retrySend → buildMessage → buildEmailMessage`, which lets `Device $deviceForFiles` and `Document $project` drop out of that chain.
- **Nothing is written back to the file's own path.** The old `copy($path, $path, $localDevice)` needed a `DeviceType::Local` guard precisely because on a local install `getLocalDevice($project)` *is* `deviceForFiles`; writing plaintext there would have destroyed the ciphertext irrecoverably, since `openSSLIV`/`openSSLTag` would still claim the file is encrypted. Both guards are gone now that the target is derived from the scratch directory. This also removes the same-path copy race, where up to `MESSAGE_SEND_CONCURRENCY` coroutines truncated and refilled one destination while siblings read it.
- **Cleanup moved to a `finally` in `action()`**, so decrypted plaintext no longer survives the five early returns and every throw that skipped the old post-delivery block. Deleting one directory also drops the two `getDocument()` calls per attachment that the old cleanup performed, and with them its ability to throw over a bucket deleted between send and cleanup.
- **A decompressor reports failure as an empty string** (`GZIP::decompress` is `: string` in a file without `strict_types`, so `gzdecode()`'s `false` is coerced to `''`). Files stored above the 20MB read buffer before 1.5.0 recorded an `algorithm` they were never compressed with; they now fall back to their stored bytes rather than being mailed as an empty file, matching how `Files/Download/Get.php:190-216` keeps them downloadable. An undecryptable file (rotated or missing `_APP_OPENSSL_KEY_V*`) fails the send instead of mailing ciphertext.
- Attachments carry a path and no `content`: `Sendgrid.php:88,97` and `Mailgun.php:111,121-126` read only `Attachment::getPath()`, so a content-only attachment would throw on both. Keeping a real file also keeps their `filesize()`-based size guards honest.
- `OpenSSL::decrypt`'s docblock said `@return string`; `openssl_decrypt` returns `string|false`. Corrected, so the new guard type-checks at PHPStan level 4.

## Test Plan

**Reproduced on `main` and fixed on this branch, same fixture.** Loaded `main`'s `Workers/Messaging.php` under a separate namespace alongside this branch's, stored one file the way `Files/Create.php` does for an encrypted + gzip bucket, and read the bytes each version's `Attachment` puts on the wire:

| | first bytes the adapter sends |
|---|---|
| stored on disk (ciphertext) | `746a776b4d514f4e675a324651463568502f454e43755132…` |
| **before** (`main`) | `746a776b4d514f4e675a324651463568502f454e43755132…` — identical to the ciphertext |
| **after** (this branch) | `696e766f6963655f69642c616d6f756e740a494e562d312c…` = `invoice_id,amount\nINV-1,…` |

**`prepareAttachments()` executed against real stored files**, seven cases, all delivering the expected bytes: encrypted+gzip, encrypted only, gzip only, zstd only, plain, a legacy row whose `algorithm` says gzip over uncompressed bytes, and a genuinely zero-byte upload. In every case the stored original stayed byte-intact and the scratch directory was fully reclaimed. Separately confirmed that the remote-device branch copies into the scratch directory rather than the stored path, and that a file whose key no longer decrypts it throws instead of being sent.

**New e2e:** `testSendEmailEncryptedAttachment` uploads a CSV to an encrypted + gzip bucket, mails it through an SMTP provider to maildev, and asserts the delivered attachment bytes equal the source file. It guards the premise with `assertTrue($file['body']['encryption'])` so it cannot pass vacuously, and binds its own target to its own provider so it does not depend on which email provider the project enabled first. The maildev REST shape it asserts on (`attachments[].generatedFileName`, `GET /email/:id/attachment/:name`) was verified live.

**Static analysis and formatting:** `pint --test` and `composer refactor:check` are clean, and a full `composer analyze` on this branch produces an error set byte-identical to `main`'s own baseline measured in the same tree (2 pre-existing errors, both in `Files/Preview/Get.php`, neither in a file this PR touches).

The new e2e test could **not** be executed locally: every worker container crash-loops because `composer.lock` pins `utopia-php/queue` 1.1.4 while `app/worker.php:80` passes `maxCoroutines:`, so `POST /v1/messaging/messages/email` 500s on `Utopia\Queue\Publisher not found` before the worker is ever reached. That is pre-existing on `main` and unrelated to this change; the test's first 18 assertions pass and it stops exactly there.

## Related PRs and Issues

- Closes #9068

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? — no API surface change; the worker is internal.
