### PR TITLE
fix(events): generate the attribute event before the action event

### DIFF
--- a/src/Appwrite/Event/Event.php
+++ b/src/Appwrite/Event/Event.php
@@ -520,7 +520,9 @@ class Event
         }
 
         /**
-         * Create all possible patterns including placeholders.
+         * Create all possible patterns including placeholders, most specific first:
+         * consumers such as the functions worker take the first event as the name of
+         * the event that actually happened.
          */
         if ($action) {
             if ($subSubResource) {
@@ -536,10 +538,10 @@ class Event
                 $patterns[] = \implode('.', [$type, $resource, $subType, $subResource, $action]);
                 $patterns[] = \implode('.', [$type, $resource, $subType, $subResource]);
             } else {
+                if ($attribute) {
+                    $patterns[] = \implode('.', [$type, $resource, $action, $attribute]);
+                }
                 $patterns[] = \implode('.', [$type, $resource, $action]);
-            }
-            if ($attribute) {
-                $patterns[] = \implode('.', [$type, $resource, $action, $attribute]);
             }
         }
         if ($subSubResource) {

--- a/tests/unit/Event/EventTest.php
+++ b/tests/unit/Event/EventTest.php
@@ -196,6 +196,32 @@ final class EventTest extends TestCase
         ], $events);
     }
 
+    public function testGenerateEventsOrder(): void
+    {
+        // The first event is the concrete event that happened, in full. Consumers that
+        // report a single name take it from there -- the functions worker publishes it
+        // as `x-appwrite-event` and `APPWRITE_FUNCTION_EVENT`.
+        $this->assertSame([
+            'users.torsten.update.name',
+            'users.*.update.name',
+            'users.torsten.update',
+            'users.*.update',
+            'users.torsten',
+            'users.*',
+        ], Event::generateEvents('users.[userId].update.name', [
+            'userId' => 'torsten'
+        ]));
+
+        $membershipEvents = Event::generateEvents('teams.[teamId].memberships.[membershipId].update.status', [
+            'teamId' => 'jets',
+            'membershipId' => 'torsten',
+        ]);
+        $this->assertSame('teams.jets.memberships.torsten.update.status', $membershipEvents[0]);
+
+        // An attribute of a sub-resource does not also belong to its parent.
+        $this->assertNotContains('teams.jets.update.status', $membershipEvents);
+    }
+
     public function testGenerateMirrorEvents(): void
     {
         $legacyDatabase = new Document(['type' => 'legacy']);


### PR DESCRIPTION
## What does this PR do?

`Event::generateEvents()` built its pattern list with the attribute-qualified pattern *after* the plain action pattern for top-level resources, so for `users.[userId].update.name` the generated list started with the less specific event:

```
users.<id>.update | users.*.update | users.<id>.update.name | users.*.update.name | users.<id> | users.*
```

Consumers that have to report a single name read `events[0]` — the functions worker publishes it as `x-appwrite-event` / `APPWRITE_FUNCTION_EVENT` (`Workers/Functions.php:190`), and `Realtime::toTailMetadata()` derives its metadata from it. A function triggered by a name change therefore saw `APPWRITE_FUNCTION_EVENT=users.<id>.update`, with the `.name` silently dropped. Same for `.email`, `.phone`, `.password`, `.status`, `.prefs`, `.labels`, `.mfa`, `.verification` and `teams.*.update.prefs`.

Sub-resource patterns already emitted the most specific event first (`users.<id>.sessions.<id>.delete` is `events[0]`), and `testWildcardDeduplicationPreservesDeliveryOrder` already pins that invariant for the database family. This only fixes the one branch that broke it: the attribute pattern moves into the `else` branch, ahead of the action pattern.

```
users.<id>.update.name | users.*.update.name | users.<id>.update | users.*.update | users.<id> | users.*
```

That trailing `if ($attribute)` also applied to sub-resource patterns, so a membership status update was emitting `teams.<id>.update.status` and `teams.*.update.status` on top of the real events. Neither is in `app/config/events.php`, and `Appwrite\Event\Validator\Event` rejects them, so no webhook or function could ever have subscribed to them — they are now gone (16 events → 14).

Webhooks are unaffected: they already send the full list in `X-Appwrite-Webhook-Events`.

## Test Plan

New regression test `EventTest::testGenerateEventsOrder` pins the full ordering for the reported pattern and asserts the sub-resource attribute case.

Before (on `main`):

```
FAIL order users.[userId].update.name
  got: users.torsten.update | users.*.update | users.torsten.update.name | users.*.update.name | users.torsten | users.*
FAIL no spurious parent attribute event
```

After:

```
docker compose exec appwrite test tests/unit/Event/
OK (14 tests, 281 assertions)
```

Existing expectations are unchanged — event counts (4 / 6 / 10 / 42), the mirror-event tests, and `testWildcardDeduplicationPreservesDeliveryOrder` all still pass, as does the full unit suite (1164 tests).

## Related PRs and Issues

- Fixes #3441

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? — no API metadata changed.
