### PR TITLE
Fix deployment deletion and deferred jobs lifecycle coordination

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Delete.php
@@ -65,6 +65,7 @@ class Delete extends Action
             ->inject('publisherForDeletes')
             ->inject('queueForEvents')
             ->inject('deviceForFunctions')
+            ->inject('locks')
             ->callback($this->action(...));
     }
 
@@ -75,69 +76,74 @@ class Delete extends Action
         Database $dbForProject,
         DeletePublisher $publisherForDeletes,
         Event $queueForEvents,
-        Device $deviceForFunctions
+        Device $deviceForFunctions,
+        callable $locks,
     ) {
-        $function = $dbForProject->getDocument('functions', $functionId);
-        if ($function->isEmpty()) {
-            throw new Exception(Exception::FUNCTION_NOT_FOUND);
-        }
-
-        $deployment = $dbForProject->getDocument('deployments', $deploymentId);
-        if ($deployment->isEmpty()) {
-            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
-        }
-
-        $resourceType = $deployment->getAttribute('resourceType');
-        // Untyped deployments predate Sites and belong to Functions.
-        if (
-            $deployment->getAttribute('resourceId') !== $function->getId()
-            || ($resourceType !== 'functions' && !empty($resourceType))
-        ) {
-            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
-        }
-
-        try {
-            if (!$dbForProject->deleteDocument('deployments', $deployment->getId())) {
-                throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
+        [$deployment, $function] = $locks('jobs-deployment:' . $deploymentId, 30, function () use ($dbForProject, $functionId, $deploymentId) {
+            $function = $dbForProject->getDocument('functions', $functionId);
+            if ($function->isEmpty()) {
+                throw new Exception(Exception::FUNCTION_NOT_FOUND);
             }
-        } catch (TransactionException) {
-            $deploymentExists = !$dbForProject->getDocument('deployments', $deployment->getId())->isEmpty();
 
-            if ($deploymentExists && !$dbForProject->deleteDocument('deployments', $deployment->getId())) {
-                throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
+            $deployment = $dbForProject->getDocument('deployments', $deploymentId);
+            if ($deployment->isEmpty()) {
+                throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
             }
-        }
+
+            $resourceType = $deployment->getAttribute('resourceType');
+            // Untyped deployments predate Sites and belong to Functions.
+            if (
+                $deployment->getAttribute('resourceId') !== $function->getId()
+                || ($resourceType !== 'functions' && !empty($resourceType))
+            ) {
+                throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+            }
+
+            try {
+                if (!$dbForProject->deleteDocument('deployments', $deployment->getId())) {
+                    throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
+                }
+            } catch (TransactionException) {
+                $deploymentExists = !$dbForProject->getDocument('deployments', $deployment->getId())->isEmpty();
+
+                if ($deploymentExists && !$dbForProject->deleteDocument('deployments', $deployment->getId())) {
+                    throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
+                }
+            }
+
+            if ($function->getAttribute('latestDeploymentId') === $deployment->getId()) {
+                $latestDeployment = $dbForProject->findOne('deployments', [
+                    Query::equal('resourceType', ['functions']),
+                    Query::equal('resourceInternalId', [$function->getSequence()]),
+                    Query::orderDesc('$createdAt'),
+                ]);
+                $function = $dbForProject->updateDocument(
+                    'functions',
+                    $function->getId(),
+                    new Document([
+                        'latestDeploymentCreatedAt' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getCreatedAt(),
+                        'latestDeploymentInternalId' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getSequence(),
+                        'latestDeploymentId' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getId(),
+                        'latestDeploymentStatus' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getAttribute('status', ''),
+                    ])
+                );
+            }
+
+            if ($function->getAttribute('deploymentId') === $deployment->getId()) { // Reset function deployment
+                $function = $dbForProject->updateDocument('functions', $function->getId(), new Document([
+                    'deploymentId' => '',
+                    'deploymentInternalId' => '',
+                    'deploymentCreatedAt' => '',
+                ]));
+            }
+
+            return [$deployment, $function];
+        }, 10.0);
 
         if (!empty($deployment->getAttribute('sourcePath', ''))) {
             if (!($deviceForFunctions->delete($deployment->getAttribute('sourcePath', '')))) {
                 throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from storage');
             }
-        }
-
-        if ($function->getAttribute('latestDeploymentId') === $deployment->getId()) {
-            $latestDeployment = $dbForProject->findOne('deployments', [
-                Query::equal('resourceType', ['functions']),
-                Query::equal('resourceInternalId', [$function->getSequence()]),
-                Query::orderDesc('$createdAt'),
-            ]);
-            $function = $dbForProject->updateDocument(
-                'functions',
-                $function->getId(),
-                new Document([
-                    'latestDeploymentCreatedAt' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getCreatedAt(),
-                    'latestDeploymentInternalId' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getSequence(),
-                    'latestDeploymentId' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getId(),
-                    'latestDeploymentStatus' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getAttribute('status', ''),
-                ])
-            );
-        }
-
-        if ($function->getAttribute('deploymentId') === $deployment->getId()) { // Reset function deployment
-            $function = $dbForProject->updateDocument('functions', $function->getId(), new Document(array_merge($function->getArrayCopy(), [
-                'deploymentId' => '',
-                'deploymentInternalId' => '',
-                'deploymentCreatedAt' => '',
-            ])));
         }
 
         $queueForEvents

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
@@ -14,7 +14,6 @@ use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Transaction as TransactionException;
 use Utopia\Database\Validator\UID;
-use Utopia\Lock\Exception\Contention;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 
@@ -80,31 +79,34 @@ class Update extends Action
             throw new Exception(Exception::FUNCTION_NOT_FOUND);
         }
 
-        $deployment = $dbForProject->getDocument('deployments', $deploymentId);
+        // Read and decide under the same lock as completion; never cancel a
+        // stale snapshot or fall back to an unlocked write on contention.
+        $deployment = $locks('jobs-deployment:' . $deploymentId, 30, function () use ($dbForProject, $deploymentId, $function) {
+            $deployment = $dbForProject->getDocument('deployments', $deploymentId);
 
-        if ($deployment->isEmpty()) {
-            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
-        }
+            if ($deployment->isEmpty()) {
+                throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+            }
 
-        if (
-            $deployment->getAttribute('resourceId') !== $function->getId()
-            || $deployment->getAttribute('resourceType') !== 'functions'
-        ) {
-            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
-        }
+            if (
+                $deployment->getAttribute('resourceId') !== $function->getId()
+                || $deployment->getAttribute('resourceType') !== 'functions'
+            ) {
+                throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+            }
 
-        if (\in_array($deployment->getAttribute('status'), ['ready', 'failed'])) {
-            throw new Exception(Exception::BUILD_ALREADY_COMPLETED);
-        }
+            if (\in_array($deployment->getAttribute('status'), ['ready', 'failed'])) {
+                throw new Exception(Exception::BUILD_ALREADY_COMPLETED);
+            }
 
-        $startTime = new \DateTime($deployment->getAttribute('buildStartedAt', 'now'));
-        $endTime = new \DateTime('now');
-        $duration = $endTime->getTimestamp() - $startTime->getTimestamp();
+            if ($deployment->getAttribute('status') === 'canceled') {
+                return $deployment;
+            }
 
-        // Write under the Jobs worker's per-deployment lock: its handlers
-        // read-modify-write buildLogs, and an unserialized cancel write here
-        // loses the closing log line to an in-flight append.
-        $cancel = function () use ($dbForProject, $deployment, $duration) {
+            $startTime = new \DateTime($deployment->getAttribute('buildStartedAt', 'now'));
+            $endTime = new \DateTime('now');
+            $duration = $endTime->getTimestamp() - $startTime->getTimestamp();
+
             try {
                 return $dbForProject->updateDocument('deployments', $deployment->getId(), new Document($this->cancel($deployment, $duration)));
             } catch (TransactionException) {
@@ -124,13 +126,7 @@ class Update extends Action
 
                 return $deployment;
             }
-        };
-
-        try {
-            $deployment = $locks('jobs-deployment:' . $deploymentId, 30, $cancel, 10.0);
-        } catch (Contention) {
-            $deployment = $cancel();
-        }
+        }, 10.0);
 
         // Best-effort cleanup — the deployment is already marked 'canceled'.
         try {

--- a/src/Appwrite/Platform/Modules/Functions/Http/Jobs/Event/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Jobs/Event/Create.php
@@ -57,6 +57,13 @@ class Create extends Action
 
         $event = \json_decode($body, true) ?? [];
 
+        // Internal queue events must never be supplied by callback ingestion.
+        // Unknown jobs-service events were no-ops in the worker; acknowledge them.
+        if (!\in_array($event['type'] ?? '', ['orchestrator.job.log', 'orchestrator.job.artifact', 'orchestrator.job.exit', 'orchestrator.job.complete'], true)) {
+            $response->noContent();
+            return;
+        }
+
         // The project isn't a request-scoped resource here (the jobs-service is
         // the caller), so resolve it from the job meta Appwrite authored. The
         // worker reloads the full project document from this id.

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -124,11 +124,18 @@ class Jobs extends Action
                 if ($cache->load($key, self::DEDUPE_TTL) !== false) {
                     return; // already processed
                 }
-                $cache->save($key, true);
             }
 
             $deployment = $dbForProject->getDocument('deployments', $deploymentId);
             if ($deployment->isEmpty() || $deployment->getAttribute('status') === 'canceled') {
+                return;
+            }
+
+            // Terminal outcomes are immutable, but late logs and source-size
+            // artifacts still belong to the build (callbacks arrive out of order).
+            if (\in_array($deployment->getAttribute('status'), ['ready', 'failed'], true)
+                && $event->event !== 'orchestrator.job.log'
+                && !($event->event === 'orchestrator.job.artifact' && ($event->data['artifactId'] ?? '') === 'sourceSize')) {
                 return;
             }
 
@@ -159,6 +166,11 @@ class Jobs extends Action
             // (success), so key off the status change rather than the event.
             if ($statusBefore !== $deployment->getAttribute('status') && \in_array($deployment->getAttribute('status'), ['ready', 'failed'], true)) {
                 $this->dispatchUpdate($queueForEvents, $queueForWebhooks, $publisherForFunctions, $project, $deployment);
+            }
+
+            // Failed handlers must remain retryable, including deferred-work enqueue failures.
+            if ($event->id !== '') {
+                $cache->save($key, true);
             }
         }, self::LOCK_TIMEOUT);
     }
@@ -239,7 +251,7 @@ class Jobs extends Action
      * every attempt at the transition, not only the first, so an override must be
      * idempotent.
      */
-    protected function onVerified(Database $dbForProject, Document $project, Document $deployment, Cache $cache): void
+    protected function onVerified(Database $dbForProject, Document $project, Document $deployment, Cache $cache, int $buildSize = 0): void
     {
     }
 
@@ -442,7 +454,7 @@ class Jobs extends Action
 
         // Every check this worker makes has passed, so the deployment is publishable
         // as far as it is concerned. Idempotent: each retry of the join arrives here.
-        $this->onVerified($dbForProject, $project, $deployment, $cache);
+        $this->onVerified($dbForProject, $project, $deployment, $cache, $size);
 
         // Something else is not finished. Whatever it is reports back as its own
         // callback, which re-enters through onCallback() and retries this.

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -149,6 +149,13 @@ class Jobs extends Action
                 default => $this->onCallback($event->event, $dbForProject, $dbForPlatform, $project, $deployment, $event->data, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
             };
 
+            // Deduplicate successful handlers before notifications: a realtime
+            // failure must not replay a persisted log append. Handler failures,
+            // including deferred-work enqueue failures, remain retryable.
+            if ($event->id !== '') {
+                $cache->save($key, true);
+            }
+
             // Console realtime on every callback (log stream + status).
             $queueForRealtime
                 ->setSubscribers(['console'])
@@ -166,11 +173,6 @@ class Jobs extends Action
             // (success), so key off the status change rather than the event.
             if ($statusBefore !== $deployment->getAttribute('status') && \in_array($deployment->getAttribute('status'), ['ready', 'failed'], true)) {
                 $this->dispatchUpdate($queueForEvents, $queueForWebhooks, $publisherForFunctions, $project, $deployment);
-            }
-
-            // Failed handlers must remain retryable, including deferred-work enqueue failures.
-            if ($event->id !== '') {
-                $cache->save($key, true);
             }
         }, self::LOCK_TIMEOUT);
     }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Delete.php
@@ -65,6 +65,7 @@ class Delete extends Action
             ->inject('publisherForDeletes')
             ->inject('queueForEvents')
             ->inject('deviceForSites')
+            ->inject('locks')
             ->callback($this->action(...));
     }
 
@@ -75,69 +76,74 @@ class Delete extends Action
         Database $dbForProject,
         DeletePublisher $publisherForDeletes,
         Event $queueForEvents,
-        Device $deviceForSites
+        Device $deviceForSites,
+        callable $locks,
     ) {
-        $site = $dbForProject->getDocument('sites', $siteId);
-        if ($site->isEmpty()) {
-            throw new Exception(Exception::SITE_NOT_FOUND);
-        }
-
-        $deployment = $dbForProject->getDocument('deployments', $deploymentId);
-        if ($deployment->isEmpty()) {
-            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
-        }
-
-        if (
-            $deployment->getAttribute('resourceId') !== $site->getId()
-            || $deployment->getAttribute('resourceType') !== 'sites'
-        ) {
-            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
-        }
-
-        try {
-            if (!$dbForProject->deleteDocument('deployments', $deployment->getId())) {
-                throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
+        [$deployment, $site] = $locks('jobs-deployment:' . $deploymentId, 30, function () use ($dbForProject, $siteId, $deploymentId) {
+            $site = $dbForProject->getDocument('sites', $siteId);
+            if ($site->isEmpty()) {
+                throw new Exception(Exception::SITE_NOT_FOUND);
             }
-        } catch (TransactionException) {
-            $deploymentExists = !$dbForProject->getDocument('deployments', $deployment->getId())->isEmpty();
 
-            if ($deploymentExists && !$dbForProject->deleteDocument('deployments', $deployment->getId())) {
-                throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
+            $deployment = $dbForProject->getDocument('deployments', $deploymentId);
+            if ($deployment->isEmpty()) {
+                throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
             }
-        }
+
+            if (
+                $deployment->getAttribute('resourceId') !== $site->getId()
+                || $deployment->getAttribute('resourceType') !== 'sites'
+            ) {
+                throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+            }
+
+            try {
+                if (!$dbForProject->deleteDocument('deployments', $deployment->getId())) {
+                    throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
+                }
+            } catch (TransactionException) {
+                $deploymentExists = !$dbForProject->getDocument('deployments', $deployment->getId())->isEmpty();
+
+                if ($deploymentExists && !$dbForProject->deleteDocument('deployments', $deployment->getId())) {
+                    throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
+                }
+            }
+
+            if ($site->getAttribute('latestDeploymentId') === $deployment->getId()) {
+                $latestDeployment = $dbForProject->findOne('deployments', [
+                    Query::equal('resourceType', ['sites']),
+                    Query::equal('resourceInternalId', [$site->getSequence()]),
+                    Query::orderDesc('$createdAt'),
+                ]);
+                $site = $dbForProject->updateDocument(
+                    'sites',
+                    $site->getId(),
+                    new Document([
+                        'latestDeploymentCreatedAt' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getCreatedAt(),
+                        'latestDeploymentInternalId' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getSequence(),
+                        'latestDeploymentId' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getId(),
+                        'latestDeploymentStatus' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getAttribute('status', ''),
+                    ])
+                );
+            }
+
+            if ($site->getAttribute('deploymentId') === $deployment->getId()) { // Reset site deployment
+                $site = $dbForProject->updateDocument('sites', $site->getId(), new Document([
+                    'deploymentId' => '',
+                    'deploymentInternalId' => '',
+                    'deploymentScreenshotDark' => '',
+                    'deploymentScreenshotLight' => '',
+                    'deploymentCreatedAt' => '',
+                ]));
+            }
+
+            return [$deployment, $site];
+        }, 10.0);
 
         if (!empty($deployment->getAttribute('sourcePath', ''))) {
             if (!($deviceForSites->delete($deployment->getAttribute('sourcePath', '')))) {
                 throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from storage');
             }
-        }
-
-        if ($site->getAttribute('latestDeploymentId') === $deployment->getId()) {
-            $latestDeployment = $dbForProject->findOne('deployments', [
-                Query::equal('resourceType', ['sites']),
-                Query::equal('resourceInternalId', [$site->getSequence()]),
-                Query::orderDesc('$createdAt'),
-            ]);
-            $site = $dbForProject->updateDocument(
-                'sites',
-                $site->getId(),
-                new Document([
-                    'latestDeploymentCreatedAt' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getCreatedAt(),
-                    'latestDeploymentInternalId' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getSequence(),
-                    'latestDeploymentId' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getId(),
-                    'latestDeploymentStatus' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getAttribute('status', ''),
-                ])
-            );
-        }
-
-        if ($site->getAttribute('deploymentId') === $deployment->getId()) { // Reset site deployment
-            $site = $dbForProject->updateDocument('sites', $site->getId(), new Document(array_merge($site->getArrayCopy(), [
-                'deploymentId' => '',
-                'deploymentInternalId' => '',
-                'deploymentScreenshotDark' => '',
-                'deploymentScreenshotLight' => '',
-                'deploymentCreatedAt' => '',
-            ])));
         }
 
         $queueForEvents

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
@@ -14,7 +14,6 @@ use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Transaction as TransactionException;
 use Utopia\Database\Validator\UID;
-use Utopia\Lock\Exception\Contention;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 
@@ -78,31 +77,34 @@ class Update extends Action
             throw new Exception(Exception::SITE_NOT_FOUND);
         }
 
-        $deployment = $dbForProject->getDocument('deployments', $deploymentId);
+        // Read and decide under the same lock as completion; never cancel a
+        // stale snapshot or fall back to an unlocked write on contention.
+        $deployment = $locks('jobs-deployment:' . $deploymentId, 30, function () use ($dbForProject, $deploymentId, $site) {
+            $deployment = $dbForProject->getDocument('deployments', $deploymentId);
 
-        if ($deployment->isEmpty()) {
-            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
-        }
+            if ($deployment->isEmpty()) {
+                throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+            }
 
-        if (
-            $deployment->getAttribute('resourceId') !== $site->getId()
-            || $deployment->getAttribute('resourceType') !== 'sites'
-        ) {
-            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
-        }
+            if (
+                $deployment->getAttribute('resourceId') !== $site->getId()
+                || $deployment->getAttribute('resourceType') !== 'sites'
+            ) {
+                throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+            }
 
-        if (\in_array($deployment->getAttribute('status'), ['ready', 'failed'])) {
-            throw new Exception(Exception::BUILD_ALREADY_COMPLETED);
-        }
+            if (\in_array($deployment->getAttribute('status'), ['ready', 'failed'])) {
+                throw new Exception(Exception::BUILD_ALREADY_COMPLETED);
+            }
 
-        $startTime = new \DateTime($deployment->getAttribute('buildStartedAt', 'now'));
-        $endTime = new \DateTime('now');
-        $duration = $endTime->getTimestamp() - $startTime->getTimestamp();
+            if ($deployment->getAttribute('status') === 'canceled') {
+                return $deployment;
+            }
 
-        // Write under the Jobs worker's per-deployment lock: its handlers
-        // read-modify-write buildLogs, and an unserialized cancel write here
-        // loses the closing log line to an in-flight append.
-        $cancel = function () use ($dbForProject, $deployment, $duration) {
+            $startTime = new \DateTime($deployment->getAttribute('buildStartedAt', 'now'));
+            $endTime = new \DateTime('now');
+            $duration = $endTime->getTimestamp() - $startTime->getTimestamp();
+
             try {
                 return $dbForProject->updateDocument('deployments', $deployment->getId(), new Document($this->cancel($deployment, $duration)));
             } catch (TransactionException) {
@@ -122,13 +124,7 @@ class Update extends Action
 
                 return $deployment;
             }
-        };
-
-        try {
-            $deployment = $locks('jobs-deployment:' . $deploymentId, 30, $cancel, 10.0);
-        } catch (Contention) {
-            $deployment = $cancel();
-        }
+        }, 10.0);
 
         // Best-effort cleanup — the deployment is already marked 'canceled'.
         try {

--- a/src/Appwrite/Platform/Workers/Deletes.php
+++ b/src/Appwrite/Platform/Workers/Deletes.php
@@ -43,6 +43,8 @@ use function Swoole\Coroutine\batch;
 
 class Deletes extends Action
 {
+    protected \Closure $locks;
+
     protected array $selects = ['$sequence', '$id', '$collection', '$permissions', '$updatedAt'];
     public const PROCESSING_STUCK_RETENTION_SECONDS = 3 * 24 * 60 * 60; // 3 days
 
@@ -76,7 +78,8 @@ class Deletes extends Action
             ->inject('publisherForDeletes')
             ->inject('publisherForUsage')
             ->inject('bus')
-            ->inject('executionStore');
+            ->inject('executionStore')
+            ->inject('locks');
 
         if (System::getEnv('_APP_EDITION', 'self-hosted') === 'self-hosted') {
             $this
@@ -108,6 +111,7 @@ class Deletes extends Action
         UsagePublisher $publisherForUsage,
         Bus $bus,
         Store $executionStore,
+        callable $locks,
         UsageConnection $usageConnection,
     ): void {
         $payload = $message->getPayload();
@@ -142,6 +146,7 @@ class Deletes extends Action
             $publisherForUsage,
             $bus,
             $executionStore,
+            $locks,
         );
 
         // Sweep rows that landed between the purge and the delete. The
@@ -236,7 +241,10 @@ class Deletes extends Action
         UsagePublisher $publisherForUsage,
         Bus $bus,
         Store $executionStore,
+        callable $locks,
     ): void {
+        $this->locks = \Closure::fromCallable($locks);
+
         $payload = $message->getPayload();
 
         if (empty($payload)) {
@@ -595,16 +603,33 @@ class Deletes extends Action
                 $queries[] = Query::notEqual('$id', $activeDeploymentId);
             }
 
-            $this->deleteByGroup(
+            $this->listByGroup(
                 'deployments',
                 $queries,
                 $dbForProject,
-                function (Document $deployment) use ($publisherForDeletes, $project) {
-                    $publisherForDeletes->enqueue(new DeleteMessage(
-                        project: $project,
-                        type: DELETE_TYPE_DOCUMENT,
-                        document: $deployment,
-                    ));
+                function (Document $candidate) use ($dbForProject, $publisherForDeletes, $project, $resource) {
+                    $deployment = ($this->locks)('jobs-deployment:' . $candidate->getId(), 30, function () use ($dbForProject, $candidate, $resource): Document {
+                        // Selection precedes the lock. A completion may have made
+                        // this deployment active while retention was waiting.
+                        $current = $dbForProject->findOne($resource->getCollection(), [Query::equal('$id', [$resource->getId()])]);
+                        if ($current->getAttribute('deploymentId') === $candidate->getId()) {
+                            return new Document();
+                        }
+
+                        $deployment = $dbForProject->getDocument('deployments', $candidate->getId());
+                        if (!$deployment->isEmpty() && !$dbForProject->deleteDocument('deployments', $deployment->getId())) {
+                            throw new \RuntimeException('Failed to remove deployment from DB');
+                        }
+                        return $deployment;
+                    }, 10.0);
+
+                    if (!$deployment->isEmpty()) {
+                        $publisherForDeletes->enqueue(new DeleteMessage(
+                            project: $project,
+                            type: DELETE_TYPE_DOCUMENT,
+                            document: $deployment,
+                        ));
+                    }
                 }
             );
         };
@@ -1753,6 +1778,25 @@ class Deletes extends Action
         Database $database,
         ?callable $callback = null
     ): void {
+        if ($collection === 'deployments') {
+            // Bulk deletion must not remove a row under an in-flight Jobs
+            // transition. Only the DB delete is locked; storage cleanup is not.
+            $this->listByGroup($collection, $queries, $database, function (Document $candidate) use ($database, $callback): void {
+                $deployment = ($this->locks)('jobs-deployment:' . $candidate->getId(), 30, function () use ($database, $candidate): Document {
+                    $deployment = $database->getDocument('deployments', $candidate->getId());
+                    if (!$deployment->isEmpty() && !$database->deleteDocument('deployments', $deployment->getId())) {
+                        throw new \RuntimeException('Failed to remove deployment from DB');
+                    }
+                    return $deployment;
+                }, 10.0);
+
+                if (!$deployment->isEmpty() && $callback !== null) {
+                    $callback($deployment);
+                }
+            });
+            return;
+        }
+
         $start = \microtime(true);
 
         $message = 'collection:'.$database->getNamespace().'_'.$collection;


### PR DESCRIPTION
## Summary

Coordinate deployment deletion/cancellation with Jobs transitions so deferred build work cannot finalize a concurrently removed deployment.

- Lock explicit and cascade deletion; keep storage cleanup outside the lock. Retention rechecks whether a candidate became active.
- Read cancellation state inside the lock; remove the unlocked contention fallback.
- Pass verified build size to deferred-work hooks; deduplicate successful handlers before notifications so realtime failure cannot replay persisted logs, while failed deferred enqueue remains retryable. Preserve terminal outcomes while accepting genuine late logs/source-size artifacts.
- Reserve internal queue events by accepting only supported orchestrator events at authenticated callback ingestion.

Companion: https://github.com/appwrite-labs/cloud/pull/5706 (draft until CE publication and dependency update). It moves edge distribution outside the transition lock and uses these lifecycle guarantees.

## Testing

- Fresh rerun: CE existing worker tests **8 tests / 16 assertions**, Cloud existing worker tests **5 tests / 20 assertions**, using an isolated bootstrap mapping both worktrees to shared read-only dependencies.
- Pint passes in both repositories; `git diff --check` passes.
- Earlier implementation-session procedural drill: **160 passing checks** with production callbacks, real Redis locks/broker, SQLite and six loopback HTTP edges. Covered delete/cancel during polling, late/duplicate completion, enqueue retries, retention/cascade races and internal-progress billing. Red was observed against the original implementation and the rejected synthetic-progress revision. Reports are retained locally; scratch scripts/logs are no longer available after session resumption, so this drill was **not rerun for PR creation**.
- **Not run:** full deployed service E2E, production MySQL, Kubernetes or real remote-edge artifact cleanup. No unit tests added.

Screenshot below is actual PHPUnit output rendered in a browser, **not a product/E2E screenshot**.

![Fresh CE and Cloud PHPUnit output](https://github.com/user-attachments/assets/748844bb-0f99-4aff-907b-528d115ec3e0)

## Integration / rollout

Cloud requires the matching CE dependency and Jobs/Deletes overrides. New internal Cloud events must not reach old consumers: coordinate consumer pause/drain/replacement before resuming, rather than mixed-version consumption. No deployment was performed.

Already accepted remote work cannot be canceled by the local polling predicate. Exceptional finalization beyond the lock TTL and post-terminal side-effect recovery remain limitations.

## Review follow-up validation

- Fresh public-callback procedural reproduction with real SQLite and Redis observed duplicate persisted log lines before the fix and a single line afterward. Failed deferred enqueue left no dedupe key/queued work; redelivery enqueued distribution with verified buildSize=23; another redelivery did not duplicate it.
- Existing CE tests rerun: **8 tests / 16 assertions**; Pint and diff checks pass. No new unit tests.
- Post-terminal side-effect recovery remains preexisting: base `45a0168` cached callback IDs before all processing and already persisted terminal status before side effects. This change does not claim crash-atomic DB/cache or notification recovery.

## Main synchronization

The feature branches were synchronized with current main to resolve the Cloud lock conflict without losing the newly upstreamed CE S3 service/event optimizations. No PR was merged and Cloud remains draft. The temporary Cloud pin now targets pushed CE `b3a661957ecee4a2f26df96aa5b4b51a7cad9b4b`.

Fresh post-synchronization checks: existing CE Jobs/Event/S3 tests **47 tests / 173 assertions**; existing Cloud Deletes/Jobs/Edge/Registration tests **19 tests / 43 assertions** (4 existing mock-expectation notices); callback SQLite/Redis drill passes; focused Cloud PHPStan and Pint pass. Latest-head GitHub CI is still required and tracked separately from Greptile.
