### PR TITLE
fix(users): report the recovery code factor when listing user MFA factors

### DIFF
--- a/src/Appwrite/Platform/Modules/Users/Http/Users/MFA/Factors/XList.php
+++ b/src/Appwrite/Platform/Modules/Users/Http/Users/MFA/Factors/XList.php
@@ -82,6 +82,9 @@ class XList extends Action
             throw new Exception(Exception::USER_NOT_FOUND);
         }
 
+        $mfaRecoveryCodes = $user->getAttribute('mfaRecoveryCodes', []);
+        $recoveryCodeEnabled = \is_array($mfaRecoveryCodes) && \count($mfaRecoveryCodes) > 0;
+
         $totp = TOTP::getAuthenticatorFromUser($user);
 
         $mfaFactors = $project->getAttribute('auths', [])['mfaFactors'] ?? [];
@@ -90,6 +93,7 @@ class XList extends Action
             Type::TOTP => ($mfaFactors['totp'] ?? true) && $totp !== null && $totp->getAttribute('verified', false),
             Type::EMAIL => ($mfaFactors['email'] ?? true) && $user->getAttribute('email', false) && $user->getAttribute('emailVerification', false),
             Type::PHONE => ($mfaFactors['phone'] ?? true) && $user->getAttribute('phone', false) && $user->getAttribute('phoneVerification', false),
+            Type::RECOVERY_CODE => $recoveryCodeEnabled,
             Type::CUSTOM => $mfaFactors['custom'] ?? false
         ]);
 

--- a/src/Appwrite/Platform/Modules/Users/Http/Users/MFA/RecoveryCodes/Create.php
+++ b/src/Appwrite/Platform/Modules/Users/Http/Users/MFA/RecoveryCodes/Create.php
@@ -102,6 +102,8 @@ class Create extends Action
             'recoveryCodes' => $mfaRecoveryCodes
         ]);
 
-        $response->dynamic($document, Response::MODEL_MFA_RECOVERY_CODES);
+        $response
+            ->setStatusCode(Response::STATUS_CODE_CREATED)
+            ->dynamic($document, Response::MODEL_MFA_RECOVERY_CODES);
     }
 }

--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -3010,4 +3010,63 @@ trait UsersBase
         ]);
         $this->assertEquals(404, $response['headers']['status-code']);
     }
+
+    public function testListMFAFactorsRecoveryCode(): void
+    {
+        $projectId = $this->getProject()['$id'];
+        $headers = array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+        ], $this->getHeaders());
+
+        $user = $this->client->call(Client::METHOD_POST, '/users', $headers, [
+            'userId' => ID::unique(),
+            'email' => \uniqid() . '@appwrite.io',
+            'password' => 'password',
+            'name' => 'MFA Recovery Code User',
+        ]);
+
+        $this->assertEquals(201, $user['headers']['status-code']);
+        $userId = $user['body']['$id'];
+
+        $session = $this->client->call(Client::METHOD_POST, '/users/' . $userId . '/sessions', $headers);
+
+        $this->assertEquals(201, $session['headers']['status-code']);
+        $sessionHeaders = [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+            'x-appwrite-session' => $session['body']['secret'],
+        ];
+
+        /**
+         * Test for SUCCESS: both endpoints report no recovery codes before any are generated
+         */
+        $factors = $this->client->call(Client::METHOD_GET, '/users/' . $userId . '/mfa/factors', $headers);
+
+        $this->assertEquals(200, $factors['headers']['status-code']);
+        $this->assertFalse($factors['body']['recoveryCode']);
+
+        $accountFactors = $this->client->call(Client::METHOD_GET, '/account/mfa/factors', $sessionHeaders);
+
+        $this->assertEquals(200, $accountFactors['headers']['status-code']);
+        $this->assertFalse($accountFactors['body']['recoveryCode']);
+
+        $recoveryCodes = $this->client->call(Client::METHOD_PATCH, '/users/' . $userId . '/mfa/recovery-codes', $headers);
+
+        $this->assertEquals(201, $recoveryCodes['headers']['status-code']);
+        $this->assertNotEmpty($recoveryCodes['body']['recoveryCodes']);
+
+        /**
+         * Test for SUCCESS: both endpoints agree once recovery codes exist
+         */
+        $factors = $this->client->call(Client::METHOD_GET, '/users/' . $userId . '/mfa/factors', $headers);
+
+        $this->assertEquals(200, $factors['headers']['status-code']);
+        $this->assertTrue($factors['body']['recoveryCode']);
+
+        $accountFactors = $this->client->call(Client::METHOD_GET, '/account/mfa/factors', $sessionHeaders);
+
+        $this->assertEquals(200, $accountFactors['headers']['status-code']);
+        $this->assertTrue($accountFactors['body']['recoveryCode']);
+    }
 }


### PR DESCRIPTION
Closes #10927

### What does this PR do?

Makes Users MFA factors report whether recovery codes exist, using the same calculation as Account. Previously the omitted `recoveryCode` key defaulted to false even after codes were generated.

Also returns the documented 201 status when creating user recovery codes, matching the Account route and the existing SDK response definition.

### Test Plan

`testListMFAFactorsRecoveryCode` checks both Users and Account before and after generating recovery codes and asserts the creation status.
