### PR TITLE
fix(messaging): keep a single SMTP recipient in the To header

### DIFF
--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -1056,16 +1056,18 @@ class Messaging extends Action
         $content = $data['content'];
         $html = $data['html'] ?? false;
 
-        // SMTP hands one envelope to the whole batch, so a multi-recipient send would show every
-        // subscriber the rest of the list. Those move to BCC, which is carried in the envelope and
-        // never written to a header. A lone recipient has nobody to be hidden from, and emptying To
-        // for them only drops the header - the renderer omits any field that renders empty - which
-        // leaves the client with no recipient to show.
-        if ($provider->getAttribute('provider') === 'smtp' && \count($to) > 1) {
-            foreach ($to as $recipient) {
-                $bcc[] = ['email' => $recipient];
+        if ($provider->getAttribute('provider') === 'smtp') {
+            // SMTP sends one message to the whole batch. Hide subscribers from each other.
+            if (\count($to) > 1) {
+                foreach ($to as $recipient) {
+                    $bcc[] = ['email' => $recipient];
+                }
+                $to = [];
+            } else {
+                // Failed BCC recipients re-enter through To on retry. Keep them hidden,
+                // while ordinary single recipients retain a visible To header.
+                $to = \array_values(\array_diff($to, \array_column($bcc, 'email')));
             }
-            $to = [];
         }
 
         return new Email(

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -1056,8 +1056,12 @@ class Messaging extends Action
         $content = $data['content'];
         $html = $data['html'] ?? false;
 
-        // For SMTP, move all recipients to BCC and use default recipient in TO field
-        if ($provider->getAttribute('provider') === 'smtp') {
+        // SMTP hands one envelope to the whole batch, so a multi-recipient send would show every
+        // subscriber the rest of the list. Those move to BCC, which is carried in the envelope and
+        // never written to a header. A lone recipient has nobody to be hidden from, and emptying To
+        // for them only drops the header - the renderer omits any field that renders empty - which
+        // leaves the client with no recipient to show.
+        if ($provider->getAttribute('provider') === 'smtp' && \count($to) > 1) {
             foreach ($to as $recipient) {
                 $bcc[] = ['email' => $recipient];
             }

--- a/tests/e2e/Services/Messaging/MessagingBase.php
+++ b/tests/e2e/Services/Messaging/MessagingBase.php
@@ -2875,20 +2875,34 @@ trait MessagingBase
 
         $this->assertEquals(201, $provider['headers']['status-code']);
 
+        // Distinct from the user's own email, whose target is created automatically
+        // and holds that identifier already.
         $recipient = \uniqid() . '@appwrite.io';
 
         $user = $this->client->call(Client::METHOD_POST, '/users', $headers, [
             'userId' => ID::unique(),
-            'email' => $recipient,
+            'email' => \uniqid() . '@appwrite.io',
             'password' => 'password',
             'name' => 'SMTP Recipient',
         ]);
 
         $this->assertEquals(201, $user['headers']['status-code']);
 
+        // Bind the target to this provider. A target without a provider id is
+        // delivered through whichever enabled email provider is found first,
+        // which other tests in this suite also create.
+        $target = $this->client->call(Client::METHOD_POST, '/users/' . $user['body']['$id'] . '/targets', $headers, [
+            'targetId' => ID::unique(),
+            'providerType' => 'email',
+            'providerId' => $provider['body']['$id'],
+            'identifier' => $recipient,
+        ]);
+
+        $this->assertEquals(201, $target['headers']['status-code']);
+
         $message = $this->client->call(Client::METHOD_POST, '/messaging/messages/email', $headers, [
             'messageId' => ID::unique(),
-            'targets' => [$user['body']['targets'][0]['$id']],
+            'targets' => [$target['body']['$id']],
             'subject' => 'To header check',
             'content' => 'To header check',
         ]);

--- a/tests/e2e/Services/Messaging/MessagingBase.php
+++ b/tests/e2e/Services/Messaging/MessagingBase.php
@@ -2864,8 +2864,10 @@ trait MessagingBase
         $provider = $this->client->call(Client::METHOD_POST, '/messaging/providers/smtp', $headers, [
             'providerId' => ID::unique(),
             'name' => 'SMTP-to-header',
-            'host' => 'maildev',
+            'host' => System::getEnv('_APP_SMTP_HOST', 'maildev'),
             'port' => \intval(System::getEnv('_APP_SMTP_PORT', '1025')),
+            'username' => System::getEnv('_APP_SMTP_USERNAME', 'user'),
+            'password' => System::getEnv('_APP_SMTP_PASSWORD', 'password'),
             'encryption' => 'none',
             'autoTLS' => false,
             'fromName' => 'Sender',

--- a/tests/e2e/Services/Messaging/MessagingBase.php
+++ b/tests/e2e/Services/Messaging/MessagingBase.php
@@ -2853,7 +2853,7 @@ trait MessagingBase
         $this->assertEquals(404, $response['headers']['status-code']);
     }
 
-    public function testSendEmailOverSmtpKeepsSingleRecipientInToHeader(): void
+    public function testSendEmailSmtpHeaders(): void
     {
         $headers = [
             'content-type' => 'application/json',
@@ -2864,10 +2864,10 @@ trait MessagingBase
         $provider = $this->client->call(Client::METHOD_POST, '/messaging/providers/smtp', $headers, [
             'providerId' => ID::unique(),
             'name' => 'SMTP-to-header',
-            'host' => System::getEnv('_APP_SMTP_HOST', 'maildev'),
-            'port' => \intval(System::getEnv('_APP_SMTP_PORT', '1025')),
-            'username' => System::getEnv('_APP_SMTP_USERNAME', 'user'),
-            'password' => System::getEnv('_APP_SMTP_PASSWORD', 'password'),
+            'host' => 'maildev',
+            'port' => 1025,
+            'username' => 'user',
+            'password' => 'password',
             'encryption' => 'none',
             'autoTLS' => false,
             'fromName' => 'Sender',
@@ -2902,6 +2902,7 @@ trait MessagingBase
 
         $this->assertEquals(201, $target['headers']['status-code']);
 
+        // Test for SUCCESS
         $message = $this->client->call(Client::METHOD_POST, '/messaging/messages/email', $headers, [
             'messageId' => ID::unique(),
             'targets' => [$target['body']['$id']],
@@ -2914,6 +2915,7 @@ trait MessagingBase
         $messageId = $message['body']['$id'];
         $this->assertEventually(function () use ($messageId, $headers) {
             $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $messageId, $headers);
+            $this->assertEquals(200, $response['headers']['status-code']);
             $this->assertEquals(MessageStatus::SENT, $response['body']['status']);
         }, 30000, 500);
 
@@ -2922,5 +2924,56 @@ trait MessagingBase
         $email = $this->getLastEmailByAddress($recipient);
 
         $this->assertEquals($recipient, $email['to'][0]['address']);
+
+        $ccRecipient = \uniqid() . '@appwrite.io';
+        $cc = $this->client->call(Client::METHOD_POST, '/users/' . $user['body']['$id'] . '/targets', $headers, [
+            'targetId' => ID::unique(),
+            'providerType' => 'email',
+            'providerId' => $provider['body']['$id'],
+            'identifier' => $ccRecipient,
+        ]);
+
+        $this->assertEquals(201, $cc['headers']['status-code']);
+
+        $topic = $this->client->call(Client::METHOD_POST, '/messaging/topics', $headers, [
+            'topicId' => ID::unique(),
+            'name' => ID::unique(),
+        ]);
+
+        $this->assertEquals(201, $topic['headers']['status-code']);
+
+        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topic['body']['$id'] . '/subscribers', $headers, [
+            'subscriberId' => ID::unique(),
+            'targetId' => $target['body']['$id'],
+        ]);
+
+        $this->assertEquals(201, $subscriber['headers']['status-code']);
+
+        // A topic subscriber explicitly included in BCC must stay hidden from CC.
+        // A retry of a lone failed BCC recipient produces the same To/BCC overlap.
+        $message = $this->client->call(Client::METHOD_POST, '/messaging/messages/email', $headers, [
+            'messageId' => ID::unique(),
+            'topics' => [$topic['body']['$id']],
+            'cc' => [$cc['body']['$id']],
+            'bcc' => [$target['body']['$id']],
+            'subject' => 'BCC header check',
+            'content' => 'BCC header check',
+        ]);
+
+        $this->assertEquals(201, $message['headers']['status-code']);
+
+        $messageId = $message['body']['$id'];
+        $this->assertEventually(function () use ($messageId, $headers) {
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $messageId, $headers);
+            $this->assertEquals(200, $response['headers']['status-code']);
+            $this->assertEquals(MessageStatus::SENT, $response['body']['status']);
+        }, 30000, 500);
+
+        $email = $this->getLastEmail(1, function (array $email) use ($ccRecipient) {
+            $this->assertEquals($ccRecipient, $email['cc'][0]['address'] ?? null);
+        });
+
+        $this->assertEmpty($email['to'] ?? []);
+        $this->assertEmpty($email['bcc'] ?? []);
     }
 }

--- a/tests/e2e/Services/Messaging/MessagingBase.php
+++ b/tests/e2e/Services/Messaging/MessagingBase.php
@@ -2852,4 +2852,59 @@ trait MessagingBase
 
         $this->assertEquals(404, $response['headers']['status-code']);
     }
+
+    public function testSendEmailOverSmtpKeepsSingleRecipientInToHeader(): void
+    {
+        $headers = [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ];
+
+        $provider = $this->client->call(Client::METHOD_POST, '/messaging/providers/smtp', $headers, [
+            'providerId' => ID::unique(),
+            'name' => 'SMTP-to-header',
+            'host' => 'maildev',
+            'port' => \intval(System::getEnv('_APP_SMTP_PORT', '1025')),
+            'encryption' => 'none',
+            'autoTLS' => false,
+            'fromName' => 'Sender',
+            'fromEmail' => 'sender@appwrite.io',
+            'enabled' => true,
+        ]);
+
+        $this->assertEquals(201, $provider['headers']['status-code']);
+
+        $recipient = \uniqid() . '@appwrite.io';
+
+        $user = $this->client->call(Client::METHOD_POST, '/users', $headers, [
+            'userId' => ID::unique(),
+            'email' => $recipient,
+            'password' => 'password',
+            'name' => 'SMTP Recipient',
+        ]);
+
+        $this->assertEquals(201, $user['headers']['status-code']);
+
+        $message = $this->client->call(Client::METHOD_POST, '/messaging/messages/email', $headers, [
+            'messageId' => ID::unique(),
+            'targets' => [$user['body']['targets'][0]['$id']],
+            'subject' => 'To header check',
+            'content' => 'To header check',
+        ]);
+
+        $this->assertEquals(201, $message['headers']['status-code']);
+
+        $messageId = $message['body']['$id'];
+        $this->assertEventually(function () use ($messageId, $headers) {
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $messageId, $headers);
+            $this->assertEquals(MessageStatus::SENT, $response['body']['status']);
+        }, 30000, 500);
+
+        // A single recipient must stay in To. Moving them to BCC leaves the message
+        // with no To header at all, and clients show no recipient.
+        $email = $this->getLastEmailByAddress($recipient);
+
+        $this->assertEquals($recipient, $email['to'][0]['address']);
+    }
 }


### PR DESCRIPTION
Closes #12365
Closes #10474

### What does this PR do?

Keeps an ordinary single SMTP recipient in the To header while placing batch recipients in BCC. Explicit BCC recipients stay hidden when retry handling puts a failed address back into the pending To list.

No placeholder recipient is added: an address in To is also an SMTP envelope recipient and would receive a copy.

### Test Plan

`testSendEmailSmtpHeaders` uses the existing Maildev fixture. It checks a normal single-recipient To header and a topic subscriber also explicitly listed as BCC, asserting that the hidden recipient is absent from visible recipient headers received by CC.

A local reproduction using the actual worker methods also checked a transient failure of a lone BCC recipient: the original code exposed it in To on retry; the fix keeps it hidden while retaining To for ordinary single recipients. Targeted Pint, PHP syntax and diff checks passed. Full Messaging E2E validation runs in CI.

Repeated CC/BCC delivery across batches and delivery accounting are unchanged by this PR.
