### PR TITLE
fix(databases): emit surface-correct ids in committed transaction events

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Update.php
@@ -473,9 +473,12 @@ class Update extends Action
                 $webhooksEvents = $eventProcessor->getWebhooksEvents($project);
 
                 foreach ($documentsToTrigger as $doc) {
+                    // Match the key set processDocument() gives every other row and document
+                    // event: the synthetic $databaseId, plus whichever of $tableId or
+                    // $collectionId belongs to the surface that was called.
                     $payload = $doc->getArrayCopy();
-                    $payload['$tableId'] = $collection->getId();
-                    $payload['$collectionId'] = $collection->getId();
+                    $payload['$databaseId'] = $database->getId();
+                    $payload['$' . $groupId] = $collection->getId();
 
                     $queueForEvents
                         ->setParam('documentId', $doc->getId())

--- a/tests/e2e/Services/Databases/Transactions/TransactionsBase.php
+++ b/tests/e2e/Services/Databases/Transactions/TransactionsBase.php
@@ -1807,6 +1807,54 @@ trait TransactionsBase
         $this->assertEquals(Exception::TRANSACTION_NOT_FOUND, $unknown['body']['type']);
     }
 
+    public function testCommitEventPayloadCarriesSurfaceIds(): void
+    {
+        $databaseId = $this->getSharedDatabase();
+        $collectionId = $this->getSharedCollection();
+
+        $transaction = $this->client->call(Client::METHOD_POST, $this->getTransactionUrl(), array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals(201, $transaction['headers']['status-code']);
+
+        $recordId = ID::unique();
+
+        $created = $this->client->call(Client::METHOD_POST, $this->getRecordUrl($databaseId, $collectionId, null), array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]), [
+            $this->getRecordIdParam() => $recordId,
+            'data' => ['name' => 'Event payload'],
+            'transactionId' => $transaction['body']['$id'],
+        ]);
+
+        $this->assertEquals(201, $created['headers']['status-code']);
+
+        $committed = $this->client->call(Client::METHOD_PATCH, $this->getTransactionUrl($transaction['body']['$id']), array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]), [
+            'commit' => true
+        ]);
+
+        $this->assertEquals(200, $committed['headers']['status-code']);
+
+        // The commit handler builds this payload by hand rather than going through
+        // processDocument(), so it has to add the same keys: the synthetic $databaseId,
+        // and only the container id belonging to the surface that was called.
+        $delivery = $this->getLastRequest(function (array $request) use ($recordId) {
+            $this->assertStringContainsString($recordId, $request['headers']['X-Appwrite-Webhook-Events'] ?? '');
+        });
+
+        $this->assertEquals($databaseId, $delivery['data']['$databaseId']);
+        $this->assertEquals($collectionId, $delivery['data'][$this->getContainerIdResponseKey()]);
+        $this->assertArrayNotHasKey($this->getOppositeContainerIdResponseKey(), $delivery['data']);
+    }
+
     /**
      * Test updateDocument with transactionId via normal route
      */

--- a/tests/e2e/Services/Databases/Transactions/TransactionsBase.php
+++ b/tests/e2e/Services/Databases/Transactions/TransactionsBase.php
@@ -1846,9 +1846,12 @@ trait TransactionsBase
         // The commit handler builds this payload by hand rather than going through
         // processDocument(), so it has to add the same keys: the synthetic $databaseId,
         // and only the container id belonging to the surface that was called.
-        $delivery = $this->getLastRequest(function (array $request) use ($recordId) {
-            $this->assertStringContainsString($recordId, $request['headers']['X-Appwrite-Webhook-Events'] ?? '');
-        });
+        $delivery = $this->getLastRequestForProject(
+            $this->getProject()['$id'],
+            probe: function (array $request) use ($recordId) {
+                $this->assertStringContainsString($recordId, $request['headers']['X-Appwrite-Webhook-Events'] ?? '');
+            }
+        );
 
         $this->assertEquals($databaseId, $delivery['data']['$databaseId']);
         $this->assertEquals($collectionId, $delivery['data'][$this->getContainerIdResponseKey()]);


### PR DESCRIPTION
Related to #12418.

### What does this PR do?

Adds `$databaseId` and the appropriate `$tableId` or `$collectionId` to document and row events emitted when committing a transaction. The handler previously omitted the database ID and added both container keys.

The identifiers come from the database and collection resolved for each operation, matching normal document processing. This fixes the transaction path; it does not establish that the ordinary-create scenario in #12418 is resolved.

### Test Plan

`testCommitEventPayloadCarriesSurfaceIds` stages and commits a record through the API, then uses `getLastRequestForProject()` with the unique record ID to find its webhook. It checks the database ID, the correct container ID and absence of the opposite container key.

The test uses the existing shared transaction suite. Pint and PHP syntax checks passed; the updated E2E runs in CI.
