### PR TITLE
fix(certificates): keep retrying DNS verification for rules older than 3 days

### DIFF
--- a/src/Appwrite/Platform/Tasks/Interval.php
+++ b/src/Appwrite/Platform/Tasks/Interval.php
@@ -3,13 +3,11 @@
 namespace Appwrite\Platform\Tasks;
 
 use Appwrite\Event\Publisher\Certificate;
-use DateTime;
 use Swoole\Coroutine\Channel;
 use Swoole\Process;
 use Swoole\Timer;
 use Utopia\Console;
 use Utopia\Database\Database;
-use Utopia\Database\DateTime as DatabaseDateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Query;
 use Utopia\Platform\Action;
@@ -90,11 +88,7 @@ class Interval extends Action
 
     private function verifyDomain(Database $dbForPlatform, Certificate $publisherForCertificates): void
     {
-        $time = DatabaseDateTime::now();
-        $fromTime = new DateTime('-3 days'); // Max 3 days old
-
         $rules = $dbForPlatform->find('rules', [
-            Query::createdAfter(DatabaseDateTime::format($fromTime)),
             Query::equal('status', [RULE_STATUS_CREATED]), // Created but not verified yet
             Query::orderAsc('$updatedAt'), // Pick the ones waiting for another attempt for longest
             Query::equal('region', [System::getEnv('_APP_REGION', 'default')]), // Only current region

--- a/tests/unit/Platform/Tasks/IntervalTest.php
+++ b/tests/unit/Platform/Tasks/IntervalTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform\Tasks;
+
+use Appwrite\Event\Publisher\Certificate;
+use Appwrite\Platform\Tasks\Interval;
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Database;
+use Utopia\Database\Query;
+
+final class IntervalTest extends TestCase
+{
+    public function testDomainVerificationRetriesRulesOfAnyAge(): void
+    {
+        foreach ($this->domainVerificationQueries() as $query) {
+            $this->assertNotSame('$createdAt', $query->getAttribute(), 'A rule stuck on DNS verification must stay in the scan however old it is');
+        }
+    }
+
+    public function testDomainVerificationRetriesOldestAttemptsFirst(): void
+    {
+        $queries = $this->domainVerificationQueries();
+
+        $order = $this->queryOfMethod($queries, Query::TYPE_ORDER_ASC);
+        $this->assertInstanceOf(Query::class, $order);
+        $this->assertSame('$updatedAt', $order->getAttribute());
+
+        $limit = $this->queryOfMethod($queries, Query::TYPE_LIMIT);
+        $this->assertInstanceOf(Query::class, $limit);
+        $this->assertSame(100, $limit->getValue());
+    }
+
+    /**
+     * @return array<Query>
+     */
+    private function domainVerificationQueries(): array
+    {
+        $captured = [];
+
+        $dbForPlatform = $this->createStub(Database::class);
+        $dbForPlatform->method('find')->willReturnCallback(
+            function (string $collection, array $queries = []) use (&$captured): array {
+                $captured = $queries;
+
+                return [];
+            }
+        );
+
+        (new IntervalTestTasks())->exposeDomainVerification($dbForPlatform, $this->createStub(Certificate::class));
+
+        return $captured;
+    }
+
+    /**
+     * @param array<Query> $queries
+     */
+    private function queryOfMethod(array $queries, string $method): ?Query
+    {
+        foreach ($queries as $query) {
+            if ($query->getMethod() === $method) {
+                return $query;
+            }
+        }
+
+        return null;
+    }
+}
+
+final class IntervalTestTasks extends Interval
+{
+    public function exposeDomainVerification(Database $dbForPlatform, Certificate $publisherForCertificates): void
+    {
+        foreach ($this->getTasks() as $task) {
+            if ($task['name'] === 'domainVerification') {
+                $task['callback']($dbForPlatform, fn () => null, $publisherForCertificates);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

A custom domain rule stays in `created` status until its DNS verification succeeds. `Interval::verifyDomain()` retries those rules every 2 minutes, but only the ones created in the last 3 days:

```php
$fromTime = new DateTime('-3 days'); // Max 3 days old

$rules = $dbForPlatform->find('rules', [
    Query::createdAfter(DatabaseDateTime::format($fromTime)),
    Query::equal('status', [RULE_STATUS_CREATED]),
    ...
```

So a user who adds the domain in the console first and points the CNAME later — which is the normal order, since the console shows you the record to add — falls off the retry list after three days:

1. Rule is created, `verifyRule()` fails because DNS is not pointed yet, status stays `created`. No certificate job is queued, so the domain is never attached to the CDN.
2. The interval task re-checks it for three days, then stops.
3. The user points the CNAME on day 5. Traffic now reaches the CDN, which has never heard of the domain, and gets an error page — permanently, until someone retries verification by hand.

This drops the age bound. Nothing else about the scan changes: it is still capped at `limit(100)` per tick and ordered by `$updatedAt` ascending, and `Certificates::handleDomainVerificationAction()` writes the rule back on every attempt (status on success, `logs` on failure) via `updateRuleAndSendEvents()`. So each attempt moves that rule to the back of the queue and the sweep round-robins fairly however many rules are waiting.

The `$time` variable removed alongside it was already dead — assigned and never read.

## Test Plan

`tests/unit/Platform/Tasks/IntervalTest.php` drives the `domainVerification` task through a `Database` stub that captures the queries, and asserts:

- no query filters on `$createdAt` — this is the regression, and it fails on `main`
- `orderAsc('$updatedAt')` and `limit(100)` are still there, since they are what keeps the now-unbounded scan fair and bounded per tick

```
$ vendor/bin/phpunit tests/unit/Platform/Tasks/IntervalTest.php
OK, Tests: 2, Assertions: 8

$ composer lint src/Appwrite/Platform/Tasks/Interval.php tests/unit/Platform/Tasks/IntervalTest.php
{"tool":"pint","result":"passed"}
```

Verified against `main` by stashing the `Interval.php` change: `testDomainVerificationRetriesRulesOfAnyAge` fails, then passes with it.

## Related PRs and Issues

Part of the domain/SSL work alongside appwrite/appwrite#13467. The two fix different stages of the pipeline and neither depends on the other: this one is the DNS **verification** stage (`created` → `certificate-generating`), #13467 is the **issuance** stage after verification already succeeded. #13467 does not touch `verifyDomain()`.

**They do both edit `src/Appwrite/Platform/Tasks/Interval.php`, and whichever lands second needs a manual check.** This PR deletes `use DateTime;` and `use Utopia\Database\DateTime as DatabaseDateTime;` because `verifyDomain()` was their only consumer. #13467 adds `generateCertificate()`, which uses both. The deletions do not overlap any #13467 hunk, so git will merge them silently and `generateCertificate()` will hit an undefined-class fatal. Whoever merges second should restore the two imports.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? — no API metadata changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MeytoiisEusFMCU44PDYav