### PR TITLE
chore: bump utopia database to 7.3.5

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3636,16 +3636,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "7.3.4",
+            "version": "7.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "debef429479c86d8b5610a32e390651855131e7d"
+                "reference": "91472058cfee806958758bfa39d1da1758b0b410"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/debef429479c86d8b5610a32e390651855131e7d",
-                "reference": "debef429479c86d8b5610a32e390651855131e7d",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/91472058cfee806958758bfa39d1da1758b0b410",
+                "reference": "91472058cfee806958758bfa39d1da1758b0b410",
                 "shasum": ""
             },
             "require": {
@@ -3690,9 +3690,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/7.3.4"
+                "source": "https://github.com/utopia-php/database/tree/7.3.5"
             },
-            "time": "2026-09-01T06:40:07+00:00"
+            "time": "2026-09-08T11:44:29+00:00"
         },
         {
             "name": "utopia-php/detector",

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Operations/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Operations/Create.php
@@ -121,7 +121,7 @@ class Create extends Action
                 throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$operation['databaseId']]);
             }
 
-            $collection = $collections[$operation[$this->getGroupId()]] ??=
+            $collection = $collections[$database->getId()][$operation[$this->getGroupId()]] ??=
                 $authorization->skip(fn () => $dbForProject->getDocument('database_' . $database->getSequence(), $operation[$this->getGroupId()]));
 
             if ($collection->isEmpty() || (!$collection->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
@@ -273,21 +273,8 @@ class Create extends Action
             return;
         }
 
-        $chunksUploaded = $deviceForFunctions->upload(
-            $deviceForLocal->read($fileTmpName),
-            $path,
-            $metadata['content_type'] ?? '',
-            $chunk,
-            $chunks,
-            $metadata
-        );
-
-        if (empty($chunksUploaded)) {
-            throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed moving file');
-        }
-
         try {
-            $locks($lockKey, 600, function () use ($activate, &$chunks, $chunksUploaded, $commands, $dbForProject, $deploymentId, $deviceForFunctions, $entrypoint, $fileSize, &$function, $path, &$metadata, $mergeUploadMetadata, $deployments, $queueForEvents, $response, $type): void {
+            $locks($lockKey, 600, function () use ($activate, $chunk, &$chunks, $commands, $dbForProject, $deploymentId, $deviceForFunctions, $deviceForLocal, $entrypoint, $fileSize, $fileTmpName, &$function, $path, &$metadata, $mergeUploadMetadata, $deployments, $queueForEvents, $response, $type): void {
                 $deployment = $dbForProject->getDocument('deployments', $deploymentId);
                 $uploaded = 0;
 
@@ -311,6 +298,21 @@ class Create extends Action
                             ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
                         return;
                     }
+                }
+
+                // Keep chunk writes and assembly under the same lock so another
+                // request cannot count or assemble a partially written chunk.
+                $chunksUploaded = $deviceForFunctions->upload(
+                    $deviceForLocal->read($fileTmpName),
+                    $path,
+                    $metadata['content_type'] ?? '',
+                    $chunk,
+                    $chunks,
+                    $metadata
+                );
+
+                if (empty($chunksUploaded)) {
+                    throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed moving file');
                 }
 
                 $chunksUploaded = max($uploaded, $chunksUploaded, (int) ($metadata['chunks'] ?? 0));

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Templates/Email/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Templates/Email/Update.php
@@ -146,6 +146,10 @@ class Update extends Action
             ])));
         });
 
+        // A concurrent read can cache the old templates before the transaction
+        // commits. Invalidate again once the new templates are visible.
+        $dbForPlatform->purgeCachedDocument('projects', $project->getId());
+
         $template = $project->getAttribute('templates', [])[$templateKey] ?? [];
 
         $queueForEvents->setParam('templateId', $templateId);

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -319,17 +319,8 @@ class Create extends Action
             return;
         }
 
-        $chunksUploaded = $deviceForSites->upload(
-            $deviceForLocal->read($fileTmpName),
-            $path,
-            $metadata['content_type'] ?? '',
-            $chunk,
-            $chunks,
-            $metadata
-        );
-
         try {
-            $locks($lockKey, 600, function () use ($activate, $authorization, $bus, $commands, &$chunks, $chunksUploaded, $dbForPlatform, $dbForProject, $deploymentId, $deployments, $deviceForSites, $fileSize, &$metadata, $mergeUploadMetadata, $outputDirectory, $path, $platform, $project, $queueForEvents, $response, &$site, $type): void {
+            $locks($lockKey, 600, function () use ($activate, $authorization, $bus, $commands, $chunk, &$chunks, $dbForPlatform, $dbForProject, $deploymentId, $deployments, $deviceForLocal, $deviceForSites, $fileSize, $fileTmpName, &$metadata, $mergeUploadMetadata, $outputDirectory, $path, $platform, $project, $queueForEvents, $response, &$site, $type): void {
                 $deployment = $dbForProject->getDocument('deployments', $deploymentId);
                 $uploaded = 0;
 
@@ -355,8 +346,17 @@ class Create extends Action
                     }
                 }
 
-                // Another chunk request may have finalized the upload and removed
-                // its temporary parts before this request counted them.
+                // Keep chunk writes and assembly under the same lock so another
+                // request cannot count or assemble a partially written chunk.
+                $chunksUploaded = $deviceForSites->upload(
+                    $deviceForLocal->read($fileTmpName),
+                    $path,
+                    $metadata['content_type'] ?? '',
+                    $chunk,
+                    $chunks,
+                    $metadata
+                );
+
                 if (empty($chunksUploaded)) {
                     throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed moving file');
                 }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -328,10 +328,6 @@ class Create extends Action
             $metadata
         );
 
-        if (empty($chunksUploaded)) {
-            throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed moving file');
-        }
-
         try {
             $locks($lockKey, 600, function () use ($activate, $authorization, $bus, $commands, &$chunks, $chunksUploaded, $dbForPlatform, $dbForProject, $deploymentId, $deployments, $deviceForSites, $fileSize, &$metadata, $mergeUploadMetadata, $outputDirectory, $path, $platform, $project, $queueForEvents, $response, &$site, $type): void {
                 $deployment = $dbForProject->getDocument('deployments', $deploymentId);
@@ -357,6 +353,12 @@ class Create extends Action
                             ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
                         return;
                     }
+                }
+
+                // Another chunk request may have finalized the upload and removed
+                // its temporary parts before this request counted them.
+                if (empty($chunksUploaded)) {
+                    throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed moving file');
                 }
 
                 $chunksUploaded = max($uploaded, $chunksUploaded, (int) ($metadata['chunks'] ?? 0));

--- a/tests/e2e/Services/Project/TemplatesBase.php
+++ b/tests/e2e/Services/Project/TemplatesBase.php
@@ -771,17 +771,8 @@ trait TemplatesBase
             message: 'Body',
         )['headers']['status-code']);
 
-        $before = [];
-        $this->assertEventually(function () use ($firstSubject, &$before) {
-            $before = $this->listEmailTemplates();
-            $this->assertSame(200, $before['headers']['status-code']);
-            $matches = \array_values(\array_filter(
-                $before['body']['templates'],
-                fn ($template) => $template['templateId'] === 'mfaChallenge' && $template['locale'] === 'en',
-            ));
-            $this->assertCount(1, $matches);
-            $this->assertSame($firstSubject, $matches[0]['subject']);
-        });
+        $before = $this->listEmailTemplates();
+        $this->assertSame(200, $before['headers']['status-code']);
         $beforeTotal = $before['body']['total'];
 
         $this->assertSame(200, $this->updateEmailTemplate(
@@ -791,20 +782,18 @@ trait TemplatesBase
             message: 'Body',
         )['headers']['status-code']);
 
-        $this->assertEventually(function () use ($beforeTotal, $secondSubject) {
-            $after = $this->listEmailTemplates();
-            $this->assertSame(200, $after['headers']['status-code']);
+        $after = $this->listEmailTemplates();
+        $this->assertSame(200, $after['headers']['status-code']);
 
-            // Same templateId/locale must remain a single entry, not accumulate.
-            $this->assertSame($beforeTotal, $after['body']['total']);
+        // Same templateId/locale must remain a single entry, not accumulate.
+        $this->assertSame($beforeTotal, $after['body']['total']);
 
-            $matches = \array_values(\array_filter(
-                $after['body']['templates'],
-                fn ($t) => $t['templateId'] === 'mfaChallenge' && $t['locale'] === 'en',
-            ));
-            $this->assertCount(1, $matches);
-            $this->assertSame($secondSubject, $matches[0]['subject']);
-        });
+        $matches = \array_values(\array_filter(
+            $after['body']['templates'],
+            fn ($t) => $t['templateId'] === 'mfaChallenge' && $t['locale'] === 'en',
+        ));
+        $this->assertCount(1, $matches);
+        $this->assertSame($secondSubject, $matches[0]['subject']);
     }
 
     public function testListEmailTemplatesTotalFalse(): void

--- a/tests/e2e/Services/Project/TemplatesBase.php
+++ b/tests/e2e/Services/Project/TemplatesBase.php
@@ -771,8 +771,17 @@ trait TemplatesBase
             message: 'Body',
         )['headers']['status-code']);
 
-        $before = $this->listEmailTemplates();
-        $this->assertSame(200, $before['headers']['status-code']);
+        $before = [];
+        $this->assertEventually(function () use ($firstSubject, &$before) {
+            $before = $this->listEmailTemplates();
+            $this->assertSame(200, $before['headers']['status-code']);
+            $matches = \array_values(\array_filter(
+                $before['body']['templates'],
+                fn ($template) => $template['templateId'] === 'mfaChallenge' && $template['locale'] === 'en',
+            ));
+            $this->assertCount(1, $matches);
+            $this->assertSame($firstSubject, $matches[0]['subject']);
+        });
         $beforeTotal = $before['body']['total'];
 
         $this->assertSame(200, $this->updateEmailTemplate(
@@ -782,18 +791,20 @@ trait TemplatesBase
             message: 'Body',
         )['headers']['status-code']);
 
-        $after = $this->listEmailTemplates();
-        $this->assertSame(200, $after['headers']['status-code']);
+        $this->assertEventually(function () use ($beforeTotal, $secondSubject) {
+            $after = $this->listEmailTemplates();
+            $this->assertSame(200, $after['headers']['status-code']);
 
-        // Same templateId/locale must remain a single entry, not accumulate.
-        $this->assertSame($beforeTotal, $after['body']['total']);
+            // Same templateId/locale must remain a single entry, not accumulate.
+            $this->assertSame($beforeTotal, $after['body']['total']);
 
-        $matches = \array_values(\array_filter(
-            $after['body']['templates'],
-            fn ($t) => $t['templateId'] === 'mfaChallenge' && $t['locale'] === 'en',
-        ));
-        $this->assertCount(1, $matches);
-        $this->assertSame($secondSubject, $matches[0]['subject']);
+            $matches = \array_values(\array_filter(
+                $after['body']['templates'],
+                fn ($t) => $t['templateId'] === 'mfaChallenge' && $t['locale'] === 'en',
+            ));
+            $this->assertCount(1, $matches);
+            $this->assertSame($secondSubject, $matches[0]['subject']);
+        });
     }
 
     public function testListEmailTemplatesTotalFalse(): void

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -77,8 +77,10 @@ final class SitesCustomServerTest extends Scope
             $proxyClient = new Client();
             $proxyClient->setEndpoint('http://' . $this->getSiteDomain($siteId));
 
-            $response = $proxyClient->call(Client::METHOD_GET, '/logs-inline');
-            $this->assertEquals(200, $response['headers']['status-code']);
+            $this->assertEventually(function () use ($proxyClient) {
+                $response = $proxyClient->call(Client::METHOD_GET, '/logs-inline');
+                $this->assertEquals(200, $response['headers']['status-code']);
+            });
 
             $log = $this->waitForSiteLog($siteId, '/logs-inline');
             $this->assertEquals($deploymentId, $log['deploymentId']);

--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -1218,27 +1218,29 @@ trait StorageBase
         $this->assertEquals(201, $file['headers']['status-code']);
         $this->assertNotEmpty($file['body']['$id']);
 
-        //get image preview after
-        $file3 = $this->client->call(Client::METHOD_GET, '/storage/buckets/' . $bucketId . '/files/' . $fileId . '/preview', array_merge([
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $this->getProject()['$id'],
-        ], $this->getHeaders()), [
-            'width' => 300,
-            'height' => 100,
-            'borderRadius' => '50',
-            'opacity' => '0.5',
-            'output' => 'png',
-            'rotation' => '45',
-        ]);
+        // The delete worker invalidates previews asynchronously.
+        $this->assertEventually(function () use ($bucketId, $fileId, $imageBefore) {
+            $file3 = $this->client->call(Client::METHOD_GET, '/storage/buckets/' . $bucketId . '/files/' . $fileId . '/preview', array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'width' => 300,
+                'height' => 100,
+                'borderRadius' => '50',
+                'opacity' => '0.5',
+                'output' => 'png',
+                'rotation' => '45',
+            ]);
 
-        $this->assertEquals(200, $file3['headers']['status-code']);
-        $this->assertEquals('image/png', $file3['headers']['content-type']);
-        $this->assertNotEmpty($file3['body']);
+            $this->assertEquals(200, $file3['headers']['status-code']);
+            $this->assertEquals('image/png', $file3['headers']['content-type']);
+            $this->assertNotEmpty($file3['body']);
 
-        $imageAfter = new \Imagick();
-        $imageAfter->readImageBlob($file3['body']);
+            $imageAfter = new \Imagick();
+            $imageAfter->readImageBlob($file3['body']);
 
-        $this->assertNotSame($imageBefore->getImageBlob(), $imageAfter->getImageBlob());
+            $this->assertNotSame($imageBefore->getImageBlob(), $imageAfter->getImageBlob());
+        }, 10_000, 500);
     }
 
     public function testFilePreviewCacheControlOnCacheHit(): void


### PR DESCRIPTION
## What does this PR do?

Bumps the locked `utopia-php/database` dependency from `7.3.4` to `7.3.5`, which reduces document copying and allocations during database validation and conversion. The existing `^7.0.0` constraint already permits this patch.

Also fixes failures exposed by the full CI matrix:

- Scope staged transaction collections by database as well as collection ID. A transaction spanning two databases with the same public collection ID previously reused the first database's collection metadata and failed on MongoDB.
- Keep function and site deployment chunk writes and assembly under the same upload lock. Previously a concurrent request could count or assemble partially written chunks, corrupting the archive, or count zero parts after another request finalized the upload.
- Invalidate the project cache after committing template updates, so a concurrent reader cannot leave a pre-commit value cached. Keep the template tests' immediate read-after-write assertions.
- Wait for the SSR route to become available before checking its execution logs, and for the delete worker to invalidate an old preview before comparing replacement file content.

## Test Plan

- [Full CI passed](https://github.com/appwrite/appwrite/actions/runs/34232968716) on `88fe31fb3a`: build, unit tests, lint, Rector, PHPStan, E2E matrix, and benchmark.
- All six Project adapter suites pass with immediate template read-after-write assertions. Both MongoDB Usage suites and all Functions/Sites adapter suites pass.
- Existing E2E tests cover cross-database collection IDs, parallel chunk uploads, template overwrites, and replacement file previews.
- Targeted Pint, PHPStan, Composer validation, and `git diff --check` pass. Composer reports existing version-constraint warnings; lockfile generation used `--ignore-platform-reqs` on the host, with runtime compatibility validated by CI.
- CI required retries for an antivirus stream failure, an unhealthy MongoDB startup, account setup and realtime event failures, and a transient site-route 404. Two stalled jobs were cancelled and restarted on fresh runners; all final results are green.
- [Latest benchmark](https://github.com/appwrite/appwrite/pull/13540#issuecomment-5584714110), 20 virtual users for one minute per version:

  | Metric | Before | After | Change |
  | --- | ---: | ---: | ---: |
  | Requests/sec | 170.15 | 172.11 | +1.2% |
  | Latency P50 | 100.29 ms | 99.21 ms | -1.1% |
  | Latency P95 | 244.72 ms | 240.41 ms | -1.8% |

  These modest changes fall within the benchmark's ±5% neutral band; one run does not establish a statistically significant improvement.

## Related PRs and Issues

- https://github.com/utopia-php/database/pull/958

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- API metadata is unchanged; no specs or example updates are needed.

