### PR TITLE
fix(teams): accept null optional membership fields

### DIFF
--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
@@ -101,8 +101,14 @@ class Create extends Action
             ->callback($this->action(...));
     }
 
-    public function action(string $teamId, string $email, string $userId, string $phone, array $roles, string $url, string $name, Response $response, Document $project, User $user, Database $dbForProject, Authorization $authorization, Locale $locale, MailPublisher $publisherForMails, MessagingPublisher $publisherForMessaging, Event $queueForEvents, callable $timelimit, Context $usage, array $plan, array $platform, Password $proofForPassword, Token $proofForToken)
+    public function action(string $teamId, ?string $email, ?string $userId, ?string $phone, array $roles, ?string $url, ?string $name, Response $response, Document $project, User $user, Database $dbForProject, Authorization $authorization, Locale $locale, MailPublisher $publisherForMails, MessagingPublisher $publisherForMessaging, Event $queueForEvents, callable $timelimit, Context $usage, array $plan, array $platform, Password $proofForPassword, Token $proofForToken)
     {
+        $email ??= '';
+        $userId ??= '';
+        $phone ??= '';
+        $url ??= '';
+        $name ??= '';
+
         $isAppUser = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
         $invitee = new Document();

--- a/tests/e2e/Services/Teams/TeamsCustomServerTest.php
+++ b/tests/e2e/Services/Teams/TeamsCustomServerTest.php
@@ -18,6 +18,87 @@ final class TeamsCustomServerTest extends Scope
     use ProjectCustom;
     use SideServer;
 
+    public function testCreateMembershipWithNullOptionals(): void
+    {
+        $headers = array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders());
+        $teamId = ID::unique();
+        $team = $this->client->call(Client::METHOD_POST, '/teams', $headers, [
+            'teamId' => $teamId,
+            'name' => 'Nullable membership fields',
+        ]);
+        $this->assertEquals(201, $team['headers']['status-code']);
+
+        try {
+            // Test for SUCCESS: explicit nulls behave like omitted optional fields.
+            $email = ID::unique() . '@localhost.test';
+            $membership = $this->client->call(Client::METHOD_POST, '/teams/' . $teamId . '/memberships', $headers, [
+                'email' => $email,
+                'phone' => null,
+                'url' => null,
+                'name' => null,
+                'roles' => ['editor'],
+            ]);
+            $this->assertEquals(201, $membership['headers']['status-code']);
+            $this->assertEquals($email, $membership['body']['userEmail']);
+            $this->assertEquals($email, $membership['body']['userName']);
+            $this->assertTrue($membership['body']['confirm']);
+
+            $userId = $membership['body']['userId'];
+            $membershipId = $membership['body']['$id'];
+            $stored = $this->client->call(Client::METHOD_GET, '/teams/' . $teamId . '/memberships/' . $membershipId, $headers);
+            $this->assertEquals(200, $stored['headers']['status-code']);
+            $this->assertEquals($userId, $stored['body']['userId']);
+            $this->assertEquals(['editor'], $stored['body']['roles']);
+
+            $deleted = $this->client->call(Client::METHOD_DELETE, '/teams/' . $teamId . '/memberships/' . $membershipId, $headers);
+            $this->assertEquals(204, $deleted['headers']['status-code']);
+
+            $membership = $this->client->call(Client::METHOD_POST, '/teams/' . $teamId . '/memberships', $headers, [
+                'userId' => $userId,
+                'email' => null,
+                'phone' => null,
+                'url' => null,
+                'name' => null,
+                'roles' => ['reader'],
+            ]);
+            $this->assertEquals(201, $membership['headers']['status-code']);
+            $this->assertEquals($userId, $membership['body']['userId']);
+            $this->assertEquals($email, $membership['body']['userEmail']);
+
+            // Test for FAILURE: nulls do not bypass the required identity check.
+            $invalid = $this->client->call(Client::METHOD_POST, '/teams/' . $teamId . '/memberships', $headers, [
+                'userId' => null,
+                'email' => null,
+                'phone' => null,
+                'roles' => [],
+            ]);
+            $this->assertEquals(400, $invalid['headers']['status-code']);
+            $this->assertEquals('general_argument_invalid', $invalid['body']['type']);
+
+            $invalid = $this->client->call(Client::METHOD_POST, '/teams/' . $teamId . '/memberships', $headers, [
+                'email' => $email,
+                'phone' => 'not-a-phone-number',
+                'roles' => [],
+            ]);
+            $this->assertEquals(400, $invalid['headers']['status-code']);
+            $this->assertEquals('general_argument_invalid', $invalid['body']['type']);
+
+            $memberships = $this->client->call(Client::METHOD_GET, '/teams/' . $teamId . '/memberships', $headers);
+            $this->assertEquals(200, $memberships['headers']['status-code']);
+            $this->assertEquals(1, $memberships['body']['total']);
+            $this->assertEquals($userId, $memberships['body']['memberships'][0]['userId']);
+            $this->assertEquals(['reader'], $memberships['body']['memberships'][0]['roles']);
+        } finally {
+            $this->client->call(Client::METHOD_DELETE, '/teams/' . $teamId, $headers);
+            if (isset($userId)) {
+                $this->client->call(Client::METHOD_DELETE, '/users/' . $userId, $headers);
+            }
+        }
+    }
+
     public function testMembershipDeletedWhenTeamDeleted(): array
     {
         /* 1. Create Team */

--- a/tests/e2e/Services/Teams/TeamsCustomServerTest.php
+++ b/tests/e2e/Services/Teams/TeamsCustomServerTest.php
@@ -42,11 +42,12 @@ final class TeamsCustomServerTest extends Scope
                 'roles' => ['editor'],
             ]);
             $this->assertEquals(201, $membership['headers']['status-code']);
+            $userId = $membership['body']['userId'];
+
             $this->assertEquals($email, $membership['body']['userEmail']);
             $this->assertEquals($email, $membership['body']['userName']);
             $this->assertTrue($membership['body']['confirm']);
 
-            $userId = $membership['body']['userId'];
             $membershipId = $membership['body']['$id'];
             $stored = $this->client->call(Client::METHOD_GET, '/teams/' . $teamId . '/memberships/' . $membershipId, $headers);
             $this->assertEquals(200, $stored['headers']['status-code']);


### PR DESCRIPTION
## What does this PR do?

Fixes team membership creation returning HTTP 500 when an optional string is explicitly `null` in a JSON request. Utopia HTTP accepts null for optional parameters, but the action required non-null strings.

Accept nullable `email`, `userId`, `phone`, `url`, and `name`, then normalize them to their existing empty-string defaults. Identity requirements, URL requirements for client invitations, and non-null input validation remain unchanged. This belongs in CE because Cloud uses this handler from `appwrite/server-ce`.

## Test Plan

Tested through the real local CE HTTP API with PostgreSQL and Redis, using PHP 8.5.10 / PHPUnit 12.5.34. No mocks of the handler or database and no unit tests added.

- New E2E flow creates a member by email with null phone/name/URL, reads back persisted membership and roles, deletes and re-adds the existing user with null email, and verifies missing identities and malformed phone numbers return 400 without changing membership count or roles.
- **Red/green observed:** on the original handler the regression fails with HTTP 500 instead of 201; with this patch it passes (**1 test, 30 assertions**).

Commands run inside the local API container:

```sh
php vendor/bin/phpunit tests/e2e/Services/Teams/TeamsCustomServerTest.php --filter testCreateMembershipWithNullOptionals
# PASS: 1 test, 30 assertions

php vendor/bin/phpunit tests/e2e/Services/Teams/TeamsCustomServerTest.php --filter '/::test(?!DeleteUserUpdatesTeamMembershipCount)/'
# PASS: 12 tests, 225 assertions

php vendor/bin/pint --test src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php tests/e2e/Services/Teams/TeamsCustomServerTest.php
# PASS: 2 files

git diff --check
# PASS
```

**Full-suite limitation:** the unfiltered `TeamsCustomServerTest.php` run passed 12 of 13 tests. `testDeleteUserUpdatesTeamMembershipCount` timed out waiting for the async deletes worker to reduce the team count from 1 to 0. Re-ran that test with the original handler restored and reproduced the same failure. It is not counted as passing. Client invitation/email delivery flows were not run. This is a backend-only change; screenshots are not applicable.

## Related PRs and Issues

- [CLOUD-3QSB](https://appwrite.sentry.io/issues/CLOUD-3QSB)

## Checklist

- [x] Read the contributing guidelines.
- [x] No API metadata changes; specs and example docs are unchanged.
