### PR TITLE
chore: bump orchestrator to 2.1.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1687,7 +1687,7 @@ services:
     # One image carrying every orchestrator control plane. Appwrite drives the
     # jobs plane today; the per-plane images exist for Kubernetes, where each
     # scales, fails and gets RBAC on its own.
-    image: ghcr.io/open-runtimes/orchestrator/orchestrator:2.1.0
+    image: ghcr.io/open-runtimes/orchestrator/orchestrator:2.1.1
     restart: unless-stopped
     user: root
     networks:


### PR DESCRIPTION
Adopt orchestrator 2.1.1 to fix missing build logs for fast-failing Kubernetes jobs. The release drains worker logs before emitting exit and retries failed initial log connections. Upstream fix: https://github.com/open-runtimes/orchestrator/pull/106.

Updates the combined orchestrator Compose image from 2.1.0 to 2.1.1.

Validation: Docker Compose config and diff whitespace checks passed. Published image tag verified.

No live deployment or build drill was performed as part of this version bump.
