### PR TITLE
feat(specs): replace optional security extension with alternatives

### DIFF
--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -188,27 +188,18 @@ class Specs extends Action
                     'name' => 'X-Appwrite-Impersonate-User-Id',
                     'description' => 'Impersonate a user by ID',
                     'in' => 'header',
-                    'x-appwrite' => [
-                        'optional' => true,
-                    ],
                 ],
                 'ImpersonateUserEmail' => [
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-Impersonate-User-Email',
                     'description' => 'Impersonate a user by email',
                     'in' => 'header',
-                    'x-appwrite' => [
-                        'optional' => true,
-                    ],
                 ],
                 'ImpersonateUserPhone' => [
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-Impersonate-User-Phone',
                     'description' => 'Impersonate a user by phone',
                     'in' => 'header',
-                    'x-appwrite' => [
-                        'optional' => true,
-                    ],
                 ],
             ],
             APP_SDK_PLATFORM_SERVER => [
@@ -287,27 +278,18 @@ class Specs extends Action
                     'name' => 'X-Appwrite-Impersonate-User-Id',
                     'description' => 'Impersonate a user by ID',
                     'in' => 'header',
-                    'x-appwrite' => [
-                        'optional' => true,
-                    ],
                 ],
                 'ImpersonateUserEmail' => [
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-Impersonate-User-Email',
                     'description' => 'Impersonate a user by email',
                     'in' => 'header',
-                    'x-appwrite' => [
-                        'optional' => true,
-                    ],
                 ],
                 'ImpersonateUserPhone' => [
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-Impersonate-User-Phone',
                     'description' => 'Impersonate a user by phone',
                     'in' => 'header',
-                    'x-appwrite' => [
-                        'optional' => true,
-                    ],
                 ],
             ],
             APP_SDK_PLATFORM_CONSOLE => [
@@ -386,27 +368,18 @@ class Specs extends Action
                     'name' => 'X-Appwrite-Impersonate-User-Id',
                     'description' => 'Impersonate a user by ID',
                     'in' => 'header',
-                    'x-appwrite' => [
-                        'optional' => true,
-                    ],
                 ],
                 'ImpersonateUserEmail' => [
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-Impersonate-User-Email',
                     'description' => 'Impersonate a user by email',
                     'in' => 'header',
-                    'x-appwrite' => [
-                        'optional' => true,
-                    ],
                 ],
                 'ImpersonateUserPhone' => [
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-Impersonate-User-Phone',
                     'description' => 'Impersonate a user by phone',
                     'in' => 'header',
-                    'x-appwrite' => [
-                        'optional' => true,
-                    ],
                 ],
             ],
         ];

--- a/src/Appwrite/SDK/Method.php
+++ b/src/Appwrite/SDK/Method.php
@@ -35,7 +35,7 @@ class Method
      * @param array $additionalParameters
      * @param string $desc
      * @param bool $public Whether this method should be rendered on the website/documentation
-     * @param array<string> $locationAuth Security scheme keys injected for location-type methods (includes project auth)
+     * @param array<string> $locationAuth Security scheme keys for location-type methods: first is the required project binding; additional keys supplement the base auth as an optional alternative
      */
     public function __construct(
         protected string $namespace,

--- a/src/Appwrite/SDK/Specification/Format.php
+++ b/src/Appwrite/SDK/Specification/Format.php
@@ -469,12 +469,36 @@ abstract class Format
 
     protected function shouldEmitDefaultForSchema(mixed $default, array $schema): bool
     {
-        if (isset($schema['enum'])) {
-            return \in_array($default, $schema['enum'], true);
+        if (isset($schema['enum']) && !\in_array($default, $schema['enum'], true)) {
+            return false;
         }
 
-        if (\is_array($schema['items'] ?? null) && isset($schema['items']['enum'])) {
-            return \is_array($default) && empty(\array_diff($default, $schema['items']['enum']));
+        // Named enums use titled oneOf branches; open enums additionally
+        // accept a free-string branch through anyOf.
+        foreach (['oneOf', 'anyOf'] as $composition) {
+            if (!isset($schema[$composition])) {
+                continue;
+            }
+            $matches = 0;
+            foreach ($schema[$composition] as $branch) {
+                if ($this->shouldEmitDefaultForSchema($default, $branch)) {
+                    $matches++;
+                }
+            }
+            if ($composition === 'oneOf' ? $matches !== 1 : $matches === 0) {
+                return false;
+            }
+        }
+
+        if (\is_array($schema['items'] ?? null)) {
+            if (!\is_array($default)) {
+                return false;
+            }
+            foreach ($default as $item) {
+                if (!$this->shouldEmitDefaultForSchema($item, $schema['items'])) {
+                    return false;
+                }
+            }
         }
 
         return true;

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -560,11 +560,17 @@ class OpenAPI3 extends Format
                     : [];
                 $temp['x-appwrite']['auth'] = $this->getExampleAuth($securities, $locationKeys, $sdkPlatforms);
 
-                foreach ($locationKeys as $key) {
-                    $securities[$key] = [];
-                }
-
                 $temp['security'][] = $securities;
+                // Location credentials supplement the base authentication. The
+                // first location key (project binding) is already required;
+                // impersonation can be supplied without making it mandatory.
+                $withLocationAuth = $securities;
+                foreach ($locationKeys as $key) {
+                    $withLocationAuth[$key] = [];
+                }
+                if ($withLocationAuth !== $securities) {
+                    $temp['security'][] = $withLocationAuth;
+                }
             }
 
             $parameterNodes = [];

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -233,6 +233,51 @@ final class FormatTest extends TestCase
         $this->assertArrayNotHasKey('x-enum-keys', $kind);
     }
 
+    #[DataProvider('defaultLocations')]
+    public function testAnnotatedEnumDefaultsMatchAllowedValues(string $method): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route($method, '/v1/tests'))
+            ->desc('Get test')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'getTest',
+                description: 'Get test.',
+                auth: [AuthType::ADMIN],
+                responses: [],
+            ))
+            ->param('timezone', '', new WhiteList(['utc', 'europe/london']), 'Timezone.', optional: true, enum: new Enum(name: 'TestTimezone'))
+            ->param('validZone', 'utc', new WhiteList(['utc', 'europe/london']), 'Valid timezone.', optional: true, enum: new Enum(name: 'TestValidTimezone'))
+            ->param('zones', ['invalid'], new ArrayList(new WhiteList(['utc', 'europe/london'])), 'Timezones.', optional: true, enum: new Enum(name: 'TestZones'))
+            ->param('validZones', ['utc'], new ArrayList(new WhiteList(['utc', 'europe/london'])), 'Valid timezones.', optional: true, enum: new Enum(name: 'TestValidZones'))
+            ->param('emptyZones', [], new ArrayList(new WhiteList(['utc'])), 'Empty timezones.', optional: true, enum: new Enum(name: 'TestEmptyZones'))
+            ->param('openZone', 'custom', new AnyOf([new WhiteList(['utc']), new Text(64)]), 'Open timezone.', optional: true, enum: new Enum(name: 'TestOpenZone'))
+            ->param('openZones', ['custom'], new AnyOf([new ArrayList(new WhiteList(['utc'])), new ArrayList(new Text(64))]), 'Open timezones.', optional: true, enum: new Enum(name: 'TestOpenZones'));
+
+        $spec = (new OpenAPI3(new Container(), [], [$route], [], [], ['console' => 0], 'console'))->parse();
+        $operation = $spec['paths']['/tests'][strtolower($method)];
+        if ($method === 'GET') {
+            $schemas = array_column($operation['parameters'], 'schema', 'name');
+        } else {
+            $schemas = $operation['requestBody']['content']['application/json']['schema']['properties'];
+        }
+
+        $this->assertArrayHasKey('oneOf', $schemas['timezone']);
+        $this->assertArrayNotHasKey('default', $schemas['timezone']);
+        $this->assertSame(['utc', 'europe/london'], array_column(array_column($schemas['timezone']['oneOf'], 'enum'), 0));
+        $this->assertSame('utc', $schemas['validZone']['default']);
+        $this->assertArrayNotHasKey('default', $schemas['zones']);
+        $this->assertSame(['utc'], $schemas['validZones']['default']);
+        $this->assertSame([], $schemas['emptyZones']['default']);
+        $this->assertArrayHasKey('anyOf', $schemas['openZone']);
+        $this->assertSame('custom', $schemas['openZone']['default']);
+        $this->assertArrayHasKey('anyOf', $schemas['openZones']['items']);
+        $this->assertSame(['custom'], $schemas['openZones']['default']);
+    }
+
     public function testEnumNameMustNotOverlapServiceName(): void
     {
         Method::$processed = [];

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\SDK\Specification;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
+use Appwrite\SDK\MethodType;
 use Appwrite\SDK\Parameter;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\SDK\Specification\Format;
@@ -1304,16 +1305,63 @@ final class FormatTest extends TestCase
             'server' => ['Project' => [], 'Session' => []],
             'console' => ['Project' => []],
         ], $operation['x-appwrite']['auth']);
-        $this->assertSame(['Project' => [], 'Session' => [], 'Key' => []], $operation['security'][0]);
+        $this->assertSame([['Project' => [], 'Session' => [], 'Key' => []]], $operation['security']);
 
         $this->assertSame(['Project' => [], 'Session' => []], $server['paths']['/account']['get']['x-appwrite']['auth']);
-        $this->assertSame(['Project' => [], 'Session' => [], 'Key' => []], $server['paths']['/account']['get']['security'][0]);
+        $this->assertSame([['Project' => [], 'Session' => [], 'Key' => []]], $server['paths']['/account']['get']['security']);
 
         $this->assertSame(['Project', 'Session', 'Key'], \array_keys($canonical['components']['securitySchemes']));
         $this->assertSame(['client', 'server', 'console'], $canonical['components']['securitySchemes']['Project']['x-appwrite']['platforms']);
         $this->assertSame(['server'], $canonical['components']['securitySchemes']['Key']['x-appwrite']['platforms']);
         $this->assertSame(['Project', 'Key', 'Session'], \array_keys($server['components']['securitySchemes']));
         $this->assertSame(['server'], $server['components']['securitySchemes']['Key']['x-appwrite']['platforms']);
+    }
+
+    public function testLocationAuthUsesSecurityAlternatives(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route('GET', '/v1/avatars/browser'))
+            ->desc('Get browser')
+            ->label('scope', 'public')
+            ->label('sdk', new Method(
+                namespace: 'avatars',
+                group: null,
+                name: 'getBrowser',
+                description: 'Get browser.',
+                auth: [AuthType::SESSION, AuthType::KEY, AuthType::ADMIN],
+                responses: [],
+                type: MethodType::LOCATION,
+                locationAuth: ['Project', 'ImpersonateUserId'],
+            ));
+
+        $keys = $this->platformKeys();
+        foreach ($keys as &$schemes) {
+            $schemes['ImpersonateUserId'] = [
+                'type' => 'apiKey',
+                'name' => 'X-Appwrite-Impersonate-User-Id',
+                'in' => 'header',
+            ];
+        }
+        unset($schemes);
+        $authCounts = ['client' => 1, 'server' => 2, 'console' => 1];
+
+        foreach ([null, 'client', 'server', 'console'] as $platform) {
+            $spec = (new OpenAPI3(new Container(), [], [$route], [], $keys, $authCounts, $platform))->parse();
+            $operation = $spec['paths']['/avatars/browser']['get'];
+            $required = ['Project' => []];
+            if ($platform !== 'console') {
+                $required['Session'] = [];
+            }
+            if ($platform === null || $platform === 'server') {
+                $required['Key'] = [];
+            }
+            $this->assertSame([$required, [...$required, 'ImpersonateUserId' => []]], $operation['security']);
+            $auth = $platform === null ? $operation['x-appwrite']['auth']['server'] : $operation['x-appwrite']['auth'];
+            $this->assertArrayHasKey('ImpersonateUserId', $auth);
+            $this->assertArrayNotHasKey('optional', $spec['components']['securitySchemes']['ImpersonateUserId']['x-appwrite']);
+        }
     }
 
     public function testCanonicalDocumentListsEveryAliasVariant(): void


### PR DESCRIPTION
## Owner-approved scope deferral

The owner approved deferring the remaining pre-existing schema issues and continuing this migration. Strict full-document validation still fails on the documented custom-array schemas; that failure is **deferred, not fixed or passing**. No additional schema-cleanup work is included in this rollout.

Proceed with the optional-security migration's review/CI and coordinated producer → Cloud/specs → generator release steps. Keep the temporary producer dependency pin and SDK compatibility/release sequencing explicit; this deferral is not approval to disable checks or merge unrelated fixes.

---

## Latest verification — includes enum-default fix #13545 (now merged)

Cloud head `12abbfeab6fd35ddccb669cd43cf8d55eb407068` locks producer integration commit `e36198300f0efe854d442526253ae2b7eab2c2fb`, which includes #13545's code.

- Both non-publishing workflows passed: [2.0.x](https://github.com/appwrite-labs/cloud/actions/runs/34260375332), [latest](https://github.com/appwrite-labs/cloud/actions/runs/34260378191).
- Artifacts are byte-identical: SHA256 `eb9761f869119e57c2f01e3eca3ec12e5bcda9e87ec5bfc8f6750bc4190d1001`.
- Comparison against the preceding object-default-fixed artifacts shows exactly **15 invalid enum defaults removed**, and no other parsed differences. Includes timezone, screenshot output, runtime/adapter, locale, encryption, password version, and region defaults.
- Producer formatter suite passed: **41 tests, 244 assertions**, plus targeted Pint.
- **Strict validation still fails** on both artifacts: `[] is not of type 'string'`. The same failure category exists in the published document.
- A recursive schema scan finds 10 string schemas with empty-array defaults: OAuth2 `resource` on authorize GET/POST, device authorization, PAR, and token; WAF `conditions` on bypass, challenge, deny, rate-limit, and redirect creation. Their source validators declare arrays (`Multiple(..., TYPE_ARRAY)` and WAF `Conditions`), but the producer's fallback maps them to string. Removing defaults alone would hide the underlying type mismatch.

No PRs merged by this verification, no spec publication or deployment. The release gate remains blocked on these custom-array schema mappings and the previously listed SDK compatibility checks. Earlier sections below are historical evidence.

---

## Latest verification — includes merged #13544

Producer #13543 now includes main through `f66db6e969` (merged object-default fix); head `e4d63346abff7a70f04c820862b2d285e66b2595`. Cloud #5716 locks that producer commit at Cloud head `6f68bc428`.

- Producer formatter tests: **39 tests, 222 assertions**, passing; targeted Pint passes.
- Cloud `composer validate --no-check-publish` passes; only the server-ce lock reference changed.
- Non-publishing specs workflows passed: [2.0.x](https://github.com/appwrite-labs/cloud/actions/runs/34259378879), [latest](https://github.com/appwrite-labs/cloud/actions/runs/34259381747).
- Both artifacts are byte-identical: SHA256 `a5fad5d320ab9592181451b7c479f5d85f603f6d895a829f353374fea81694bb`.
- Compared with the previous genuine candidate artifacts, exactly **16 defaults changed from `[]` to `{}`**, with no other parsed differences. The optional-security migration is unchanged.
- Strict `openapi-spec-validator` now gets past the empty-object-default failure but fails on screenshot `timezone`: `GET /avatars/screenshots`, parameter index 9, has `default: ""` outside its titled `oneOf` timezone enum. This field is unchanged from the previous artifact. **Full spec validation remains blocked**, not passing.
- No specs were published or deployments performed. Historical verification below refers to earlier commits/artifacts; SDK output parity has not been rerun after the object-default fix.

---

## Summary

Part of [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards): replace security-scheme `x-appwrite.optional` with standard security alternatives.

- Emit the existing base authentication requirement, followed by an alternative that includes supplemental location credentials (currently ImpersonateUserId).
- Preserve the existing AND grouping of base credentials, project binding, platform availability, and `x-appwrite.auth` example configuration.
- Remove `optional` from the three impersonation scheme definitions on all platforms. Keep the definitions; do not introduce operation references for Email/Phone.
- Document the location-auth metadata contract and cover canonical/client/server/console output.

The current producer emits OpenAPI 3 only; there is no Swagger 2 emitter here to update.

## Coordination / rollout

Companion generator PR: [appwrite/sdk-generator#1891](https://github.com/appwrite/sdk-generator/pull/1891).

The generator uses the standard-security methods released in [utopia-php/openapi#11](https://github.com/utopia-php/openapi/pull/11), version 0.2.2. API security remains separate from platform-specific SDK example configuration.

Keep this draft until genuine Cloud generation and structural/output baseline comparisons are complete. Promote the producer and publish canonical `2.0.x`/`latest` before releasing the generator that removes legacy handling. Also verify the deployed generator against the replacement specs before publication. No specs publishing, Cloud promotion, or releases were performed.

## Verification

- `vendor/bin/phpunit tests/unit/SDK/Specification/FormatTest.php` — passed: 37 tests, 204 assertions.
- `vendor/bin/pint --test src/Appwrite/Platform/Tasks/Specs.php src/Appwrite/SDK/Method.php src/Appwrite/SDK/Specification/Format/OpenAPI3.php tests/unit/SDK/Specification/FormatTest.php` — passed.
- `git diff --check` — passed.

Tests exercise the producer formatter with real route/SDK metadata, including optional location auth on all platforms and unchanged single-alternative non-location auth. The companion generator's PHP mock-API e2e passes, but that is not Appwrite authentication runtime verification.

### Cloud workflow verification

[Cloud #5716](https://github.com/appwrite-labs/cloud/pull/5716) pins this producer branch. Non-publishing specs runs passed for [2.0.x](https://github.com/appwrite-labs/cloud/actions/runs/34257058117) and [latest](https://github.com/appwrite-labs/cloud/actions/runs/34257061099). A [controlled parent-commit run](https://github.com/appwrite-labs/cloud/actions/runs/34257451096) isolates the migration from current-main drift.

Against that genuine baseline, the only parsed differences are the 3 scheme `optional` removals and 16 security-array replacements (including Cloud invoice download/view). Both versions produce identical bytes, SHA256 `5454c86362e1ee39d0eaa0d1f1282d965b334041824bc047336fe262a6c27740`; 1,022 operations, 77 aliases, 16 schemes. PHP client/server/console full generated trees match old-generator/old-spec versus new-generator/new-spec.

Remaining: strict OpenAPI validation fails on an object schema with `default: []`, identically in the published spec. Current generation also has independent OAuth/DNS changes versus the published 1,020-operation spec; those require publication review. Cross-language parity, deployed-generator compatibility, Appwrite impersonation runtime e2e, and full-project static analysis remain incomplete. No screenshots apply to these nonvisual changes.
