### PR TITLE
fix(specs): serialize empty object defaults as objects

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -975,7 +975,11 @@ class OpenAPI3 extends Format
                 }
 
                 if ($parameter['emitDefault'] && $this->shouldEmitDefaultForSchema($param['default'], $node['schema'])) { // Param has default value
-                    $node['schema']['default'] = $param['default'];
+                    // PHP uses [] for empty maps too; preserve the declared
+                    // object type when serializing its default to JSON.
+                    $node['schema']['default'] = $node['schema']['type'] === 'object' && $param['default'] === []
+                        ? new \stdClass()
+                        : $param['default'];
                 }
 
                 $pathAliases = [$name, ...($param['aliases'] ?? [])];

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -356,9 +356,10 @@ final class FormatTest extends TestCase
         $this->assertSame('["one","two"]', $properties['text']['example']);
     }
 
-    public static function defaultLocations(): array
+    public static function defaultLocations(): \Iterator
     {
-        return [['GET'], ['POST']];
+        yield ['GET'];
+        yield ['POST'];
     }
 
     #[DataProvider('defaultLocations')]
@@ -398,7 +399,6 @@ final class FormatTest extends TestCase
 
         foreach (['headers', 'data'] as $name) {
             $this->assertSame('object', $schemas[$name]->type);
-            $this->assertInstanceOf(\stdClass::class, $schemas[$name]->default);
             $this->assertSame('{}', json_encode($schemas[$name]->default));
         }
         $this->assertEquals((object) ['enabled' => true], $schemas['metadata']->default);

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -356,6 +356,58 @@ final class FormatTest extends TestCase
         $this->assertSame('["one","two"]', $properties['text']['example']);
     }
 
+    public static function defaultLocations(): array
+    {
+        return [['GET'], ['POST']];
+    }
+
+    #[DataProvider('defaultLocations')]
+    public function testEmptyObjectDefaultsSerializeAsObjects(string $method): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route($method, '/v1/tests'))
+            ->desc('Get test')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'getTest',
+                description: 'Get test.',
+                auth: [AuthType::ADMIN],
+                responses: [],
+            ))
+            ->param('headers', [], new Assoc(), 'Headers.', optional: true)
+            ->param('data', [], new JSON(), 'Data.', optional: true)
+            ->param('metadata', ['enabled' => true], new Assoc(), 'Metadata.', optional: true)
+            ->param('labels', [], new ArrayList(new Text(16)), 'Labels.', optional: true)
+            ->param('count', 0, new Range(0, 100), 'Count.', optional: true)
+            ->param('enabled', false, new BooleanValidator(true), 'Enabled.', optional: true);
+
+        $spec = (new OpenAPI3(new Container(), [], [$route], [], [], ['console' => 0], 'console'))->parse();
+        // Check serialized JSON, where PHP's empty array and empty object differ.
+        $operation = json_decode(json_encode($spec, JSON_THROW_ON_ERROR), flags: JSON_THROW_ON_ERROR)->paths->{'/tests'}->{strtolower($method)};
+        if ($method === 'GET') {
+            $schemas = [];
+            foreach ($operation->parameters as $parameter) {
+                $schemas[$parameter->name] = $parameter->schema;
+            }
+        } else {
+            $schemas = (array) $operation->requestBody->content->{'application/json'}->schema->properties;
+        }
+
+        foreach (['headers', 'data'] as $name) {
+            $this->assertSame('object', $schemas[$name]->type);
+            $this->assertInstanceOf(\stdClass::class, $schemas[$name]->default);
+            $this->assertSame('{}', json_encode($schemas[$name]->default));
+        }
+        $this->assertEquals((object) ['enabled' => true], $schemas['metadata']->default);
+        $this->assertSame('array', $schemas['labels']->type);
+        $this->assertSame([], $schemas['labels']->default);
+        $this->assertSame(0, $schemas['count']->default);
+        $this->assertFalse($schemas['enabled']->default);
+    }
+
     public function testArrayListItemTypesAreValidOpenApiTypes(): void
     {
         Method::$processed = [];


### PR DESCRIPTION
## Summary

Fix object-typed OpenAPI defaults being serialized as `[]` instead of `{}`.

Found during genuine Cloud spec verification for [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards), tracked in [Cloud #5716](https://github.com/appwrite-labs/cloud/pull/5716). This PR is independent of the optional-security migration in #13543 and branches directly from main.

### Cause and fix

The object-specific formatter branches already normalize empty defaults to `stdClass`, but the shared default assignment later overwrites the normalized value with the route's raw PHP `[]`. JSON then contains `type: object` with `default: []`, which fails strict OpenAPI validation.

Normalize an exactly empty array to `stdClass` at that shared assignment only when the final schema type is `object`. Preserve default eligibility, array defaults, populated maps, scalar defaults, examples, and runtime API behavior.

The captured Cloud document has 16 affected schemas, including screenshot headers, execution headers, presence metadata, and document/row update data. The published document has the same validation error; this was not introduced by the optional-security change.

## Verification

- Added GET-query and POST-request-body regressions that inspect the formatter's serialized JSON. Both failed before the production fix (`array` instead of `stdClass`) and pass afterward.
- Coverage verifies empty Assoc/JSON object defaults serialize as `{}`, while populated maps, empty array schemas, `0`, and `false` remain unchanged.
- `vendor/bin/phpunit tests/unit/SDK/Specification/FormatTest.php` — passed: **38 tests, 210 assertions**.
- `vendor/bin/pint --test src/Appwrite/SDK/Specification/Format/OpenAPI3.php tests/unit/SDK/Specification/FormatTest.php` — passed.
- `composer refactor:check` — passed across all 397 test files. The data provider now uses `yield`, fixing the failing CI Rector check.
- `git diff --check` — passed.
- Removed the redundant concrete-type assertion requested by Greptile; the regression asserts emitted `{}` JSON directly.

Not run for this separate branch: full Cloud specs workflow, full-document strict validation, SDK regeneration/output comparisons, Appwrite runtime e2e, or full-project static analysis. This fixes the demonstrated object-default mismatch; it does not claim that the entire live spec is now validator-clean. No screenshots apply to this nonvisual formatter change.
