### PR TITLE
fix(specs): omit invalid timezone and annotated enum defaults

### DIFF
--- a/src/Appwrite/SDK/Specification/Format.php
+++ b/src/Appwrite/SDK/Specification/Format.php
@@ -469,12 +469,36 @@ abstract class Format
 
     protected function shouldEmitDefaultForSchema(mixed $default, array $schema): bool
     {
-        if (isset($schema['enum'])) {
-            return \in_array($default, $schema['enum'], true);
+        if (isset($schema['enum']) && !\in_array($default, $schema['enum'], true)) {
+            return false;
         }
 
-        if (\is_array($schema['items'] ?? null) && isset($schema['items']['enum'])) {
-            return \is_array($default) && empty(\array_diff($default, $schema['items']['enum']));
+        // Named enums use titled oneOf branches; open enums additionally
+        // accept a free-string branch through anyOf.
+        foreach (['oneOf', 'anyOf'] as $composition) {
+            if (!isset($schema[$composition])) {
+                continue;
+            }
+            $matches = 0;
+            foreach ($schema[$composition] as $branch) {
+                if ($this->shouldEmitDefaultForSchema($default, $branch)) {
+                    $matches++;
+                }
+            }
+            if ($composition === 'oneOf' ? $matches !== 1 : $matches === 0) {
+                return false;
+            }
+        }
+
+        if (\is_array($schema['items'] ?? null)) {
+            if (!\is_array($default)) {
+                return false;
+            }
+            foreach ($default as $item) {
+                if (!$this->shouldEmitDefaultForSchema($item, $schema['items'])) {
+                    return false;
+                }
+            }
         }
 
         return true;

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -233,6 +233,51 @@ final class FormatTest extends TestCase
         $this->assertArrayNotHasKey('x-enum-keys', $kind);
     }
 
+    #[DataProvider('defaultLocations')]
+    public function testAnnotatedEnumDefaultsMatchAllowedValues(string $method): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route($method, '/v1/tests'))
+            ->desc('Get test')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'getTest',
+                description: 'Get test.',
+                auth: [AuthType::ADMIN],
+                responses: [],
+            ))
+            ->param('timezone', '', new WhiteList(['utc', 'europe/london']), 'Timezone.', optional: true, enum: new Enum(name: 'TestTimezone'))
+            ->param('validZone', 'utc', new WhiteList(['utc', 'europe/london']), 'Valid timezone.', optional: true, enum: new Enum(name: 'TestValidTimezone'))
+            ->param('zones', ['invalid'], new ArrayList(new WhiteList(['utc', 'europe/london'])), 'Timezones.', optional: true, enum: new Enum(name: 'TestZones'))
+            ->param('validZones', ['utc'], new ArrayList(new WhiteList(['utc', 'europe/london'])), 'Valid timezones.', optional: true, enum: new Enum(name: 'TestValidZones'))
+            ->param('emptyZones', [], new ArrayList(new WhiteList(['utc'])), 'Empty timezones.', optional: true, enum: new Enum(name: 'TestEmptyZones'))
+            ->param('openZone', 'custom', new AnyOf([new WhiteList(['utc']), new Text(64)]), 'Open timezone.', optional: true, enum: new Enum(name: 'TestOpenZone'))
+            ->param('openZones', ['custom'], new AnyOf([new ArrayList(new WhiteList(['utc'])), new ArrayList(new Text(64))]), 'Open timezones.', optional: true, enum: new Enum(name: 'TestOpenZones'));
+
+        $spec = (new OpenAPI3(new Container(), [], [$route], [], [], ['console' => 0], 'console'))->parse();
+        $operation = $spec['paths']['/tests'][strtolower($method)];
+        if ($method === 'GET') {
+            $schemas = array_column($operation['parameters'], 'schema', 'name');
+        } else {
+            $schemas = $operation['requestBody']['content']['application/json']['schema']['properties'];
+        }
+
+        $this->assertArrayHasKey('oneOf', $schemas['timezone']);
+        $this->assertArrayNotHasKey('default', $schemas['timezone']);
+        $this->assertSame(['utc', 'europe/london'], array_column(array_column($schemas['timezone']['oneOf'], 'enum'), 0));
+        $this->assertSame('utc', $schemas['validZone']['default']);
+        $this->assertArrayNotHasKey('default', $schemas['zones']);
+        $this->assertSame(['utc'], $schemas['validZones']['default']);
+        $this->assertSame([], $schemas['emptyZones']['default']);
+        $this->assertArrayHasKey('anyOf', $schemas['openZone']);
+        $this->assertSame('custom', $schemas['openZone']['default']);
+        $this->assertArrayHasKey('anyOf', $schemas['openZones']['items']);
+        $this->assertSame(['custom'], $schemas['openZones']['default']);
+    }
+
     public function testEnumNameMustNotOverlapServiceName(): void
     {
         Method::$processed = [];


### PR DESCRIPTION
## Summary

Fix invalid defaults on titled OpenAPI enum schemas, including screenshot `timezone` with `default: ""` despite its timezone enum excluding the empty string.

Found by strict validation of genuine Cloud workflow artifacts in [Cloud #5716](https://github.com/appwrite-labs/cloud/pull/5716), after the object-default fix in #13544. This is a separate follow-up for [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards), based directly on main rather than the optional-security branch.

The producer's existing default-eligibility check recognized plain `enum` and `items.enum`, but named enums now use titled `oneOf` branches. Extend the enum-default check to evaluate `oneOf`/`anyOf` branches and array items recursively:

- Omit defaults that are not permitted by the emitted enum, rather than changing the enum or inventing a timezone default.
- Retain valid scalar defaults, valid array defaults, and empty arrays.
- Preserve open enums: the free-string alternative still permits values outside the named enum.

No route validator, runtime behavior, or API authentication changes. This is an enum-default eligibility check, not a general JSON Schema validator.

## Spec change

`GET /avatars/screenshots` → optional `timezone` query parameter. Relevant schema excerpt below; the enum branches are abbreviated. This illustrates the intended change, not a newly generated full Cloud artifact.

```diff
 schema:
   type: string
   title: Timezone
   oneOf:
     - type: string
       enum: [africa/abidjan]
       title: africa/abidjan
     # ... remaining timezone branches unchanged ...
     - type: string
       enum: [utc]
       title: utc
-  default: ""
```

The invalid default is omitted—not replaced with `utc` or added to the enum. The parameter remains optional, and omission continues to use the browser's default timezone. Valid enum defaults remain unchanged.

## Verification

- Added GET-query and POST-request-body regressions using real route and enum metadata. Both failed before the production change because the invalid default was emitted, then passed after the fix.
- Coverage includes the empty timezone sentinel, valid timezone defaults, invalid/valid/empty enum-array defaults, and open scalar/array enums.
- `vendor/bin/phpunit tests/unit/SDK/Specification/FormatTest.php` — passed: **40 tests, 232 assertions**.
- `vendor/bin/pint --test src/Appwrite/SDK/Specification/Format.php tests/unit/SDK/Specification/FormatTest.php` — passed.
- `composer refactor:check` — passed.
- `git diff --check` — passed.

Not run for this branch: full Cloud spec generation, strict validation of the full resulting document, SDK output comparison, runtime e2e, or full-project static analysis. Further spec validation failures may surface after this one is removed; this PR does not claim the full canonical document is validator-clean. No screenshots apply to this nonvisual formatter change.

