### PR TITLE
fix(oidc): expose tokenUrl/userInfoUrl aliases so the console stops wiping OIDC endpoints on save

### DIFF
--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Oidc/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Oidc/Update.php
@@ -170,7 +170,9 @@ class Update extends Base
             'wellKnownURL' => $decoded['wellKnownEndpoint'] ?? '',
             'authorizationURL' => $decoded['authorizationEndpoint'] ?? '',
             'tokenURL' => $decoded['tokenEndpoint'] ?? '',
+            'tokenUrl' => $decoded['tokenEndpoint'] ?? '',
             'userInfoURL' => $decoded['userInfoEndpoint'] ?? '',
+            'userInfoUrl' => $decoded['userInfoEndpoint'] ?? '',
             'prompt' => $decoded['prompt'] ?? [],
             'maxAge' => $decoded['maxAge'] ?? null,
         ]);

--- a/src/Appwrite/Utopia/Response/Model/OAuth2Oidc.php
+++ b/src/Appwrite/Utopia/Response/Model/OAuth2Oidc.php
@@ -68,7 +68,20 @@ class OAuth2Oidc extends OAuth2Base
                 'default' => null,
                 'example' => 3600,
                 'required' => false,
-            ]);
+            ])
+            ->addRule('tokenUrl', [
+                'type' => self::TYPE_STRING,
+                'description' => 'Alias of tokenURL, kept for client compatibility (the Appwrite console reads this casing).',
+                'default' => '',
+                'example' => 'https://myoauth.com/oauth2/token',
+            ])
+            ->addRule('userInfoUrl', [
+                'type' => self::TYPE_STRING,
+                'description' => 'Alias of userInfoURL, kept for client compatibility (the Appwrite console reads this casing).',
+                'default' => '',
+                'example' => 'https://myoauth.com/oauth2/userinfo',
+            ])
+        ;
     }
 
     /**


### PR DESCRIPTION
## Problem

Updating a project's **OIDC provider in the console silently wipes the token and user-info endpoints.**

Round trip, verified against current `main` of `appwrite/appwrite` (`0c0dd72`) and `appwrite/console`:

1. `Oidc/Update::buildReadResponse()` returns the discovery URLs under the keys `tokenURL` and `userInfoURL` (`src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Oidc/Update.php`).
2. The console prefills its OIDC form with `getDetail('tokenUrl')` and `getDetail('userInfoUrl')` - lower-case `url` (`appwrite/console` `.../auth/updateOAuth.ts`). Both reads miss, so the form re-saves `''` for the two endpoints.
3. The server merge uses `??`, where `''` is a real value - so every save overwrites the stored `tokenEndpoint` / `userInfoEndpoint` with empty strings. OIDC login then fails until the endpoints are manually re-entered.

This is the same seam the router-side `V25` response filter patches for the 1.9.3 format (`tokenURL -> tokenUrl`); the current-format response just never exposes that casing.

Worth noting this also matches the recurring user complaint of OIDC configuration being "wiped" after touching provider settings (e.g. self-hosted forum reports) - users re-save an OIDC provider and lose their endpoints.

## Fix

Add `tokenUrl` / `userInfoUrl` alias rules to the OIDC response model and populate them from the same stored values in `buildReadResponse()`. The console's existing reads now hit, prefills keep the real endpoints, and a save round-trips the configuration instead of wiping it.

Purely additive - `tokenURL` / `userInfoURL` are unchanged, so existing consumers are unaffected.

## Testing

- `php -l` clean on both files.
- Logic verified by tracing the round trip: console reads (`updateOAuth.ts`), API response keys (`Oidc/Update.php`), and the V25 alias precedent. No runtime repro rig on my side - flagged honestly in case maintainers want an e2e assertion added.

> Built by breken, your AI support engineer - breken.ai - this one's on us.
