### PR TITLE
fix(realtime): cast presence ids to string in onClose cleanup

### DIFF
--- a/app/realtime.php
+++ b/app/realtime.php
@@ -1407,7 +1407,7 @@ $server->onClose(function (int $connection) use ($realtime, $stats, $register, $
                             return;
                         }
 
-                        $presenceIds = \array_map('strval', \array_keys($presencesById));
+                        $presenceIds = \array_map(strval(...), \array_keys($presencesById));
                         $dbForProject = getProjectDB($project);
 
                         $user = new User([]);

--- a/app/realtime.php
+++ b/app/realtime.php
@@ -1448,7 +1448,9 @@ $server->onClose(function (int $connection) use ($realtime, $stats, $register, $
                                 'projectId' => $projectId,
                                 'userId' => $userId ?? 'n/a',
                                 'presences' => \count($presenceIds),
-                                'presenceIds' => \implode(',', $presenceIds),
+                                // Bounded sample; total is carried by `presences` above so the
+                                // tag cannot blow past telemetry length limits on a busy connection.
+                                'presenceIds' => \implode(',', \array_slice($presenceIds, 0, 10)),
                             ]);
                         }
 

--- a/app/realtime.php
+++ b/app/realtime.php
@@ -1446,7 +1446,7 @@ $server->onClose(function (int $connection) use ($realtime, $stats, $register, $
                             Span::current()?->setError($th);
                             logError($th, 'realtimeOnClosePresenceDeletion', tags: [
                                 'projectId' => $projectId,
-                                'userId' => $userId ?? 'n/a',
+                                'userId' => $userId ?? '',
                                 'presences' => \count($presenceIds),
                                 // Bounded sample; total is carried by `presences` above so the
                                 // tag cannot blow past telemetry length limits on a busy connection.

--- a/app/realtime.php
+++ b/app/realtime.php
@@ -1406,7 +1406,7 @@ $server->onClose(function (int $connection) use ($realtime, $stats, $register, $
                             return;
                         }
 
-                        $presenceIds = \array_keys($presencesById);
+                        $presenceIds = \array_map('strval', \array_keys($presencesById));
                         $dbForProject = getProjectDB($project);
 
                         $user = new User([]);

--- a/app/realtime.php
+++ b/app/realtime.php
@@ -1397,6 +1397,7 @@ $server->onClose(function (int $connection) use ($realtime, $stats, $register, $
                     Span::init('realtime.close.presenceCleanup');
                     Span::add('realtime.projectId', $projectId);
                     Span::add('realtime.presenceCount', \count($presencesById));
+                    Span::add('user.id', $userId ?? null);
 
                     try {
                         $dbForPlatform = getConsoleDB();
@@ -1445,7 +1446,9 @@ $server->onClose(function (int $connection) use ($realtime, $stats, $register, $
                             Span::current()?->setError($th);
                             logError($th, 'realtimeOnClosePresenceDeletion', tags: [
                                 'projectId' => $projectId,
-                                'presences' => \count($presenceIds)
+                                'userId' => $userId ?? 'n/a',
+                                'presences' => \count($presenceIds),
+                                'presenceIds' => \implode(',', $presenceIds),
                             ]);
                         }
 

--- a/tests/e2e/Services/Presences/PresenceRealtimeClientTest.php
+++ b/tests/e2e/Services/Presences/PresenceRealtimeClientTest.php
@@ -654,6 +654,13 @@ final class PresenceRealtimeClientTest extends Scope
             );
             $this->assertSame(404, $read['headers']['status-code']);
         } finally {
+            // Publisher is closed mid-body to trigger onClose; guard against a double close
+            // and still tear it down if an earlier assertion threw first.
+            try {
+                $publisher->close();
+            } catch (\Throwable) {
+                // Already closed.
+            }
             $listener->close();
         }
     }

--- a/tests/e2e/Services/Presences/PresenceRealtimeClientTest.php
+++ b/tests/e2e/Services/Presences/PresenceRealtimeClientTest.php
@@ -618,6 +618,46 @@ final class PresenceRealtimeClientTest extends Scope
         }
     }
 
+    public function testPresenceCloseWithNumericIdEmitsDeleteEvent(): void
+    {
+        [$project, $user, $headers] = $this->bootstrapIsolatedProject();
+
+        // A purely numeric id is a valid presence $id (UID allows digits), but when stored as
+        // an array key in the realtime worker's in-memory connection map it is coerced to an int
+        // by PHP. onClose must still delete it — regression for the coerced-key $id cleanup query.
+        $presenceId = (string) \random_int(10_000_000, 99_999_999);
+        $metadata = ['testRunId' => ID::unique(), 'source' => 'close-delete-numeric'];
+
+        $publisher = $this->connectRealtimeAndSubscribe($project, $headers, ['presences', 'presences.' . $presenceId], timeout: 1);
+        $listener = $this->connectRealtimeAndSubscribe($project, $headers, ['presences', 'presences.' . $presenceId], timeout: 1);
+
+        try {
+            $this->sendPresenceMessage(
+                $publisher,
+                $presenceId,
+                'online',
+                $metadata,
+                $this->getPresencePermissions(Role::any())
+            );
+            $this->collectPresenceOutcome($publisher, $presenceId, 'online', $metadata, $user['$id']);
+            $this->receivePresenceEvent($listener, $presenceId, 'upsert', 'online', $metadata, $user['$id']);
+
+            $publisher->close();
+
+            $this->receivePresenceEvent($listener, $presenceId, 'delete', 'online', $metadata, $user['$id'], timeoutMs: 3000);
+
+            // The row must actually be gone, not just the event fired.
+            $read = $this->client->call(
+                Client::METHOD_GET,
+                '/presences/' . $presenceId,
+                $this->getServerHeaders($project)
+            );
+            $this->assertSame(404, $read['headers']['status-code']);
+        } finally {
+            $listener->close();
+        }
+    }
+
     public function testHttpDeleteThenCloseDoesNotDuplicateDeleteEvent(): void
     {
         [$project, $user, $headers] = $this->bootstrapIsolatedProject();


### PR DESCRIPTION
## What

Fixes an `Invalid query: Query value is invalid for attribute "$id"` error thrown from the realtime `onClose` presence-cleanup path (Sentry: `realtimeOnClosePresenceDeletion` / `realtime.close.presenceCleanup`).

## Root cause

A presence id is a valid UID, and a UID may be **purely numeric** (`0-9` are allowed). The `presenceId` param is validated only as `Text(36)`, so a client can publish a presence with an id like `"12345"`.

The realtime worker tracks live presences as a set keyed by id:

```php
$realtime->connections[$connectionId]['presences'][$presence->getId()] = true;
```

PHP coerces any canonical-integer **string key** to an `int`. On disconnect the cleanup does:

```php
$presenceIds = \array_keys($presencesById);        // numeric ids come back as int
$dbForProject->deleteDocuments('presenceLogs', [Query::equal('$id', $presenceIds)]);
```

So `$id` (a string column) is queried with an integer:
- the query validator rejects it → the observed exception, and
- even where it passes, an int never matches the string id on strict adapters (Postgres/Mongo), so those presence rows **leak** instead of being cleaned up.

Note: `user.id`/`project.id` reading `n/a` in the Sentry tags is a span-tagging artifact (the cleanup span only sets `realtime.projectId`), not evidence the user was unauthenticated — a presence cannot be created without an authenticated user.

## Fix

Cast the ids back to strings right before the delete query:

```php
$presenceIds = \array_map('strval', \array_keys($presencesById));
```

## Diagnostics

To make any future occurrence self-explanatory, the cleanup now records `user.id` on the span and adds `userId` + the concrete `presenceIds` to the `realtimeOnClosePresenceDeletion` error tags (previously only a count). Ids are attached on the failure path only, to avoid span cardinality blowup.

## Tests

Adds `testPresenceCloseWithNumericIdEmitsDeleteEvent` (e2e, `PresenceRealtimeClientTest`): publishes a presence with a numeric id over realtime, closes the connection, and asserts the `presences.<id>.delete` event fires **and** `GET /presences/<id>` returns `404`. Without the fix the numeric id is queried as an int, the row is not deleted, and both assertions fail.

`app/realtime.php` is a process entrypoint with no unit-testable seam for this glue, so the regression is covered through the real realtime API per the repo's E2E conventions.

## Verification

```
docker compose up -d --force-recreate --build   # realtime container must reload app/realtime.php
docker compose exec appwrite test tests/e2e/Services/Presences/PresenceRealtimeClientTest --filter=testPresenceCloseWithNumericIdEmitsDeleteEvent
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
