### PR TITLE
fix: reuse the cloned branch when pushing templates

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -358,7 +358,9 @@ class Builds extends Action
 
                 // Commit and push
                 $commitMessage = \escapeshellarg('Create ' . $resource->getAttribute('name', '') . ' function');
-                $exit = Console::execute('git config --global user.email ' . \escapeshellarg(APP_VCS_GITHUB_EMAIL) . ' && git config --global user.name ' . \escapeshellarg(APP_VCS_GITHUB_USERNAME) . ' && cd ' . \escapeshellarg($tmpDirectory) . ' && git checkout -b ' . \escapeshellarg($branchName) . ' && git add . && git commit -m ' . $commitMessage . ' && git push origin ' . \escapeshellarg($branchName), '', $stdout, $stderr);
+                // Branch clones already created the local branch; commit clones
+                // have a detached HEAD. Both should commit on the cloned HEAD.
+                $exit = Console::execute('git config --global user.email ' . \escapeshellarg(APP_VCS_GITHUB_EMAIL) . ' && git config --global user.name ' . \escapeshellarg(APP_VCS_GITHUB_USERNAME) . ' && cd ' . \escapeshellarg($tmpDirectory) . ' && git checkout -B ' . \escapeshellarg($branchName) . ' && git add . && git commit -m ' . $commitMessage . ' && git push origin ' . \escapeshellarg($branchName), '', $stdout, $stderr);
 
                 if ($exit !== 0) {
                     throw new \Exception('Unable to push code repository: ' . $stderr);


### PR DESCRIPTION
Template deployments clone the destination branch and then try to create the same local branch with `git checkout -b`. The push fails with "a branch named ... already exists" before the template can be committed.

Use `git checkout -B` at the cloned HEAD so both an existing branch checkout and a detached commit checkout can receive the template commit. This only changes the temporary build clone; the push remains a normal fast-forward push.

Validation: local bare-Git regression scenarios for branch and detached-HEAD clones both push the template successfully while preserving the original file and parent commit. The previous command reproduces the existing-branch failure. Targeted Pint, PHPStan, PHP syntax, and `git diff --check` pass. No production VCS services were called; a complete build-worker/API flow was not run.

Fixes [CLOUD-3QX7](https://appwrite.sentry.io/issues/CLOUD-3QX7).
