### PR TITLE
fix(sites): tell edge a screenshot capture is a one-shot render

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -147,6 +147,14 @@ class Screenshots extends Action
             $headers = [
                 'x-appwrite-hostname' => $rule->getAttribute('domain'),
                 'x-appwrite-key' => API_KEY_EPHEMERAL . '_' . $apiKey,
+                // A capture is the only request this deployment will ever get:
+                // it fires once per successful build, against a preview URL
+                // nobody visits. Edge holds a site runtime warm for 90 minutes
+                // after its last request, so without this every build leaves a
+                // runtime occupying a node for an hour and a half to serve a
+                // screenshot that took 15 seconds. This tells edge to keep the
+                // runtime only as long as an ordinary function.
+                'x-appwrite-runtime-ephemeral' => '1',
             ];
 
             $framework = Config::getParam('frameworks', [])[$site->getAttribute('framework', '')] ?? null;


### PR DESCRIPTION
## A capture is the only request that deployment ever gets

`Jobs.php:521` enqueues a screenshot job on **every successful site build,
activated or not**. This worker then fetches the deployment's preview URL twice,
light and dark, holding each open for `screenshotSleep`.

Edge keeps a **site** runtime warm for 90 minutes after its last request
(`OPR_EXECUTOR_INACTIVE_THRESHOLD_SITES=5400`, against 600s for a function).
That is the right trade for a site people visit. A capture is not a visit: the
deployment it targets has never been requested and never will be again, so each
one leaves a runtime occupying a node for an hour and a half to serve a render
that took ~15 seconds.

## What that cost

On 2026-09-06 a single site emitted **~247 deployments in two hours**, deployment
ids sequential and seconds apart. Every build enqueued a capture; every capture
cold-started its **own** runtime, since runtime ids are `projectId-deploymentId`
and no two builds share one; and the 90-minute threshold stacked them instead of
letting them churn.

| | |
|---|---|
| Screenshot jobs, that one site, 4h | **247** — 86% of all sites combined |
| Worker rate | 1–11/30min → **101/30min** |
| edge nyc3 runtimes | **769 → 978** |
| edge nyc3 nodes | **18 → 47** |

The load was gone by 01:00; nyc3 still held 44 nodes two days later.

## The change

One header, so edge can tell a render from a visit and keep the runtime only as
long as an ordinary function.

Sent from here rather than inferred on the edge side, because nothing already on
the wire identifies a capture: the `ephemeral_` API key prefix is minted in
seven places including ordinary function executions, and `?appwrite-preview=1`
is client-supplied.

## Ordering

Needs the edge side that reads it, **appwrite-labs/edge#1391**. Until that ships
the header is simply ignored, so the two can land in either order and neither
blocks the other.

## Worth a follow-up, not in this PR

Two things this does not address:

- **The fan-out.** 247 captures for one site, of which one was ever useful.
  Coalescing per site — debounce, or only capture the activated deployment —
  would remove the waste rather than shorten it.
- **The trigger.** Nothing capped one site at 247 deployments in two hours.