### PR TITLE
fix(teams): return query errors for unsupported searches

### DIFF
--- a/src/Appwrite/Platform/Modules/Teams/Http/Teams/XList.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Teams/XList.php
@@ -94,6 +94,8 @@ class XList extends Action
             $total = $includeTotal ? $dbForProject->count('teams', $filterQueries, APP_LIMIT_COUNT) : 0;
         } catch (OrderException $e) {
             throw new Exception(Exception::DATABASE_QUERY_ORDER_NULL, "The order attribute '{$e->getAttribute()}' had a null value. Cursor pagination requires all documents order attribute values are non-null.");
+        } catch (QueryException $e) {
+            throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
         }
 
         $response->dynamic(new Document([

--- a/tests/e2e/Services/Teams/TeamsBase.php
+++ b/tests/e2e/Services/Teams/TeamsBase.php
@@ -362,6 +362,19 @@ trait TeamsBase
 
         $this->assertEquals(400, $response['headers']['status-code']);
 
+        foreach ([true, false] as $includeTotal) {
+            $response = $this->client->call(Client::METHOD_GET, '/teams', array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'queries' => [Query::search('name', 'Arsenal')->toString()],
+                'total' => $includeTotal,
+            ]);
+
+            $this->assertEquals(400, $response['headers']['status-code']);
+            $this->assertEquals('general_query_invalid', $response['body']['type']);
+        }
+
         /**
          * Test for SUCCESS with total=false
          */


### PR DESCRIPTION
Searching teams with `Query::search('name', ...)` returns HTTP 500 because `name` has no fulltext index. Map the database query exception to HTTP 400 with `general_query_invalid`, following the existing Functions, Variables, and Proxy list handlers from #13208.

The regression extends `TeamsBase::testListTeams` for both `total` settings. Existing cases continue to cover the supported `search` parameter, name equality filters, and cursor pagination.

Validation: the regression failed with HTTP 500 before the fix. Afterward, the three console/client/server list tests pass with 196 assertions. Targeted Pint, PHPStan, Rector, and `git diff --check` pass.

Fixes [CLOUD-3QX9](https://appwrite.sentry.io/issues/7713757041).
