### PR TITLE
fix(jobs): preserve UTF-8 boundaries in truncated logs

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -800,6 +800,7 @@ class Jobs extends Action
             return $logs;
         }
 
-        return \substr($logs, -$limit);
+        // Drop UTF-8 continuation bytes orphaned at the start of the retained tail.
+        return \ltrim(\substr($logs, -$limit), "\x80..\xBF");
     }
 }

--- a/tests/e2e/General/JobsTest.php
+++ b/tests/e2e/General/JobsTest.php
@@ -36,16 +36,16 @@ use Utopia\Storage\Device\Local;
 final class JobsTest extends TestCase
 {
     #[DataProvider('callbacks')]
-    public function testUpdateDuringDeletion(string $event, bool $extension, bool $delete): void
+    public function testUpdate(string $event, bool $extension, bool $delete, string $log = 'build output', string $expectedLogs = "build output\n"): void
     {
         if (! \extension_loaded('swoole')) {
             $this->markTestSkipped('Swoole extension required');
         }
 
         $error = null;
-        \Swoole\Coroutine\run(function () use ($event, $extension, $delete, &$error): void {
+        \Swoole\Coroutine\run(function () use ($event, $extension, $delete, $log, $expectedLogs, &$error): void {
             try {
-                $this->update($event, $extension, $delete);
+                $this->update($event, $extension, $delete, $log, $expectedLogs);
             } catch (\Throwable $e) {
                 $error = $e;
             }
@@ -56,7 +56,7 @@ final class JobsTest extends TestCase
         }
     }
 
-    private function update(string $event, bool $extension, bool $delete): void
+    private function update(string $event, bool $extension, bool $delete, string $log, string $expectedLogs): void
     {
         global $register;
 
@@ -78,7 +78,7 @@ final class JobsTest extends TestCase
                 $attributes[] = new Document([
                     '$id' => $name,
                     'type' => Database::VAR_STRING,
-                    'size' => 512,
+                    'size' => $name === 'buildLogs' ? APP_LOG_LENGTH_LIMIT : 512,
                     'required' => false,
                     'array' => false,
                 ]);
@@ -126,7 +126,7 @@ final class JobsTest extends TestCase
                     project: $project,
                     id: ID::unique(),
                     event: $event,
-                    data: ['meta' => ['deploymentId' => $deploymentId], 'lines' => ['build output'], 'exitCode' => 1],
+                    data: ['meta' => ['deploymentId' => $deploymentId], 'lines' => [$log], 'exitCode' => 1],
                 ))->toArray()),
                 project: $project,
                 dbForProject: $db,
@@ -155,10 +155,13 @@ final class JobsTest extends TestCase
                 // Test for SUCCESS: a surviving deployment still streams logs.
                 $deployment = $db->getDocument('deployments', $deploymentId);
                 $this->assertSame('building', $deployment->getAttribute('status'));
-                $this->assertSame("build output\n", $deployment->getAttribute('buildLogs'));
+                $this->assertSame(\strlen($expectedLogs), \strlen($deployment->getAttribute('buildLogs')));
+                $this->assertSame($expectedLogs, $deployment->getAttribute('buildLogs'));
+                $this->assertTrue(\mb_check_encoding($deployment->getAttribute('buildLogs'), 'UTF-8'));
+                $this->assertLessThanOrEqual(APP_LOG_LENGTH_LIMIT, \strlen($deployment->getAttribute('buildLogs')));
                 $this->assertCount(1, $pubsub->messages);
                 $this->assertSame($deploymentId, $pubsub->messages[0]['data']['payload']['$id']);
-                $this->assertSame("build output\n", $pubsub->messages[0]['data']['payload']['buildLogs']);
+                $this->assertSame($expectedLogs, $pubsub->messages[0]['data']['payload']['buildLogs']);
             }
 
             $this->assertSame(0, $publisher->getQueueSize($queue));
@@ -176,6 +179,23 @@ final class JobsTest extends TestCase
         yield 'deleted while finalizing' => ['orchestrator.job.exit', false, true];
         yield 'deleted by a downstream finalizer' => ['orchestrator.job.exit', true, true];
         yield 'surviving deployment' => ['orchestrator.job.log', false, false];
+        yield 'short Unicode logs' => ['orchestrator.job.log', false, false, 'Build complete ✅ café', "Build complete ✅ café\n"];
+
+        $tail = 'é' . \str_repeat('x', APP_LOG_LENGTH_LIMIT - \strlen("é\n"));
+        yield 'truncation at Unicode character boundary' => ['orchestrator.job.log', false, false, 'discarded ' . $tail, $tail . "\n"];
+
+        $prefix = 'retained ';
+        $suffix = ' completed';
+        foreach (['é', '€', '🚀'] as $character) {
+            for ($bytes = 1; $bytes < \strlen($character); $bytes++) {
+                $tail = $prefix . \str_repeat('x', APP_LOG_LENGTH_LIMIT - $bytes - \strlen($prefix . $suffix . "\n")) . $suffix;
+                yield "truncation within {$character} retaining {$bytes} bytes" => [
+                    'orchestrator.job.log', false, false,
+                    'discarded ' . $character . $tail,
+                    $tail . "\n",
+                ];
+            }
+        }
     }
 }
 

--- a/tests/e2e/General/JobsTest.php
+++ b/tests/e2e/General/JobsTest.php
@@ -35,6 +35,9 @@ use Utopia\Storage\Device\Local;
 
 final class JobsTest extends TestCase
 {
+    // Keep the expected 1 MB log limit independent of production configuration.
+    private const int LOG_BYTES = 1_000_000;
+
     #[DataProvider('callbacks')]
     public function testUpdate(string $event, bool $extension, bool $delete, string $log = 'build output', string $expectedLogs = "build output\n"): void
     {
@@ -78,7 +81,7 @@ final class JobsTest extends TestCase
                 $attributes[] = new Document([
                     '$id' => $name,
                     'type' => Database::VAR_STRING,
-                    'size' => $name === 'buildLogs' ? APP_LOG_LENGTH_LIMIT : 512,
+                    'size' => $name === 'buildLogs' ? self::LOG_BYTES : 512,
                     'required' => false,
                     'array' => false,
                 ]);
@@ -158,7 +161,7 @@ final class JobsTest extends TestCase
                 $this->assertSame(\strlen($expectedLogs), \strlen($deployment->getAttribute('buildLogs')));
                 $this->assertSame($expectedLogs, $deployment->getAttribute('buildLogs'));
                 $this->assertTrue(\mb_check_encoding($deployment->getAttribute('buildLogs'), 'UTF-8'));
-                $this->assertLessThanOrEqual(APP_LOG_LENGTH_LIMIT, \strlen($deployment->getAttribute('buildLogs')));
+                $this->assertLessThanOrEqual(self::LOG_BYTES, \strlen($deployment->getAttribute('buildLogs')));
                 $this->assertCount(1, $pubsub->messages);
                 $this->assertSame($deploymentId, $pubsub->messages[0]['data']['payload']['$id']);
                 $this->assertSame($expectedLogs, $pubsub->messages[0]['data']['payload']['buildLogs']);
@@ -181,14 +184,14 @@ final class JobsTest extends TestCase
         yield 'surviving deployment' => ['orchestrator.job.log', false, false];
         yield 'short Unicode logs' => ['orchestrator.job.log', false, false, 'Build complete ✅ café', "Build complete ✅ café\n"];
 
-        $tail = 'é' . \str_repeat('x', APP_LOG_LENGTH_LIMIT - \strlen("é\n"));
+        $tail = 'é' . \str_repeat('x', self::LOG_BYTES - \strlen("é\n"));
         yield 'truncation at Unicode character boundary' => ['orchestrator.job.log', false, false, 'discarded ' . $tail, $tail . "\n"];
 
         $prefix = 'retained ';
         $suffix = ' completed';
         foreach (['é', '€', '🚀'] as $character) {
             for ($bytes = 1; $bytes < \strlen($character); $bytes++) {
-                $tail = $prefix . \str_repeat('x', APP_LOG_LENGTH_LIMIT - $bytes - \strlen($prefix . $suffix . "\n")) . $suffix;
+                $tail = $prefix . \str_repeat('x', self::LOG_BYTES - $bytes - \strlen($prefix . $suffix . "\n")) . $suffix;
                 yield "truncation within {$character} retaining {$bytes} bytes" => [
                     'orchestrator.job.log', false, false,
                     'discarded ' . $character . $tail,


### PR DESCRIPTION
Truncating deployment logs can split a UTF-8 character and leave continuation bytes at the start of the retained text. MariaDB then rejects the build-log update with `Invalid character`.

Discard those orphaned leading bytes after truncation, preserving complete characters, the newest output, and the existing byte limit. This PR builds on #13555 so it can extend the existing Jobs E2E test class; merge that PR first.

Validation: all six interior cut positions in two-, three-, and four-byte characters reproduce the exact MariaDB error before the fix. Afterward, the existing worker integration suite passes on MariaDB and PostgreSQL: 12 tests, 99 assertions each. Coverage includes an aligned character boundary, short Unicode output, persisted logs, realtime output, and the existing deletion cases. Fixtures pin the expected one-million-byte limit independently of production configuration; changing the production limit in either direction fails the regression. Targeted Pint, PHPStan, Rector, and `git diff --check` pass.

The production event does not include its log payload; this fixes the reproduced truncation defect without assuming every invalid-character event has the same cause.

Fixes [CLOUD-3QXN](https://appwrite.sentry.io/issues/7714009870).
