### PR TITLE
fix: update HTTP for Hyperloop B worker recycling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
         "utopia-php/emails": "0.8.*",
         "utopia-php/dns": "^3.0",
         "utopia-php/dsn": "0.2.1",
-        "utopia-php/http": "^2.0.0-rc30@RC",
+        "utopia-php/http": "^2.0@RC",
         "utopia-php/fetch": "^1.1",
         "utopia-php/validators": "^0.6",
         "utopia-php/image": "0.8.*",

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
         "utopia-php/emails": "0.8.*",
         "utopia-php/dns": "^3.0",
         "utopia-php/dsn": "0.2.1",
-        "utopia-php/http": "^2.0@RC",
+        "utopia-php/http": "^2.0.0-rc30@RC",
         "utopia-php/fetch": "^1.1",
         "utopia-php/validators": "^0.6",
         "utopia-php/image": "0.8.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e01715f2fe81b1e435e075ad4fa9e099",
+    "content-hash": "0b7bd06aa3aae47b07de2256380e974a",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3898,16 +3898,16 @@
         },
         {
             "name": "utopia-php/http",
-            "version": "2.0.0-rc25",
+            "version": "2.0.0-rc30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "54fa5c8a3606110a6d161be93bbbcf0043bbd262"
+                "reference": "11a45a4cc096f3df5a1219d97de96c46573d68af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/54fa5c8a3606110a6d161be93bbbcf0043bbd262",
-                "reference": "54fa5c8a3606110a6d161be93bbbcf0043bbd262",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/11a45a4cc096f3df5a1219d97de96c46573d68af",
+                "reference": "11a45a4cc096f3df5a1219d97de96c46573d68af",
                 "shasum": ""
             },
             "require": {
@@ -3916,9 +3916,9 @@
                 "utopia-php/di": "^0.3",
                 "utopia-php/psr7": "^0.2.0",
                 "utopia-php/servers": "^0.4",
-                "utopia-php/system": "^0.10",
+                "utopia-php/system": "^0.10 || ^0.11",
                 "utopia-php/telemetry": "^0.4",
-                "utopia-php/validators": "^0.6"
+                "utopia-php/validators": "^0.6 || ^1.0"
             },
             "require-dev": {
                 "swoole/ide-helper": "4.8.3"
@@ -3945,9 +3945,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/http/issues",
-                "source": "https://github.com/utopia-php/http/tree/2.0.0-rc25"
+                "source": "https://github.com/utopia-php/http/tree/2.0.0-rc30"
             },
-            "time": "2026-08-27T06:13:20+00:00"
+            "time": "2026-09-09T11:26:49+00:00"
         },
         {
             "name": "utopia-php/image",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b7bd06aa3aae47b07de2256380e974a",
+    "content-hash": "e01715f2fe81b1e435e075ad4fa9e099",
     "packages": [
         {
             "name": "adhocore/jwt",


### PR DESCRIPTION
## What does this PR do?

Update `composer.lock` to `utopia-php/http` `2.0.0-rc30`. The existing `composer.json` constraint already permits this release. Both HTTP entrypoints already use the Hyperloop B preset: this release sets `max_request` to 10,000 so workers periodically exit and release retained process memory. `max_request_grace` remains unset, preserving Swoole's default jitter (10,001–15,000 requests per worker with Swoole 6.2.2).

Appwrite moves from rc25 to rc30, also incorporating the intervening System/Validators compatibility updates. Only the HTTP package changes in the lockfile. No draining or deployment settings change.

## Test Plan

- Passed targeted Composer resolution, `composer validate --no-check-publish`, and `git diff --check`.
- Verified only `utopia-php/http` changed in the resolved package set and the existing stability flags are preserved.
- Upstream HTTP checks and test suite, plus linked platform tests, passed before merge: https://github.com/utopia-php/monorepo/actions/runs/34345326204
- Dependency resolution used `--ignore-platform-reqs`; the full application stack and staging worker-recycling behavior were not tested locally. Application CI and staging validation remain necessary.

## Related PRs and Issues

- https://github.com/utopia-php/monorepo/pull/239
- https://github.com/utopia-php/http/releases/tag/2.0.0-rc30
