### PR TITLE
fix: replace compound x-mapping with constrained unions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,8 @@
         "open-runtimes/sdk-for-php": "0.13.*",
         "utopia-php/schedule": "^0.2.0",
         "utopia-php/usage": "^0.15.0",
-        "utopia-php/query": "0.6.*"
+        "utopia-php/query": "0.6.*",
+        "utopia-php/openapi": "^0.2.4"
     },
     "require-dev": {
         "ext-fileinfo": "*",

--- a/composer.json
+++ b/composer.json
@@ -121,7 +121,7 @@
     },
     "require-dev": {
         "ext-fileinfo": "*",
-        "appwrite/sdk-generator": "^4.0",
+        "appwrite/sdk-generator": "^5.0",
         "brianium/paratest": "7.*",
         "phpunit/phpunit": "12.*",
         "swoole/ide-helper": "6.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "526e32916ce68a221c4bd47a86bf3d22",
+    "content-hash": "2e378c11104aafa142b2bcb92fb61f3a",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -4260,6 +4260,41 @@
             "time": "2026-09-09T05:42:37+00:00"
         },
         {
+            "name": "utopia-php/openapi",
+            "version": "0.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/utopia-php/openapi.git",
+                "reference": "a988ff180b973743339509d040a774ffe48aa906"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/a988ff180b973743339509d040a774ffe48aa906",
+                "reference": "a988ff180b973743339509d040a774ffe48aa906",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=8.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Utopia\\OpenAPI\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Framework-independent OpenAPI 2.0, 3.0, and 3.1 parser with an immutable canonical model",
+            "support": {
+                "issues": "https://github.com/utopia-php/openapi/issues",
+                "source": "https://github.com/utopia-php/openapi/tree/0.2.4"
+            },
+            "time": "2026-09-09T11:17:58+00:00"
+        },
+        {
             "name": "utopia-php/platform",
             "version": "1.0.0-rc20",
             "source": {
@@ -8465,41 +8500,6 @@
                 }
             ],
             "time": "2026-07-03T20:44:34+00:00"
-        },
-        {
-            "name": "utopia-php/openapi",
-            "version": "0.2.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/utopia-php/openapi.git",
-                "reference": "a988ff180b973743339509d040a774ffe48aa906"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/a988ff180b973743339509d040a774ffe48aa906",
-                "reference": "a988ff180b973743339509d040a774ffe48aa906",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "php": ">=8.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Utopia\\OpenAPI\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Framework-independent OpenAPI 2.0, 3.0, and 3.1 parser with an immutable canonical model",
-            "support": {
-                "issues": "https://github.com/utopia-php/openapi/issues",
-                "source": "https://github.com/utopia-php/openapi/tree/0.2.4"
-            },
-            "time": "2026-09-09T11:17:58+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e01715f2fe81b1e435e075ad4fa9e099",
+    "content-hash": "720abded133e594d9b8484b8294171f4",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -5307,16 +5307,16 @@
     "packages-dev": [
         {
             "name": "appwrite/sdk-generator",
-            "version": "4.9.0",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-generator.git",
-                "reference": "888b0ecdc0f755787302b24d3f41b5875f6ef99b"
+                "reference": "8ea7dcd534718ca6acf14be8b4ae10dfc5c9c1fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/888b0ecdc0f755787302b24d3f41b5875f6ef99b",
-                "reference": "888b0ecdc0f755787302b24d3f41b5875f6ef99b",
+                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/8ea7dcd534718ca6acf14be8b4ae10dfc5c9c1fc",
+                "reference": "8ea7dcd534718ca6acf14be8b4ae10dfc5c9c1fc",
                 "shasum": ""
             },
             "require": {
@@ -5326,7 +5326,7 @@
                 "matthiasmullie/minify": "^1.3",
                 "php": ">=8.5",
                 "twig/twig": "^3.28",
-                "utopia-php/openapi": "^0.2.1"
+                "utopia-php/openapi": "^0.2.4"
             },
             "require-dev": {
                 "brianium/paratest": "^7",
@@ -5353,9 +5353,9 @@
             "description": "SDK generator for Appwrite APIs across multiple programming languages and platforms",
             "support": {
                 "issues": "https://github.com/appwrite/sdk-generator/issues",
-                "source": "https://github.com/appwrite/sdk-generator/tree/4.9.0"
+                "source": "https://github.com/appwrite/sdk-generator/tree/5.0.0"
             },
-            "time": "2026-09-07T10:19:46+00:00"
+            "time": "2026-09-09T12:20:07+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -8467,26 +8467,21 @@
         },
         {
             "name": "utopia-php/openapi",
-            "version": "0.2.1",
+            "version": "0.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/openapi.git",
-                "reference": "725109d69e298ae8d88f1ffc05f6d86624233abd"
+                "reference": "a988ff180b973743339509d040a774ffe48aa906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/725109d69e298ae8d88f1ffc05f6d86624233abd",
-                "reference": "725109d69e298ae8d88f1ffc05f6d86624233abd",
+                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/a988ff180b973743339509d040a774ffe48aa906",
+                "reference": "a988ff180b973743339509d040a774ffe48aa906",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "php": ">=8.5"
-            },
-            "require-dev": {
-                "laravel/pint": "^1.0",
-                "phpunit/phpunit": "^13.3",
-                "rector/rector": "^2.0"
             },
             "type": "library",
             "autoload": {
@@ -8501,9 +8496,9 @@
             "description": "Framework-independent OpenAPI 2.0, 3.0, and 3.1 parser with an immutable canonical model",
             "support": {
                 "issues": "https://github.com/utopia-php/openapi/issues",
-                "source": "https://github.com/utopia-php/openapi/tree/0.2.1"
+                "source": "https://github.com/utopia-php/openapi/tree/0.2.4"
             },
-            "time": "2026-09-04T16:56:24+00:00"
+            "time": "2026-09-09T11:17:58+00:00"
         }
     ],
     "aliases": [],

--- a/src/Appwrite/SDK/Specification/Format.php
+++ b/src/Appwrite/SDK/Specification/Format.php
@@ -6,6 +6,7 @@ use Appwrite\SDK\Method;
 use Appwrite\Utopia\Response\Model;
 use Utopia\DI\Container;
 use Utopia\Http\Route;
+use Utopia\OpenAPI\Model\Composition;
 
 abstract class Format
 {
@@ -401,7 +402,7 @@ abstract class Format
      * @param array<Model> $models
      * @return array<string, mixed>
      */
-    protected function getUnion(array $models, string $refPrefix, string $composition = 'oneOf'): array
+    protected function getUnion(array $models, string $refPrefix, Composition $composition = Composition::ONE_OF): array
     {
         $discriminator = $this->getDiscriminator($models, $refPrefix);
         if ($discriminator === null) {
@@ -412,7 +413,7 @@ abstract class Format
         }
 
         return \array_filter([
-            $composition => \array_map(fn (Model $model) => ['$ref' => $refPrefix . $model->getType()], $models),
+            $composition->value => \array_map(fn (Model $model) => ['$ref' => $refPrefix . $model->getType()], $models),
             'discriminator' => $discriminator,
         ]);
     }
@@ -471,7 +472,7 @@ abstract class Format
             }
             $seen[$signature] = true;
 
-            $branches[] = ['allOf' => [
+            $branches[] = [Composition::ALL_OF->value => [
                 ['$ref' => $refPrefix . $model->getType()],
                 [
                     'type' => 'object',
@@ -483,7 +484,7 @@ abstract class Format
 
         // Broad String overlaps Email/Enum/Url/Ip, so these alternatives are
         // inclusive. SDK consumers retain their most-specific-first selection.
-        return ['anyOf' => $branches];
+        return [Composition::ANY_OF->value => $branches];
     }
 
     protected function shouldEmitDefaultForSchema(mixed $default, array $schema): bool
@@ -494,17 +495,17 @@ abstract class Format
 
         // Named enums use titled oneOf branches; open enums additionally
         // accept a free-string branch through anyOf.
-        foreach (['oneOf', 'anyOf'] as $composition) {
-            if (!isset($schema[$composition])) {
+        foreach ([Composition::ONE_OF, Composition::ANY_OF] as $composition) {
+            if (!isset($schema[$composition->value])) {
                 continue;
             }
             $matches = 0;
-            foreach ($schema[$composition] as $branch) {
+            foreach ($schema[$composition->value] as $branch) {
                 if ($this->shouldEmitDefaultForSchema($default, $branch)) {
                     $matches++;
                 }
             }
-            if ($composition === 'oneOf' ? $matches !== 1 : $matches === 0) {
+            if ($composition === Composition::ONE_OF ? $matches !== 1 : $matches === 0) {
                 return false;
             }
         }

--- a/src/Appwrite/SDK/Specification/Format.php
+++ b/src/Appwrite/SDK/Specification/Format.php
@@ -394,16 +394,39 @@ abstract class Format
             ];
         }
 
-        // Single-key failed — try compound discriminator
-        return $this->getCompoundDiscriminator($models, $refPrefix);
+        return null;
+    }
+
+    /**
+     * @param array<Model> $models
+     * @return array<string, mixed>
+     */
+    protected function getUnion(array $models, string $refPrefix, string $composition = 'oneOf'): array
+    {
+        $discriminator = $this->getDiscriminator($models, $refPrefix);
+        if ($discriminator === null) {
+            $compound = $this->getCompoundSchema($models, $refPrefix);
+            if ($compound !== null) {
+                return $compound;
+            }
+        }
+
+        return \array_filter([
+            $composition => \array_map(fn (Model $model) => ['$ref' => $refPrefix . $model->getType()], $models),
+            'discriminator' => $discriminator,
+        ]);
     }
 
     /**
      * @param array<Model> $models
      * @return array<string, mixed>|null
      */
-    private function getCompoundDiscriminator(array $models, string $refPrefix): ?array
+    private function getCompoundSchema(array $models, string $refPrefix): ?array
     {
+        if (\count($models) < 2 || \array_intersect(...\array_map(fn (Model $model) => \array_keys($model->conditions), $models)) === []) {
+            return null;
+        }
+
         $allKeys = [];
         foreach ($models as $model) {
             foreach (\array_keys($model->conditions) as $key) {
@@ -417,9 +440,8 @@ abstract class Format
             return null;
         }
 
-        $primaryKey = $allKeys[0];
-        $primaryMapping = [];
-        $compoundMapping = [];
+        $branches = [];
+        $seen = [];
 
         foreach ($models as $model) {
             $rules = $model->getRules();
@@ -434,37 +456,34 @@ abstract class Format
                     return null;
                 }
 
-                $conditions[$key] = \is_bool($condition) ? ($condition ? 'true' : 'false') : (string) $condition;
+                $conditions[$key] = $condition;
             }
 
             if (empty($conditions)) {
                 return null;
             }
 
-            $ref = $refPrefix . $model->getType();
-            $compoundMapping[$ref] = $conditions;
-
-            // Best-effort single-key mapping — last model with this value wins (fallback)
-            if (isset($conditions[$primaryKey])) {
-                $primaryMapping[$conditions[$primaryKey]] = $ref;
-            }
-        }
-
-        // Verify compound uniqueness
-        $seen = [];
-        foreach ($compoundMapping as $conditions) {
-            $sig = \json_encode($conditions, JSON_THROW_ON_ERROR);
-            if (isset($seen[$sig])) {
+            $signature = $conditions;
+            \ksort($signature);
+            $signature = \json_encode($signature, JSON_THROW_ON_ERROR);
+            if (isset($seen[$signature])) {
                 return null;
             }
-            $seen[$sig] = true;
+            $seen[$signature] = true;
+
+            $branches[] = ['allOf' => [
+                ['$ref' => $refPrefix . $model->getType()],
+                [
+                    'type' => 'object',
+                    'required' => \array_keys($conditions),
+                    'properties' => \array_map(fn (mixed $value) => ['enum' => [$value]], $conditions),
+                ],
+            ]];
         }
 
-        return \array_filter([
-            'propertyName' => $primaryKey,
-            'mapping' => !empty($primaryMapping) ? $primaryMapping : null,
-            'x-mapping' => $compoundMapping,
-        ]);
+        // Broad String overlaps Email/Enum/Url/Ip, so these alternatives are
+        // inclusive. SDK consumers retain their most-specific-first selection.
+        return ['anyOf' => $branches];
     }
 
     protected function shouldEmitDefaultForSchema(mixed $default, array $schema): bool

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -513,10 +513,7 @@ class OpenAPI3 extends Format
                             'description' => $modelDescription,
                             'content' => [
                                 $produces => [
-                                    'schema' => \array_filter([
-                                        'oneOf' => \array_map(fn ($m) => ['$ref' => '#/components/schemas/' . $m->getType()], $model),
-                                        'discriminator' => $this->getDiscriminator($model, '#/components/schemas/'),
-                                    ]),
+                                    'schema' => $this->getUnion($model, '#/components/schemas/'),
                                 ],
                             ],
                         ];
@@ -1210,21 +1207,7 @@ class OpenAPI3 extends Format
                                 throw new \RuntimeException("Unresolved model '{$type}'. Ensure the model is registered.");
                             }, $rule['type']);
 
-                            if ($rule['array']) {
-                                $items = \array_filter([
-                                    'anyOf' => \array_map(function ($type) {
-                                        return ['$ref' => '#/components/schemas/' . $type];
-                                    }, $rule['type']),
-                                    'discriminator' => $this->getDiscriminator($resolvedModels, '#/components/schemas/'),
-                                ]);
-                            } else {
-                                $items = \array_filter([
-                                    'oneOf' => \array_map(function ($type) {
-                                        return ['$ref' => '#/components/schemas/' . $type];
-                                    }, $rule['type']),
-                                    'discriminator' => $this->getDiscriminator($resolvedModels, '#/components/schemas/'),
-                                ]);
-                            }
+                            $items = $this->getUnion($resolvedModels, '#/components/schemas/', $rule['array'] ? 'anyOf' : 'oneOf');
                         } else {
                             $items = [
                                 '$ref' => '#/components/schemas/' . $rule['type'],

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -17,6 +17,7 @@ use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
 use Utopia\Database\Validator\Queries;
 use Utopia\Database\Validator\Spatial;
+use Utopia\OpenAPI\Model\Composition;
 use Utopia\Platform\Enum;
 use Utopia\Validator;
 use Utopia\Validator\ArrayList;
@@ -1207,7 +1208,7 @@ class OpenAPI3 extends Format
                                 throw new \RuntimeException("Unresolved model '{$type}'. Ensure the model is registered.");
                             }, $rule['type']);
 
-                            $items = $this->getUnion($resolvedModels, '#/components/schemas/', $rule['array'] ? 'anyOf' : 'oneOf');
+                            $items = $this->getUnion($resolvedModels, '#/components/schemas/', $rule['array'] ? Composition::ANY_OF : Composition::ONE_OF);
                         } else {
                             $items = [
                                 '$ref' => '#/components/schemas/' . $rule['type'],

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -23,6 +23,8 @@ use Appwrite\Utopia\Response\Model\AlgoScryptModified;
 use Appwrite\Utopia\Response\Model\AlgoSha;
 use Appwrite\Utopia\Response\Model as ResponseModel;
 use Appwrite\Utopia\Response\Model\AttributeLine;
+use Appwrite\Utopia\Response\Model\ColumnEmail;
+use Appwrite\Utopia\Response\Model\ColumnString;
 use Appwrite\Utopia\Response\Model\Error as ErrorModel;
 use Appwrite\Utopia\Response\Model\ErrorDev;
 use Appwrite\Utopia\Response\Model\FrameworkAdapter;
@@ -56,6 +58,10 @@ use Utopia\Database\Validator\Query\Offset;
 use Utopia\Database\Validator\Spatial;
 use Utopia\DI\Container;
 use Utopia\Http\Route;
+use Utopia\OpenAPI\Model\CompositeSchema;
+use Utopia\OpenAPI\Model\Composition;
+use Utopia\OpenAPI\Model\Discriminator;
+use Utopia\OpenAPI\Parser;
 use Utopia\Platform\Enum;
 use Utopia\Validator\AnyOf;
 use Utopia\Validator\ArrayList;
@@ -128,85 +134,36 @@ final class FormatTest extends TestCase
         $this->format = new TestFormat(new Container(), [], [], [], [], ['console' => 0], 'console');
     }
 
-    public static function compoundModels(): \Iterator
-    {
-        yield ['Column'];
-        yield ['Attribute'];
-    }
-
-    #[DataProvider('compoundModels')]
-    public function testCompoundUnionsUseConstrainedReferences(string $kind): void
+    public function testCompoundResponsePreservesOverlappingModelConditions(): void
     {
         Method::$processed = [];
         Method::$errors = [];
-        $models = [];
-        foreach (['Boolean', 'BigInt', 'Integer', 'Float', 'Email', 'Enum', 'URL', 'IP', 'Datetime', 'Relationship', 'Point', 'Line', 'Polygon', 'Varchar', 'Text', 'Mediumtext', 'Longtext', 'String'] as $suffix) {
-            $class = 'Appwrite\\Utopia\\Response\\Model\\' . $kind . $suffix;
-            $models[] = new $class();
-        }
-        $class = 'Appwrite\\Utopia\\Response\\Model\\' . $kind . 'List';
-        $list = new $class();
-        $references = \array_map(fn (ResponseModel $model) => $model->getType(), $models);
-        $routes = [];
-        foreach (['union' => $references, 'list' => $list->getType()] as $name => $response) {
-            $routes[] = (new Route('GET', '/v1/tests/' . $name))
-                ->desc('Get test')
-                ->label('sdk', new Method(
-                    namespace: 'test',
-                    group: null,
-                    name: 'get' . ucfirst($name),
-                    description: 'Get test.',
-                    auth: [AuthType::ADMIN],
-                    responses: [new SDKResponse(code: 200, model: $response)],
-                ));
-        }
-
-        $spec = (new OpenAPI3(new Container(), [], $routes, [...$models, $list], [], ['console' => 0], 'console'))->parse();
-        $unions = [
-            $spec['paths']['/tests/union']['get']['responses']['200']['content']['application/json']['schema'],
-            $spec['components']['schemas'][$list->getType()]['properties'][strtolower($kind) . 's']['items'],
-        ];
-        foreach ($unions as $union) {
-            $this->assertArrayNotHasKey('discriminator', $union);
-            $this->assertArrayNotHasKey('oneOf', $union);
-            $this->assertCount(18, $union['anyOf']);
-            foreach ($union['anyOf'] as $index => $branch) {
-                $this->assertSame('#/components/schemas/' . $models[$index]->getType(), $branch['allOf'][0]['$ref']);
-                $constraints = $branch['allOf'][1];
-                $this->assertSame('object', $constraints['type']);
-                $this->assertSame(array_keys($models[$index]->conditions), $constraints['required']);
-                foreach ($models[$index]->conditions as $property => $value) {
-                    $this->assertSame([$value], $constraints['properties'][$property]['enum']);
-                }
-            }
-        }
-        $this->assertStringNotContainsString('x-mapping', json_encode($spec, JSON_THROW_ON_ERROR));
-    }
-
-    public function testSinglePropertyDiscriminatorsRemainStandard(): void
-    {
-        Method::$processed = [];
-        Method::$errors = [];
-        $models = [new PlatformAndroid(), new PlatformWeb()];
-        $route = (new Route('GET', '/v1/tests/platform'))
-            ->desc('Get platform')
+        $route = (new Route('GET', '/v1/tests/column'))
+            ->desc('Get column')
             ->label('sdk', new Method(
                 namespace: 'test',
                 group: null,
-                name: 'getPlatform',
-                description: 'Get platform.',
+                name: 'getColumn',
+                description: 'Get column.',
                 auth: [AuthType::ADMIN],
-                responses: [new SDKResponse(code: 200, model: array_map(fn (ResponseModel $model) => $model->getType(), $models))],
+                responses: [new SDKResponse(code: 200, model: [Response::MODEL_COLUMN_STRING, Response::MODEL_COLUMN_EMAIL])],
             ));
-        $spec = (new OpenAPI3(new Container(), [], [$route], $models, [], ['console' => 0], 'console'))->parse();
-        $union = $spec['paths']['/tests/platform']['get']['responses']['200']['content']['application/json']['schema'];
-        $this->assertCount(2, $union['oneOf']);
-        $this->assertSame('type', $union['discriminator']['propertyName']);
+        $spec = (new OpenAPI3(new Container(), [], [$route], [new ColumnString(), new ColumnEmail()], [], ['console' => 0], 'console'))->parse();
+        $document = Parser::parse(json_encode($spec, JSON_THROW_ON_ERROR));
+        $union = $document->paths['/tests/column']->operations['get']->responses['200']->content['application/json']->schema;
+
+        $this->assertInstanceOf(CompositeSchema::class, $union);
+        $this->assertSame(Composition::ANY_OF, $union->composition);
+        $this->assertNotInstanceOf(Discriminator::class, $union->discriminator);
         $this->assertSame([
-            'android' => '#/components/schemas/platformAndroid',
-            'web' => '#/components/schemas/platformWeb',
-        ], $union['discriminator']['mapping']);
-        $this->assertArrayNotHasKey('anyOf', $union);
+            ['reference' => '#/components/schemas/columnString', 'conditions' => [
+                ['propertyName' => 'type', 'value' => 'string'],
+            ]],
+            ['reference' => '#/components/schemas/columnEmail', 'conditions' => [
+                ['propertyName' => 'type', 'value' => 'string'],
+                ['propertyName' => 'format', 'value' => 'email'],
+            ]],
+        ], $union->conditionalReferences());
     }
 
     public function testProjectRequestParameterOverrides(): void

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -128,6 +128,86 @@ final class FormatTest extends TestCase
         $this->format = new TestFormat(new Container(), [], [], [], [], ['console' => 0], 'console');
     }
 
+    public static function compoundModels(): array
+    {
+        return [['Column'], ['Attribute']];
+    }
+
+    #[DataProvider('compoundModels')]
+    public function testCompoundUnionsUseConstrainedReferences(string $kind): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+        $models = [];
+        foreach (['Boolean', 'BigInt', 'Integer', 'Float', 'Email', 'Enum', 'URL', 'IP', 'Datetime', 'Relationship', 'Point', 'Line', 'Polygon', 'Varchar', 'Text', 'Mediumtext', 'Longtext', 'String'] as $suffix) {
+            $class = 'Appwrite\\Utopia\\Response\\Model\\' . $kind . $suffix;
+            $models[] = new $class();
+        }
+        $class = 'Appwrite\\Utopia\\Response\\Model\\' . $kind . 'List';
+        $list = new $class();
+        $references = \array_map(fn (ResponseModel $model) => $model->getType(), $models);
+        $routes = [];
+        foreach (['union' => $references, 'list' => $list->getType()] as $name => $response) {
+            $routes[] = (new Route('GET', '/v1/tests/' . $name))
+                ->desc('Get test')
+                ->label('sdk', new Method(
+                    namespace: 'test',
+                    group: null,
+                    name: 'get' . ucfirst($name),
+                    description: 'Get test.',
+                    auth: [AuthType::ADMIN],
+                    responses: [new SDKResponse(code: 200, model: $response)],
+                ));
+        }
+
+        $spec = (new OpenAPI3(new Container(), [], $routes, [...$models, $list], [], ['console' => 0], 'console'))->parse();
+        $unions = [
+            $spec['paths']['/tests/union']['get']['responses']['200']['content']['application/json']['schema'],
+            $spec['components']['schemas'][$list->getType()]['properties'][strtolower($kind) . 's']['items'],
+        ];
+        foreach ($unions as $union) {
+            $this->assertArrayNotHasKey('discriminator', $union);
+            $this->assertArrayNotHasKey('oneOf', $union);
+            $this->assertCount(18, $union['anyOf']);
+            foreach ($union['anyOf'] as $index => $branch) {
+                $this->assertSame('#/components/schemas/' . $models[$index]->getType(), $branch['allOf'][0]['$ref']);
+                $constraints = $branch['allOf'][1];
+                $this->assertSame('object', $constraints['type']);
+                $this->assertSame(array_keys($models[$index]->conditions), $constraints['required']);
+                foreach ($models[$index]->conditions as $property => $value) {
+                    $this->assertSame([$value], $constraints['properties'][$property]['enum']);
+                }
+            }
+        }
+        $this->assertStringNotContainsString('x-mapping', json_encode($spec, JSON_THROW_ON_ERROR));
+    }
+
+    public function testSinglePropertyDiscriminatorsRemainStandard(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+        $models = [new PlatformAndroid(), new PlatformWeb()];
+        $route = (new Route('GET', '/v1/tests/platform'))
+            ->desc('Get platform')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'getPlatform',
+                description: 'Get platform.',
+                auth: [AuthType::ADMIN],
+                responses: [new SDKResponse(code: 200, model: array_map(fn (ResponseModel $model) => $model->getType(), $models))],
+            ));
+        $spec = (new OpenAPI3(new Container(), [], [$route], $models, [], ['console' => 0], 'console'))->parse();
+        $union = $spec['paths']['/tests/platform']['get']['responses']['200']['content']['application/json']['schema'];
+        $this->assertCount(2, $union['oneOf']);
+        $this->assertSame('type', $union['discriminator']['propertyName']);
+        $this->assertSame([
+            'android' => '#/components/schemas/platformAndroid',
+            'web' => '#/components/schemas/platformWeb',
+        ], $union['discriminator']['mapping']);
+        $this->assertArrayNotHasKey('anyOf', $union);
+    }
+
     public function testProjectRequestParameterOverrides(): void
     {
         $createWebPlatform = $this->format->requestParameterConfig(true, false, '', 'project.createWebPlatform', 'hostname');

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -128,9 +128,10 @@ final class FormatTest extends TestCase
         $this->format = new TestFormat(new Container(), [], [], [], [], ['console' => 0], 'console');
     }
 
-    public static function compoundModels(): array
+    public static function compoundModels(): \Iterator
     {
-        return [['Column'], ['Attribute']];
+        yield ['Column'];
+        yield ['Attribute'];
     }
 
     #[DataProvider('compoundModels')]


### PR DESCRIPTION
## Summary

Producer change for [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards), following merged [sdk-generator#1894](https://github.com/appwrite/sdk-generator/pull/1894) and released [SDK-generator 5.0.0](https://github.com/appwrite/sdk-generator/releases/tag/5.0.0).

The consumer was admin-merged as `8ea7dcd534718ca6acf14be8b4ae10dfc5c9c1fc` after all 59 checks passed and Greptile reached 5/5 with zero unresolved threads on reviewed head `137960eca041d842e5bccd8e70fea1564e7b0bec`. The merge tree matches that head. GitHub and Packagist both publish 5.0.0 from this merge.

Update Appwrite's dev dependency from `appwrite/sdk-generator: ^4.0` to `^5.0`; the lock moves 4.9.0 → 5.0.0 and OpenAPI 0.2.1 → 0.2.4. No other package versions changed. OpenAPI `^0.2.4` is also a direct runtime dependency: `Format` uses its `Composition` enum rather than composition-name strings. The lock moves OpenAPI into production packages without changing its version. The broader changes since generator 4.9.0 must also be considered in the eventual Cloud artifact/delta review; the earlier compound-only comparison does not cover that full dependency jump.

Replace compound discriminator `x-mapping` with standard constrained `anyOf` branches. Apply the same union builder to response unions and model-property/item unions. Keep ordinary valid single-property discriminators and unconstrained unions unchanged.

Before:

```yaml
oneOf:
  - $ref: '#/components/schemas/columnString'
  - $ref: '#/components/schemas/columnEmail'
discriminator:
  propertyName: type
  mapping:
    string: '#/components/schemas/columnEmail'
  x-mapping:
    '#/components/schemas/columnString': {type: string}
    '#/components/schemas/columnEmail': {type: string, format: email}
```

After:

```yaml
anyOf:
  - allOf:
      - $ref: '#/components/schemas/columnString'
      - type: object
        required: [type]
        properties:
          type: {enum: [string]}
  - allOf:
      - $ref: '#/components/schemas/columnEmail'
      - type: object
        required: [type, format]
        properties:
          type: {enum: [string]}
          format: {enum: [email]}
```

Broad String overlaps Email/Enum/URL/IP, so these must be inclusive `anyOf` alternatives, not exclusive `oneOf`. There is no lossy compound discriminator or synthetic public model. Referenced models are unchanged; conditions become required singleton-enum constraints. SDK selection remains most-specific-first in the consumer.

## Verification

- `vendor/bin/phpunit tests/unit/SDK/Specification/FormatTest.php`: **42 tests / 248 assertions passed**. At the owner's request, the added tests are reduced to one focused String/Email overlap test. It parses the emitted document and verifies inclusive composition, absent compound discriminator, model identities and selection conditions. No added data provider or separate discriminator test remains.
- `composer lint src/Appwrite/SDK/Specification/Format.php src/Appwrite/SDK/Specification/Format/OpenAPI3.php tests/unit/SDK/Specification/FormatTest.php`: passed.
- `composer refactor:check tests/unit/SDK/Specification/FormatTest.php`: passed.
- `vendor/bin/phpstan analyse src/Appwrite/SDK/Specification/Format.php src/Appwrite/SDK/Specification/Format/OpenAPI3.php --memory-limit=1G`: passed.
- `git diff --check`: passed.
- Enum refactor: the actual producer-emitted fixture document is byte-identical before/after adopting `Composition`. Full configured Rector and targeted PHPStan pass.
- Regression check: restoring pre-change producer files makes the compound-union tests fail; restored implementation passes.
- Cross-repository check: OpenAPI 0.2.4 parsed an actual locally emitted fixture document and recognized all four response/list-item constrained unions, each with 18 references.
- Released generator: **87 tests / 1,132 assertions / 4 existing skips**, and PHP mock-API e2e **1 test / 148 assertions**. Runtime calls check overlapping specialization, broad fallback, invalid selection fields and ignored `x-mapping`; generated-source assertions were removed during review. Candidate specs generated with the no-`x-mapping` reader match saved pre-removal output for 17 targets. That broad comparison uses a local transformation of pinned canonical specs, not a full Cloud build of this producer; details are in the generator PR.
- After the dependency update, reran the 42 producer tests and all targeted lint/Rector/PHPStan checks successfully. `composer validate --no-check-publish` passes. The installed released generator 5.0.0 successfully generated a PHP SDK from an actual producer-emitted fixture document; every generated PHP source file passes `php -l`. Dependencies were installed locally with `--ignore-platform-reqs --no-scripts --no-plugins`; this is not full-stack runtime verification.

Backend/schema output only; screenshots are not applicable.

## Remaining merge/publication gates

The owner explicitly requested **no `x-mapping` fallback in the generator** and support scoped to the string conditions currently needed in `appwrite/specs`. The generator PR removes that reader entirely. Published old compound specs therefore require coordinated migration; they are not claimed compatible with the new reader.

- [x] Generator consumer reviewed, all 59 CI checks passed, merged and released as 5.0.0; release availability verified.
- [x] Update Appwrite's generator dependency/lock and verify the installed release against locally emitted fixture specs.
- [ ] Verify deployed Vibes support and coordinate consumer upgrades before merging this producer switch.
- [ ] Run Cloud `push=false` generation and inspect the actual artifacts/delta before canonical publication.
- [ ] Obtain separate approval to publish canonical specs and coordinate the generator upgrade.

OpenAPI 0.2.4 and SDK-generator 5.0.0 are released; Vibes support is merged separately. This PR does not directly edit `appwrite/specs`, publish specs, deploy the generator to Cloud, or release Appwrite. Unrelated strict full-document validation failures remain deferred, not passing. No full Cloud generation, deployed-consumer, or all-language runtime claim is made here.
