### PR TITLE
fix(realtime): upgrade websocket to 2.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,7 @@
         "utopia-php/user-agent": "0.1.*",
         "mustangostang/spyc": "0.6.*",
         "utopia-php/vcs": "5.*.*",
-        "utopia-php/websocket": "2.0.0",
+        "utopia-php/websocket": "2.0.2",
         "dragonmantank/cron-expression": "3.4.*",
         "chillerlan/php-qrcode": "4.3.*",
         "adhocore/jwt": "1.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e01715f2fe81b1e435e075ad4fa9e099",
+    "content-hash": "04f63b4ed41918b8864f06e97a56f26f",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -5118,28 +5118,29 @@
         },
         {
             "name": "utopia-php/websocket",
-            "version": "2.0.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/websocket.git",
-                "reference": "291980bc9ed112927e81a0db8600f122ffd7aab0"
+                "reference": "d57635275e6db507adefa32f930f13eeebff5dfd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/websocket/zipball/291980bc9ed112927e81a0db8600f122ffd7aab0",
-                "reference": "291980bc9ed112927e81a0db8600f122ffd7aab0",
+                "url": "https://api.github.com/repos/utopia-php/websocket/zipball/d57635275e6db507adefa32f930f13eeebff5dfd",
+                "reference": "d57635275e6db507adefa32f930f13eeebff5dfd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0"
             },
             "require-dev": {
-                "laravel/pint": "^1.15",
-                "phpstan/phpstan": "^1.12",
-                "phpunit/phpunit": "^9.5.5",
                 "swoole/ide-helper": "5.1.2",
-                "textalk/websocket": "1.5.2",
-                "workerman/workerman": "4.1.*"
+                "workerman/workerman": "^4.1 || ^5.0"
+            },
+            "suggest": {
+                "ext-pcntl": "Required to run the Workerman server adapter.",
+                "ext-swoole": "Required to use the Swoole client and server adapter.",
+                "workerman/workerman": "Required to use the Workerman server adapter."
             },
             "type": "library",
             "autoload": {
@@ -5161,9 +5162,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/websocket/issues",
-                "source": "https://github.com/utopia-php/websocket/tree/2.0.0"
+                "source": "https://github.com/utopia-php/websocket/tree/2.0.2"
             },
-            "time": "2026-08-28T08:23:09+00:00"
+            "time": "2026-09-09T12:33:02+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
## What does this PR do?

Upgrade `utopia-php/websocket` from 2.0.0 to [2.0.2](https://github.com/utopia-php/websocket/releases/tag/2.0.2) in the manifest and lockfile. Only this dependency changes.

The Swoole adapter now defaults to a five-second timeout for each full-buffer send wait and resets connections after failed pushes. This releases stalled send coroutines and retained payloads, including the closed-connection leak reported in swoole/swoole-src#6196. The existing adapter construction picks up the default automatically. Clients whose connection is reset must reconnect and refresh state for missed events.

## Test Plan

- `composer validate --no-check-publish` passes with version-pin warnings.
- Targeted Composer update changes only WebSocket; Composer reports no security advisories.
- `composer install --dry-run --no-scripts --no-interaction --ignore-platform-req=ext-scrypt` passes. The local host lacks scrypt; no platform requirements were removed from the project.
- `git diff --check` passes.
- The released library passed its unit and E2E suites, including stalled sends, abrupt disconnects, payload recovery and healthy replacement connections: utopia-php/monorepo#240.
- Application realtime E2E coverage runs in CI; the full application stack was not run locally for this dependency-only change.

## Related PRs and Issues

- utopia-php/monorepo#240
- Cloud integration: appwrite-labs/cloud#5738
- swoole/swoole-src#6196
- Supersedes the proposed dependency integration in #13415 with the released timeout fix.

## Checklist

- [x] Have you read the Contributing Guidelines?
- [x] No API metadata or generated specs change.
