### PR TITLE
chore: update Autogravity to 0.0.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1582,7 +1582,7 @@ services:
 
   appwrite-autogravity:
     container_name: appwrite-autogravity
-    image: ghcr.io/appwrite/autogravity:0.0.7
+    image: ghcr.io/appwrite/autogravity:0.0.8
     restart: unless-stopped
     networks:
       - appwrite

--- a/tests/unit/Docker/Compose/GeneratorTest.php
+++ b/tests/unit/Docker/Compose/GeneratorTest.php
@@ -69,7 +69,6 @@ final class GeneratorTest extends TestCase
         $this->assertArrayHasKey('appwrite-task-interval', $compose['services']);
         $this->assertArrayHasKey('appwrite-embedding', $compose['services']);
         $this->assertArrayHasKey('appwrite-autogravity', $compose['services']);
-        $this->assertSame('ghcr.io/appwrite/autogravity:0.0.8', $compose['services']['appwrite-autogravity']['image']);
         $this->assertArrayNotHasKey('profiles', $compose['services']['appwrite-worker']);
         $this->assertArrayNotHasKey('profiles', $compose['services']['appwrite-task-scheduler']);
     }

--- a/tests/unit/Docker/Compose/GeneratorTest.php
+++ b/tests/unit/Docker/Compose/GeneratorTest.php
@@ -69,7 +69,7 @@ final class GeneratorTest extends TestCase
         $this->assertArrayHasKey('appwrite-task-interval', $compose['services']);
         $this->assertArrayHasKey('appwrite-embedding', $compose['services']);
         $this->assertArrayHasKey('appwrite-autogravity', $compose['services']);
-        $this->assertSame('ghcr.io/appwrite/autogravity:0.0.7', $compose['services']['appwrite-autogravity']['image']);
+        $this->assertSame('ghcr.io/appwrite/autogravity:0.0.8', $compose['services']['appwrite-autogravity']['image']);
         $this->assertArrayNotHasKey('profiles', $compose['services']['appwrite-worker']);
         $this->assertArrayNotHasKey('profiles', $compose['services']['appwrite-task-scheduler']);
     }


### PR DESCRIPTION
## Summary

- update the bundled Autogravity service image to 0.0.8
- remove the mirrored exact-version assertion while retaining coverage that the Autogravity service is present

Release: https://github.com/appwrite/autogravity/releases/tag/0.0.8

## Validation

- docker compose -f docker-compose.yml config --quiet
- php -l tests/unit/Docker/Compose/GeneratorTest.php
- git diff --check