### PR TITLE
fix: subscribe manual builds to artifact callbacks

### DIFF
--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -435,12 +435,9 @@ readonly class Deployments
         // Two terminal callbacks: exit carries the code (fires before
         // post-job artifacts), complete confirms artifact delivery — the
         // worker joins them, so readiness holds on any storage strategy.
-        // Artifact callbacks carry the source-size stat, the site manifest
-        // and the outcome of a remote device's output upload.
-        $events = [CallbackEvent::Log, CallbackEvent::Exit, CallbackEvent::Complete];
-        if ($source !== null || $isSite || $output['artifacts'] !== []) {
-            $events[] = CallbackEvent::Artifact;
-        }
+        // Manual uploads need artifact callbacks too: extraction can fail
+        // before the worker starts and produces any build output.
+        $events = [CallbackEvent::Log, CallbackEvent::Exit, CallbackEvent::Complete, CallbackEvent::Artifact];
 
         return [
             'id' => static::id($projectId, $deploymentId),

--- a/tests/unit/Deployment/UploadCallbacksTest.php
+++ b/tests/unit/Deployment/UploadCallbacksTest.php
@@ -17,7 +17,7 @@ use Utopia\Psr7\Stream;
 
 final class UploadCallbacksTest extends TestCase
 {
-    public function testManualUploadReceivesExtractionFailures(): void
+    public function testManualUploadSubscribesToArtifactCallbacks(): void
     {
         $previousKey = getenv('_APP_OPENSSL_KEY_V1');
         putenv('_APP_OPENSSL_KEY_V1=unit-test-key');

--- a/tests/unit/Deployment/UploadCallbacksTest.php
+++ b/tests/unit/Deployment/UploadCallbacksTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Deployment;
+
+use Appwrite\Deployment\Deployments;
+use OpenRuntimes\Orchestrator\Jobs;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Utopia\Config\Config;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Psr7\Response;
+use Utopia\Psr7\Stream;
+
+final class UploadCallbacksTest extends TestCase
+{
+    public function testManualUploadReceivesExtractionFailures(): void
+    {
+        $previousKey = getenv('_APP_OPENSSL_KEY_V1');
+        putenv('_APP_OPENSSL_KEY_V1=unit-test-key');
+        try {
+            $deployment = new Document(['$id' => 'deployment', '$sequence' => '1', 'type' => 'manual', 'buildCommands' => 'npm ci']);
+            $database = $this->createStub(Database::class);
+            $database->method('updateDocument')->willReturnCallback(static function (string $collection, string $id, Document $update) use ($deployment): Document {
+                $deployment->setAttributes($update->getArrayCopy());
+                return clone $deployment;
+            });
+            $database->method('updateDocuments')->willReturnCallback(static function (string $collection, Document $update) use ($deployment): int {
+                $deployment->setAttributes($update->getArrayCopy());
+                return 1;
+            });
+            $database->method('getDocument')->willReturnCallback(static fn () => clone $deployment);
+            $requests = [];
+            $client = $this->createStub(ClientInterface::class);
+            $client->method('sendRequest')->willReturnCallback(static function (RequestInterface $request) use (&$requests): Response {
+                $requests[] = json_decode((string) $request->getBody(), true, flags: JSON_THROW_ON_ERROR);
+                return new Response(202, body: new Stream('{"id":"build","status":"accepted"}'));
+            });
+            $deployments = new Deployments(new Jobs($client), $database, new Document(['$id' => 'project', 'region' => 'default']), ['apiHostname' => 'localhost']);
+            $result = $deployments->createFromUpload(new Document([
+                '$id' => 'function', '$collection' => 'functions', 'runtime' => array_key_first(Config::getParam('runtimes-v2')),
+            ]), clone $deployment);
+
+            $this->assertSame('waiting', $result->getAttribute('status'));
+            $this->assertCount(1, $requests);
+            // The real SDK serializes the callback filter sent to the service;
+            // without this event a failed pre-job extraction is never delivered.
+            $this->assertContains('orchestrator.job.artifact', $requests[0]['callback']['events']);
+            $this->assertSame('deployment', $requests[0]['meta']['deploymentId']);
+        } finally {
+            putenv($previousKey === false ? '_APP_OPENSSL_KEY_V1' : '_APP_OPENSSL_KEY_V1=' . $previousKey);
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Always subscribe build jobs to artifact callbacks. A manually uploaded function using local build storage previously omitted this subscription, so a source extraction failure before the worker started could not reach the deployment handler. Remote output uploads, templates, and sites retain their existing subscriptions.

## Test Plan

- A regression drives `createFromUpload()` through the real orchestrator PHP SDK, captures the outgoing HTTP request, and verifies that the queued deployment subscribes to artifact failures.
- The focused test passes on the current main base; it was observed failing with the subscription change removed before rebasing.
- Together with the Cloud companion, 15 PHP tests / 65 assertions pass using installed local dependencies and a focused bootstrap. Pint passes for changed PHP files.
- No cluster E2E or staging deployment was performed. The cloud-to-orchestrator-to-Kubernetes seam has not been exercised end to end.

## Related PRs and Issues

- Orchestrator: https://github.com/open-runtimes/orchestrator/pull/107
- Appwrite CE: https://github.com/appwrite/appwrite/pull/13581
- Cloud: https://github.com/appwrite-labs/cloud/pull/5743

## Checklist

- [x] Have you read the Contributing Guidelines?
- [ ] API metadata/spec updates (not applicable: no HTTP metadata changes).
