### PR TITLE
chore: upgrade utopia-php/auth to ^0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "utopia-php/abuse": "2.0.*",
         "utopia-php/agents": "2.*",
         "utopia-php/audit": "^4.0",
-        "utopia-php/auth": "^0.10",
+        "utopia-php/auth": "^0.11",
         "utopia-php/balancer": "0.4.*",
         "utopia-php/cache": "^5.0.0",
         "utopia-php/cdn": "^0.0.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e378c11104aafa142b2bcb92fb61f3a",
+    "content-hash": "984fc11f3580c942033753eba0f5ee6b",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -2930,16 +2930,16 @@
         },
         {
             "name": "utopia-php/auth",
-            "version": "0.10.1",
+            "version": "0.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/auth.git",
-                "reference": "0f1a342bceebc2659736e52a4496daf24ca4954c"
+                "reference": "cf89893531e39f98058b75fb86683770a9d79b64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/auth/zipball/0f1a342bceebc2659736e52a4496daf24ca4954c",
-                "reference": "0f1a342bceebc2659736e52a4496daf24ca4954c",
+                "url": "https://api.github.com/repos/utopia-php/auth/zipball/cf89893531e39f98058b75fb86683770a9d79b64",
+                "reference": "cf89893531e39f98058b75fb86683770a9d79b64",
                 "shasum": ""
             },
             "require": {
@@ -2982,10 +2982,10 @@
                 "security"
             ],
             "support": {
-                "source": "https://github.com/utopia-php/auth/tree/0.10.1",
+                "source": "https://github.com/utopia-php/auth/tree/0.11.1",
                 "issues": "https://github.com/utopia-php/auth/issues"
             },
-            "time": "2026-07-23T07:34:27+00:00"
+            "time": "2026-09-09T15:02:50+00:00"
         },
         {
             "name": "utopia-php/balancer",


### PR DESCRIPTION
## Summary

Upgrade the `utopia-php/auth` requirement from `^0.10` to `^0.11` (installed 0.11.1).

## Why it is safe

The `0.10.2..0.11.1` range is **additive only**. It adds the OAuth2 `AuthorizationDetails` reader and the `AuthorizationDetail` enum ([utopia-php/monorepo #242](https://github.com/utopia-php/monorepo/pull/242), [#243](https://github.com/utopia-php/monorepo/pull/243)); no existing class changed:

```
docs/oauth2.md
src/Auth/Enums/AuthorizationDetail.php
src/Auth/OAuth2/AuthorizationDetails.php
tests/Auth/OAuth2/AuthorizationDetailsTest.php
```

So no server-ce source needs updating, and the lock change is limited to `utopia-php/auth` (0.10.1 → 0.11.1), regenerated with `--minimal-changes`.

## Why now

Unblocks consumers that read a token's RFC 9396 `authorization_details` through the new reader — in particular the Appwrite Cloud OAuth2 access-token authorization path, which currently reimplements that grant matching inline.

## Verification

- `composer update utopia-php/auth --minimal-changes`: lock diff is auth-only.
- Auth unit suite passes against 0.11.1: `_APP_OPENSSL_KEY_V1=... vendor/bin/phpunit tests/unit/Auth` → 85 tests, 582 assertions, OK.
- No source changes in this PR (manifest + lock only), so lint/static analysis are unaffected.
