### PR TITLE
Enforce the self-hosted organization limit per instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,6 +544,18 @@ jobs:
             sleep 1
           done
 
+      - name: Test first organization creation
+        if: matrix.service.name == 'Teams'
+        timeout-minutes: 2
+        run: |
+          # Health/version can respond before the platform schema is initialized.
+          while [ "$(docker compose exec -T appwrite curl -s -o /dev/null -w '%{http_code}' -H 'X-Appwrite-Project: console' http://appwrite/v1/account)" != "401" ]; do
+            sleep 1
+          done
+          docker compose exec -T -e _APP_E2E_FRESH_INSTANCE=enabled \
+            -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}" \
+            appwrite test tests/e2e/Services/Teams/TeamsConsoleClientTest.php --filter=testCreateOrganization
+
       - name: Run tests
         timeout-minutes: 15
         run: |

--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -1510,6 +1510,11 @@ return [
         'description' => 'When using organization API key, make sure to pass x-appwrite-organization header with your organization ID.',
         'code' => 403,
     ],
+    Exception::ORGANIZATION_CREATION_PROHIBITED => [
+        'name' => Exception::ORGANIZATION_CREATION_PROHIBITED,
+        'description' => 'This self-hosted instance already has an organization. Ask an organization owner to invite you instead.',
+        'code' => 403,
+    ],
     Exception::PROJECT_ID_MISSING => [
         'name' => Exception::PROJECT_ID_MISSING,
         'description' => 'When using project API key, make sure to pass x-appwrite-project header with your project ID.',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -266,7 +266,7 @@ services:
         max-file: "5"
         max-size: 10m
     container_name: appwrite-console
-    image: appwrite/new:1.1.16
+    image: appwrite/new:1.1.72
     restart: unless-stopped
     networks:
       - appwrite

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -130,6 +130,7 @@ class Exception extends \Exception
     public const string TEAM_ALREADY_EXISTS = 'team_already_exists';
 
     public const string ORGANIZATION_ID_MISSING = 'organization_id_missing';
+    public const string ORGANIZATION_CREATION_PROHIBITED = 'organization_creation_prohibited';
 
     /** Console */
     public const string RESOURCE_ALREADY_EXISTS = 'resource_already_exists';

--- a/src/Appwrite/Platform/Modules/Teams/Http/Teams/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Teams/Create.php
@@ -20,7 +20,10 @@ use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\Key;
+use Utopia\Lock\Distributed;
+use Utopia\Lock\Exception\Contention;
 use Utopia\Platform\Scope\HTTP;
+use Utopia\Pools\Group;
 use Utopia\Validator\ArrayList;
 use Utopia\Validator\Text;
 
@@ -65,19 +68,29 @@ class Create extends Action
             ->inject('dbForProject')
             ->inject('authorization')
             ->inject('queueForEvents')
+            ->inject('project')
+            ->inject('pools')
             ->callback($this->action(...));
     }
 
-    public function action(string $teamId, string $name, array $roles, Response $response, User $user, Database $dbForProject, Authorization $authorization, Event $queueForEvents)
+    public function action(string $teamId, string $name, array $roles, Response $response, User $user, Database $dbForProject, Authorization $authorization, Event $queueForEvents, Document $project, Group $pools)
     {
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
         $isAppUser = $user->isKey($authorization->getRoles());
 
         $teamId = $teamId == 'unique()' ? ID::unique() : $teamId;
 
-        try {
-            // The seeded total only holds if the owner membership lands with the team
-            $team = $dbForProject->withTransaction(function () use ($dbForProject, $authorization, $teamId, $name, $roles, $user, $isPrivilegedUser, $isAppUser) {
+        $create = function () use ($dbForProject, $authorization, $teamId, $name, $roles, $user, $isPrivilegedUser, $isAppUser, $project) {
+            // The seeded total only holds if the owner membership lands with the team.
+            return $dbForProject->withTransaction(function () use ($dbForProject, $authorization, $teamId, $name, $roles, $user, $isPrivilegedUser, $isAppUser, $project) {
+                if ($project->getId() === 'console') {
+                    $organization = $authorization->skip(fn () => $dbForProject->findOne('teams'));
+
+                    if (!$organization->isEmpty()) {
+                        throw new Exception(Exception::ORGANIZATION_CREATION_PROHIBITED);
+                    }
+                }
+
                 $team = $authorization->skip(fn () => $dbForProject->createDocument('teams', new Document([
                     '$id' => $teamId,
                     '$permissions' => [
@@ -125,6 +138,25 @@ class Create extends Action
 
                 return $team;
             });
+        };
+
+        try {
+            if ($project->getId() === 'console') {
+                if ($user->isEmpty()) {
+                    throw new Exception(Exception::USER_UNAUTHORIZED);
+                }
+
+                // Serialize the instance-wide check and commit across accounts and adapters.
+                // Unlike best-effort request locks, failure must not bypass this limit.
+                $team = $pools->get('lock')->use(fn (\Redis $redis) => (new Distributed(
+                    $redis,
+                    'console:organizations:create',
+                ))->withLock($create, timeout: 3.0));
+            } else {
+                $team = $create();
+            }
+        } catch (Contention $th) {
+            throw new Exception(Exception::GENERAL_RESOURCE_LOCKED);
         } catch (Duplicate $th) {
             throw new Exception(Exception::TEAM_ALREADY_EXISTS);
         }

--- a/tests/e2e/General/AbuseTest.php
+++ b/tests/e2e/General/AbuseTest.php
@@ -39,7 +39,7 @@ final class AbuseTest extends Scope
 
         $projectId = $increasedLimitProjects[0];
 
-        $team = $this->client->call(Client::METHOD_POST, '/teams', [
+        $team = $this->createTeamFixture([
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
             'cookie' => 'a_session_console=' . $this->getRoot()['session'],
@@ -49,7 +49,7 @@ final class AbuseTest extends Scope
             'name' => 'Increased Limit Team',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
 
         $project = $this->client->call(Client::METHOD_POST, '/projects', [
             'origin' => 'http://localhost',

--- a/tests/e2e/Scopes/ProjectCustom.php
+++ b/tests/e2e/Scopes/ProjectCustom.php
@@ -37,40 +37,21 @@ trait ProjectCustom
      */
     protected function createNewProject(): array
     {
-        // Small delay to ensure session is fully propagated under parallel load
-        usleep(100000); // 100ms
-
         $maxRetries = 5;
-        $team = null;
-        $teamId = ID::unique();
+        $team = $this->createTeamFixture([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'cookie' => 'a_session_console=' . $this->getRoot()['session'],
+            'x-appwrite-project' => 'console',
+        ], [
+            'teamId' => ID::unique(),
+            'name' => 'Demo Project Team',
+        ]);
 
-        for ($i = 0; $i < $maxRetries; $i++) {
-            $team = $this->client->call(Client::METHOD_POST, '/teams', [
-                'origin' => 'http://localhost',
-                'content-type' => 'application/json',
-                'cookie' => 'a_session_console=' . $this->getRoot()['session'],
-                'x-appwrite-project' => 'console',
-            ], [
-                'teamId' => $teamId,
-                'name' => 'Demo Project Team',
-            ]);
-
-            if ($team['headers']['status-code'] === 201 || $team['headers']['status-code'] === 409) {
-                break;
-            }
-
-            if ($team['headers']['status-code'] === 401 && $i < $maxRetries - 1) {
-                \usleep(500000); // 500ms delay before retry
-                continue;
-            }
-        }
-
-        $this->assertContains($team['headers']['status-code'], [201, 409], 'Team creation failed with status: ' . $team['headers']['status-code']);
-        if ($team['headers']['status-code'] === 201) {
-            $this->assertEquals('Demo Project Team', $team['body']['name']);
-            $this->assertNotEmpty($team['body']['$id']);
-            $teamId = $team['body']['$id'];
-        }
+        $this->assertEquals(200, $team['headers']['status-code']);
+        $this->assertEquals('Demo Project Team', $team['body']['name']);
+        $this->assertNotEmpty($team['body']['$id']);
+        $teamId = $team['body']['$id'];
 
         $project = null;
         for ($i = 0; $i < $maxRetries; $i++) {

--- a/tests/e2e/Scopes/Scope.php
+++ b/tests/e2e/Scopes/Scope.php
@@ -4,11 +4,21 @@ declare(strict_types=1);
 
 namespace Tests\E2E\Scopes;
 
+use Appwrite\Database\Factory;
 use Appwrite\Tests\Async;
 use Appwrite\Tests\Retryable;
 use PHPUnit\Framework\TestCase;
 use Tests\E2E\Client;
+use Utopia\Cache\Adapter\Pool as CachePool;
+use Utopia\Cache\Adapter\Sharding;
+use Utopia\Cache\Cache;
+use Utopia\Config\Config;
+use Utopia\Database\DateTime;
+use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
+use Utopia\Database\Helpers\Permission;
+use Utopia\Database\Helpers\Role;
+use Utopia\Database\Validator\Authorization;
 use Utopia\System\System;
 
 abstract class Scope extends TestCase
@@ -43,6 +53,90 @@ abstract class Scope extends TestCase
     protected function tearDown(): void
     {
         $this->client = null;
+    }
+
+    /**
+     * Seed a pre-existing console organization for tests of projects, permissions,
+     * memberships, and legacy multi-org access. This is database fixture setup,
+     * not a successful POST /teams: the returned response is a real GET (200).
+     * Application teams still use the public create API (201).
+     */
+    protected function createTeamFixture(array $headers, array $params): array
+    {
+        if (($headers['x-appwrite-project'] ?? '') !== 'console') {
+            return $this->client->call(Client::METHOD_POST, '/teams', $headers, $params);
+        }
+
+        // Read console fixtures as their owner, not in project admin mode.
+        unset($headers['x-appwrite-mode']);
+        $account = [];
+        $this->assertEventually(function () use ($headers, &$account) {
+            $account = $this->client->call(Client::METHOD_GET, '/account', $headers);
+            $this->assertSame(200, $account['headers']['status-code']);
+        }, 3_000, 100);
+
+        $teamId = ($params['teamId'] ?? 'unique()') === 'unique()' ? ID::unique() : $params['teamId'];
+        $seed = function () use ($account, $params, $teamId) {
+            global $register;
+            $pools = $register->get('pools');
+            $cache = new Cache(new Sharding(array_map(
+                fn (string $name) => new CachePool($pools->get($name)),
+                Config::getParam('pools-cache', []),
+            )));
+            $authorization = new Authorization();
+            $database = (new Factory($pools, $cache, $authorization))->platform();
+
+            $authorization->skip(function () use ($database, $account, $params, $teamId) {
+                $database->withTransaction(function () use ($database, $account, $params, $teamId) {
+                    $user = $database->getDocument('users', $account['body']['$id']);
+                    $team = $database->createDocument('teams', new Document([
+                        '$id' => $teamId,
+                        '$permissions' => [
+                            Permission::read(Role::team($teamId)),
+                            Permission::update(Role::team($teamId, 'owner')),
+                            Permission::delete(Role::team($teamId, 'owner')),
+                        ],
+                        'name' => $params['name'],
+                        'total' => 1,
+                        'prefs' => new \stdClass(),
+                        'search' => $teamId . ' ' . $params['name'],
+                    ]));
+                    $roles = array_values(array_unique([...($params['roles'] ?? []), 'owner']));
+                    $membershipId = ID::unique();
+                    $database->createDocument('memberships', new Document([
+                        '$id' => $membershipId,
+                        '$permissions' => [
+                            Permission::read(Role::user($user->getId())),
+                            Permission::read(Role::team($teamId)),
+                            Permission::update(Role::user($user->getId())),
+                            Permission::update(Role::team($teamId, 'owner')),
+                            Permission::delete(Role::user($user->getId())),
+                            Permission::delete(Role::team($teamId, 'owner')),
+                        ],
+                        'userId' => $user->getId(),
+                        'userInternalId' => $user->getSequence(),
+                        'teamId' => $teamId,
+                        'teamInternalId' => $team->getSequence(),
+                        'roles' => $roles,
+                        'invited' => DateTime::now(),
+                        'joined' => DateTime::now(),
+                        'confirm' => true,
+                        'secret' => '',
+                        'search' => $membershipId . ' ' . $user->getId(),
+                    ]));
+                });
+                $database->purgeCachedDocument('users', $account['body']['$id']);
+            });
+        };
+        if (\Swoole\Coroutine::getCid() >= 0) {
+            $seed();
+        } else {
+            \Swoole\Coroutine\run($seed);
+        }
+
+        $response = $this->client->call(Client::METHOD_GET, '/teams/' . $teamId, $headers);
+        $this->assertSame(200, $response['headers']['status-code']);
+        return $response;
     }
 
     /**

--- a/tests/e2e/Services/Account/AccountConsoleClientTest.php
+++ b/tests/e2e/Services/Account/AccountConsoleClientTest.php
@@ -88,7 +88,7 @@ final class AccountConsoleClientTest extends Scope
         $session = $response['cookies']['a_session_' . $this->getProject()['$id']];
 
         // Create team — user becomes sole owner and only member
-        $team = $this->client->call(Client::METHOD_POST, '/teams', [
+        $team = $this->createTeamFixture([
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
@@ -97,7 +97,7 @@ final class AccountConsoleClientTest extends Scope
             'teamId' => 'unique()',
             'name' => 'myteam'
         ]);
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
 
         // Account deletion should succeed even with active membership
         $response = $this->client->call(Client::METHOD_DELETE, '/account', array_merge([

--- a/tests/e2e/Services/Organization/ProjectsBase.php
+++ b/tests/e2e/Services/Organization/ProjectsBase.php
@@ -24,21 +24,14 @@ trait ProjectsBase
         }
 
         $teamId = ID::unique();
-        $team = null;
-        for ($i = 0; $i < 3; $i++) {
-            $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
-                'content-type' => 'application/json',
-                'x-appwrite-project' => $this->getProject()['$id'],
-            ], $this->getHeaders()), [
-                'teamId' => $teamId,
-                'name' => 'Organization Test',
-            ]);
-            if (\in_array($team['headers']['status-code'], [201, 409])) {
-                break;
-            }
-            \usleep(500000);
-        }
-        $this->assertContains($team['headers']['status-code'], [201, 409], 'Setup organization (team) failed');
+        $team = $this->createTeamFixture(array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'teamId' => $teamId,
+            'name' => 'Organization Test',
+        ]);
+        $this->assertEquals(200, $team['headers']['status-code'], 'Setup organization (team) failed');
 
         self::$cachedOrganization = [
             'teamId' => $team['body']['$id'] ?? $teamId,
@@ -213,14 +206,14 @@ trait ProjectsBase
         /**
          * Test for FAILURE - project from different organization
          */
-        $otherTeam = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $otherTeam = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
             'teamId' => ID::unique(),
             'name' => 'Other Organization',
         ]);
-        $this->assertContains($otherTeam['headers']['status-code'], [201, 409]);
+        $this->assertContains($otherTeam['headers']['status-code'], [200]);
         $otherTeamId = $otherTeam['body']['$id'] ?? $otherTeam['body']['teamId'];
 
         $otherProject = $this->client->call(Client::METHOD_POST, '/v1/organization/projects', array_merge([

--- a/tests/e2e/Services/Project/OAuthGitHubIntegrationTest.php
+++ b/tests/e2e/Services/Project/OAuthGitHubIntegrationTest.php
@@ -34,11 +34,11 @@ final class OAuthGitHubIntegrationTest extends Scope
         ];
 
         // Step 1: Create new organization (team)
-        $team = $this->client->call(Client::METHOD_POST, '/teams', $consoleHeaders, [
+        $team = $this->createTeamFixture($consoleHeaders, [
             'teamId' => ID::unique(),
             'name' => 'GitHub OAuth Org ' . uniqid(),
         ]);
-        $this->assertSame(201, $team['headers']['status-code']);
+        $this->assertSame(200, $team['headers']['status-code']);
         $teamId = $team['body']['$id'];
 
         // Step 2: Create new project

--- a/tests/e2e/Services/Project/ProjectConsoleClientTest.php
+++ b/tests/e2e/Services/Project/ProjectConsoleClientTest.php
@@ -141,12 +141,12 @@ final class ProjectConsoleClientTest extends Scope
 
     protected function createTeam(string $name): array
     {
-        $response = $this->client->call(Client::METHOD_POST, '/teams', $this->getConsoleSessionHeaders(), [
+        $response = $this->createTeamFixture($this->getConsoleSessionHeaders(), [
             'teamId' => ID::unique(),
             'name' => $name,
         ]);
 
-        $this->assertSame(201, $response['headers']['status-code']);
+        $this->assertSame(200, $response['headers']['status-code']);
         $this->assertSame($name, $response['body']['name']);
         $this->assertNotEmpty($response['body']['$id']);
 

--- a/tests/e2e/Services/Projects/ProjectsBase.php
+++ b/tests/e2e/Services/Projects/ProjectsBase.php
@@ -27,21 +27,14 @@ trait ProjectsBase
         }
 
         $teamId = ID::unique();
-        $team = null;
-        for ($i = 0; $i < 3; $i++) {
-            $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
-                'content-type' => 'application/json',
-                'x-appwrite-project' => $this->getProject()['$id'],
-            ], $this->getHeaders()), [
-                'teamId' => $teamId,
-                'name' => 'Project Test',
-            ]);
-            if (\in_array($team['headers']['status-code'], [201, 409])) {
-                break;
-            }
-            \usleep(500000);
-        }
-        $this->assertContains($team['headers']['status-code'], [201, 409]);
+        $team = $this->createTeamFixture(array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'teamId' => $teamId,
+            'name' => 'Project Test',
+        ]);
+        $this->assertEquals($this->getProject()['$id'] === 'console' ? 200 : 201, $team['headers']['status-code']);
 
         $project = null;
         for ($i = 0; $i < 3; $i++) {
@@ -352,7 +345,7 @@ trait ProjectsBase
             return self::$cachedProjectWithServicesDisabled;
         }
 
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'cookie' => 'a_session_console=' . $this->getRoot()['session'],
@@ -360,7 +353,7 @@ trait ProjectsBase
             'teamId' => ID::unique(),
             'name' => 'Project Test',
         ]);
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals($this->getProject()['$id'] === 'console' ? 200 : 201, $team['headers']['status-code']);
 
         $project = $this->client->call(Client::METHOD_POST, '/projects', array_merge([
             'content-type' => 'application/json',
@@ -425,22 +418,15 @@ trait ProjectsBase
     {
         if ($newTeam) {
             $generatedTeamId = $teamId ?? ID::unique();
-            $team = null;
-            for ($i = 0; $i < 3; $i++) {
-                $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
-                    'content-type' => 'application/json',
-                    'x-appwrite-project' => $this->getProject()['$id'],
-                ], $this->getHeaders()), [
-                    'teamId' => $generatedTeamId,
-                    'name' => 'Project Test',
-                ]);
-                if (\in_array($team['headers']['status-code'], [201, 409])) {
-                    break;
-                }
-                \usleep(500000);
-            }
+            $team = $this->createTeamFixture(array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'teamId' => $generatedTeamId,
+                'name' => 'Project Test',
+            ]);
 
-            $this->assertContains($team['headers']['status-code'], [201, 409], 'Setup team failed with status code: ' . $team['headers']['status-code'] . ' and response: ' . json_encode($team['body'], JSON_PRETTY_PRINT));
+            $this->assertEquals($this->getProject()['$id'] === 'console' ? 200 : 201, $team['headers']['status-code'], 'Setup team failed with status code: ' . $team['headers']['status-code'] . ' and response: ' . json_encode($team['body'], JSON_PRETTY_PRINT));
 
             $teamId = $team['body']['$id'] ?? $generatedTeamId;
         }

--- a/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
+++ b/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
@@ -33,7 +33,7 @@ final class ProjectsConsoleClientTest extends Scope
         /**
          * Test for SUCCESS
          */
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -41,7 +41,7 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'Project Test',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $this->assertEquals('Project Test', $team['body']['name']);
         $this->assertNotEmpty($team['body']['$id']);
 
@@ -119,7 +119,7 @@ final class ProjectsConsoleClientTest extends Scope
     public function testDeleteProjectWithMultiDB(): void
     {
         // Create a team and project
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -127,7 +127,7 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'MultiDB Team',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $teamId = $team['body']['$id'];
 
         $project = $this->client->call(Client::METHOD_POST, '/projects', array_merge([
@@ -226,7 +226,7 @@ final class ProjectsConsoleClientTest extends Scope
     public function testCreateDuplicateProject(): void
     {
         // Create a team
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -234,7 +234,7 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'Duplicate Test Team',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $teamId = $team['body']['$id'];
 
         // Create a project
@@ -277,7 +277,7 @@ final class ProjectsConsoleClientTest extends Scope
         /**
          * Test for SUCCESS
          */
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -285,13 +285,13 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'Team 1',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $this->assertEquals('Team 1', $team['body']['name']);
         $this->assertNotEmpty($team['body']['$id']);
 
         $team1 = $team['body']['$id'];
 
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -299,7 +299,7 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'Team 2',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $this->assertEquals('Team 2', $team['body']['name']);
         $this->assertNotEmpty($team['body']['$id']);
 
@@ -449,7 +449,7 @@ final class ProjectsConsoleClientTest extends Scope
         /**
          * Test pagination
          */
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -457,7 +457,7 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'Project Test 2',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $this->assertEquals('Project Test 2', $team['body']['name']);
         $this->assertNotEmpty($team['body']['$id']);
 
@@ -593,7 +593,7 @@ final class ProjectsConsoleClientTest extends Scope
     #[Group('projectsCRUD')]
     public function testListProjectsQuerySelect(): void
     {
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -601,7 +601,7 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'Query Select Test Team',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $teamId = $team['body']['$id'];
 
         $project = $this->client->call(Client::METHOD_POST, '/projects', array_merge([
@@ -854,7 +854,7 @@ final class ProjectsConsoleClientTest extends Scope
     public function testGetProject(): void
     {
         // Create a team
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -862,7 +862,7 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'Get Project Test Team',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
 
         // Create a project
         $response = $this->client->call(Client::METHOD_POST, '/projects', array_merge([
@@ -1572,7 +1572,7 @@ final class ProjectsConsoleClientTest extends Scope
     public function testUpdateProject(): void
     {
         // Create a team
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -1580,7 +1580,7 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'Update Project Test Team',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $teamId = $team['body']['$id'];
 
         // Create a project
@@ -1724,7 +1724,7 @@ final class ProjectsConsoleClientTest extends Scope
         $smtpPassword = System::getEnv('_APP_SMTP_PASSWORD', 'password');
 
         // Create a team
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -1732,7 +1732,7 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'Create Project SMTP Tests Test Team',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $teamId = $team['body']['$id'];
 
         // Create a project
@@ -1920,14 +1920,14 @@ final class ProjectsConsoleClientTest extends Scope
         $smtpPassword = 'password';
 
         /** Create team */
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
             'teamId' => ID::unique(),
             'name' => 'Session Alert Locale Fallback Test Team',
         ]);
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $teamId = $team['body']['$id'];
 
         /** Create project */
@@ -2263,7 +2263,7 @@ final class ProjectsConsoleClientTest extends Scope
     public function testUpdateProjectInvalidateSessions(): void
     {
         // Create a team for the test project
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -2271,7 +2271,7 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'Session Invalidation Test Team',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
 
         // Create a test project
         $response = $this->client->call(Client::METHOD_POST, '/projects', array_merge([
@@ -2338,7 +2338,7 @@ final class ProjectsConsoleClientTest extends Scope
     public function testUpdateProjectOAuth(): void
     {
         // Create a team
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -2346,7 +2346,7 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'Update Project OAuth Test Team',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $teamId = $team['body']['$id'];
 
         // Create a project
@@ -2473,7 +2473,7 @@ final class ProjectsConsoleClientTest extends Scope
     public function testUpdateProjectAuthStatus(): void
     {
         // Create a team
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -2481,7 +2481,7 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'Update Project Auth Status Test Team',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $teamId = $team['body']['$id'];
 
         // Create a project
@@ -3590,7 +3590,7 @@ final class ProjectsConsoleClientTest extends Scope
 
     public function testUpdateProjectApiStatus(): void
     {
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'cookie' => 'a_session_console=' . $this->getRoot()['session'],
@@ -3599,7 +3599,7 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'Project Test',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $this->assertNotEmpty($team['body']['$id']);
 
         $project = $this->client->call(Client::METHOD_POST, '/projects', array_merge([
@@ -3683,7 +3683,7 @@ final class ProjectsConsoleClientTest extends Scope
 
     public function testUpdateProjectApiStatusRealtimeBackwardsCompat(): void
     {
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'cookie' => 'a_session_console=' . $this->getRoot()['session'],
@@ -3692,7 +3692,7 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'Project Test',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
 
         $project = $this->client->call(Client::METHOD_POST, '/projects', array_merge([
             'content-type' => 'application/json',
@@ -3761,7 +3761,7 @@ final class ProjectsConsoleClientTest extends Scope
 
     public function testUpdateProjectServiceStatusAdmin(): array
     {
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'cookie' => 'a_session_console=' . $this->getRoot()['session'],
@@ -3769,7 +3769,7 @@ final class ProjectsConsoleClientTest extends Scope
             'teamId' => ID::unique(),
             'name' => 'Project Test',
         ]);
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $this->assertNotEmpty($team['body']['$id']);
 
         $project = $this->client->call(Client::METHOD_POST, '/projects', array_merge([
@@ -5761,7 +5761,7 @@ final class ProjectsConsoleClientTest extends Scope
         $data = [];
 
         // Create a team and a project
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -5769,7 +5769,7 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'Amazing Team',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $this->assertEquals('Amazing Team', $team['body']['name']);
         $this->assertNotEmpty($team['body']['$id']);
 
@@ -5838,7 +5838,7 @@ final class ProjectsConsoleClientTest extends Scope
 
     public function testDeleteSharedProject(): void
     {
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -6330,7 +6330,7 @@ final class ProjectsConsoleClientTest extends Scope
     public function testProjectLabels(): void
     {
         // Setup: Prepare team
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -6338,7 +6338,7 @@ final class ProjectsConsoleClientTest extends Scope
             'name' => 'Query Select Test Team',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $teamId = $team['body']['$id'];
 
         // Setup: Prepare project

--- a/tests/e2e/Services/Projects/Schedules/SchedulesBase.php
+++ b/tests/e2e/Services/Projects/Schedules/SchedulesBase.php
@@ -17,21 +17,14 @@ trait SchedulesBase
         }
 
         $teamId = ID::unique();
-        $team = null;
-        for ($i = 0; $i < 3; $i++) {
-            $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
-                'content-type' => 'application/json',
-                'x-appwrite-project' => $this->getProject()['$id'],
-            ], $this->getHeaders()), [
-                'teamId' => $teamId,
-                'name' => 'Schedule Test Team',
-            ]);
-            if (\in_array($team['headers']['status-code'], [201, 409])) {
-                break;
-            }
-            \usleep(500000);
-        }
-        $this->assertContains($team['headers']['status-code'], [201, 409]);
+        $team = $this->createTeamFixture(array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'teamId' => $teamId,
+            'name' => 'Schedule Test Team',
+        ]);
+        $this->assertEquals(200, $team['headers']['status-code']);
 
         $project = null;
         for ($i = 0; $i < 3; $i++) {

--- a/tests/e2e/Services/Projects/Schedules/SchedulesConsoleClientTest.php
+++ b/tests/e2e/Services/Projects/Schedules/SchedulesConsoleClientTest.php
@@ -326,7 +326,7 @@ final class SchedulesConsoleClientTest extends Scope
         $scheduleId = $data['scheduleId'];
 
         // Create a second project
-        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $team = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -334,7 +334,7 @@ final class SchedulesConsoleClientTest extends Scope
             'name' => 'Isolation Test Team',
         ]);
 
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
 
         $otherProject = $this->client->call(Client::METHOD_POST, '/projects', array_merge([
             'content-type' => 'application/json',

--- a/tests/e2e/Services/Teams/TeamsBase.php
+++ b/tests/e2e/Services/Teams/TeamsBase.php
@@ -20,7 +20,7 @@ trait TeamsBase
      */
     protected function createTeamHelper(string $name = 'Arsenal', array $roles = ['player']): array
     {
-        $response = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $response = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -29,7 +29,7 @@ trait TeamsBase
             'roles' => $roles,
         ]);
 
-        $this->assertEquals(201, $response['headers']['status-code']);
+        $this->assertEquals($this->getProject()['$id'] === 'console' ? 200 : 201, $response['headers']['status-code']);
 
         return [
             'teamUid' => $response['body']['$id'],
@@ -42,7 +42,7 @@ trait TeamsBase
         /**
          * Test for SUCCESS
          */
-        $response1 = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $response1 = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -51,7 +51,7 @@ trait TeamsBase
             'roles' => ['player'],
         ]);
 
-        $this->assertEquals(201, $response1['headers']['status-code']);
+        $this->assertEquals($this->getProject()['$id'] === 'console' ? 200 : 201, $response1['headers']['status-code']);
         $this->assertNotEmpty($response1['body']['$id']);
         $this->assertEquals('Arsenal', $response1['body']['name']);
         $this->assertGreaterThan(-1, $response1['body']['total']);
@@ -120,6 +120,25 @@ trait TeamsBase
             'teamId' => $teamId,
             'name' => 'Manchester United'
         ]);
+
+        if ($this->getProject()['$id'] === 'console') {
+            $this->assertEquals(403, $response2['headers']['status-code']);
+            $this->assertEquals('organization_creation_prohibited', $response2['body']['type']);
+
+            $headers = array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => 'console',
+            ], $this->getHeaders());
+            $response = $this->client->call(Client::METHOD_POST, '/teams', $headers, []);
+            $this->assertEquals(400, $response['headers']['status-code']);
+            $response = $this->client->call(Client::METHOD_POST, '/teams', $headers, [
+                'teamId' => $response1['body']['$id'],
+                'name' => 'John',
+            ]);
+            $this->assertEquals(403, $response['headers']['status-code']);
+            $this->assertEquals('organization_creation_prohibited', $response['body']['type']);
+            return;
+        }
 
         $this->assertEquals(201, $response2['headers']['status-code']);
         $this->assertNotEmpty($response2['body']['$id']);
@@ -398,7 +417,7 @@ trait TeamsBase
         /**
          * Test for SUCCESS
          */
-        $response = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $response = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -406,7 +425,7 @@ trait TeamsBase
             'name' => 'Demo'
         ]);
 
-        $this->assertEquals(201, $response['headers']['status-code']);
+        $this->assertEquals($this->getProject()['$id'] === 'console' ? 200 : 201, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']['$id']);
         $this->assertEquals('Demo', $response['body']['name']);
         $this->assertGreaterThan(-1, $response['body']['total']);
@@ -446,7 +465,7 @@ trait TeamsBase
         /**
          * Test for SUCCESS
          */
-        $response = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+        $response = $this->createTeamFixture(array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -456,7 +475,7 @@ trait TeamsBase
 
         $teamUid = $response['body']['$id'];
 
-        $this->assertEquals(201, $response['headers']['status-code']);
+        $this->assertEquals($this->getProject()['$id'] === 'console' ? 200 : 201, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']['$id']);
         $this->assertEquals('Demo', $response['body']['name']);
         $this->assertGreaterThan(-1, $response['body']['total']);

--- a/tests/e2e/Services/Teams/TeamsConsoleClientTest.php
+++ b/tests/e2e/Services/Teams/TeamsConsoleClientTest.php
@@ -8,6 +8,8 @@ use Tests\E2E\Client;
 use Tests\E2E\Scopes\ProjectConsole;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideClient;
+use Utopia\Database\Helpers\ID;
+use Utopia\System\System;
 
 final class TeamsConsoleClientTest extends Scope
 {
@@ -15,6 +17,95 @@ final class TeamsConsoleClientTest extends Scope
     use TeamsBaseClient;
     use ProjectConsole;
     use SideClient;
+
+    public function testCreateOrganization(): void
+    {
+        if (System::getEnv('_APP_E2E_FRESH_INSTANCE', 'disabled') !== 'enabled') {
+            $this->markTestSkipped('Requires an isolated fresh instance with console signup enabled.');
+        }
+
+        $accounts = [$this->getUser(true), $this->getUser(true)];
+        $headers = ['content-type' => 'application/json', 'x-appwrite-project' => 'console'];
+        $handles = [];
+        $multi = curl_multi_init();
+        $owner = null;
+        $organization = null;
+
+        /**
+         * Test for SUCCESS: same-account and cross-account races create only one organization.
+         */
+        try {
+            foreach ([0, 1, 0, 1] as $index) {
+                $handle = curl_init($this->endpoint . '/teams');
+                curl_setopt_array($handle, [
+                    CURLOPT_POST => true,
+                    CURLOPT_RETURNTRANSFER => true,
+                    CURLOPT_TIMEOUT => 30,
+                    CURLOPT_HTTPHEADER => [
+                        'Content-Type: application/json',
+                        'X-Appwrite-Project: console',
+                        'Cookie: a_session_console=' . $accounts[$index]['session'],
+                    ],
+                    CURLOPT_POSTFIELDS => json_encode(['teamId' => ID::unique(), 'name' => 'Instance organization']),
+                ]);
+                curl_multi_add_handle($multi, $handle);
+                $handles[] = [$handle, $index];
+            }
+            do {
+                $this->assertSame(CURLM_OK, curl_multi_exec($multi, $running));
+                if ($running) {
+                    curl_multi_select($multi, 0.1);
+                }
+            } while ($running);
+
+            $created = 0;
+            foreach ($handles as [$handle, $index]) {
+                $this->assertSame(0, curl_errno($handle), curl_error($handle));
+                $code = curl_getinfo($handle, CURLINFO_RESPONSE_CODE);
+                $body = json_decode(curl_multi_getcontent($handle), true);
+                if ($code === 201) {
+                    $created++;
+                    $owner = $accounts[$index];
+                    $organization = $body;
+                } else {
+                    $this->assertContains($code, [403, 409], json_encode($body));
+                    $this->assertSame($code === 403 ? 'organization_creation_prohibited' : 'general_resource_locked', $body['type']);
+                }
+            }
+            $this->assertSame(1, $created);
+        } finally {
+            foreach ($handles as [$handle]) {
+                curl_multi_remove_handle($multi, $handle);
+            }
+            curl_multi_close($multi);
+        }
+
+        $ownerHeaders = [...$headers, 'cookie' => 'a_session_console=' . $owner['session']];
+        $response = $this->client->call(Client::METHOD_GET, '/teams', $ownerHeaders);
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame(1, $response['body']['total']);
+        $this->assertSame($organization['$id'], $response['body']['teams'][0]['$id']);
+
+        /**
+         * Test for FAILURE: neither the owner nor a newly registered account can create another.
+         */
+        $outsiderHeaders = [...$headers, 'cookie' => 'a_session_console=' . $this->getUser(true)['session']];
+        $response = $this->client->call(Client::METHOD_GET, '/teams', $outsiderHeaders);
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame(0, $response['body']['total']);
+
+        foreach ([$ownerHeaders, $outsiderHeaders] as $requestHeaders) {
+            $response = $this->client->call(Client::METHOD_POST, '/teams', $requestHeaders, [
+                'teamId' => ID::unique(),
+                'name' => 'Another organization',
+            ]);
+            $this->assertSame(403, $response['headers']['status-code']);
+            $this->assertSame('organization_creation_prohibited', $response['body']['type']);
+        }
+        $response = $this->client->call(Client::METHOD_GET, '/teams', $ownerHeaders);
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame(1, $response['body']['total']);
+    }
 
     public function testConsoleMembershipPrivacyDefaults(): void
     {

--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -935,12 +935,12 @@ trait UsersBase
 
     public function testListUsers(): void
     {
+        // Cursor assertions require users created in order, without earlier test data.
+        self::$project = $this->getProject(true);
         $data = $this->setupUser();
         $this->setupUser1();
         $this->setupHashedPasswordUsers();
-        // In --functional mode, this test runs independently with 9 users created above
-        // (setupUser: 1 + setupUser1: 1 + setupHashedPasswordUsers: 7)
-        // In sequential mode, there may be more users from other tests
+        // setupUser: 1 + setupUser1: 1 + setupHashedPasswordUsers: 7
         $minUsers = 9;
 
         /**

--- a/tests/e2e/Services/VCSGitHub/VCSGitHubConsoleClientTest.php
+++ b/tests/e2e/Services/VCSGitHub/VCSGitHubConsoleClientTest.php
@@ -801,11 +801,11 @@ final class VCSGitHubConsoleClientTest extends Scope
             'x-appwrite-project' => 'console',
         ];
 
-        $team = $this->client->call(Client::METHOD_POST, '/teams', $consoleHeaders, [
+        $team = $this->createTeamFixture($consoleHeaders, [
             'teamId' => ID::unique(),
             'name' => 'Cross Project Team',
         ]);
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $this->assertEquals(200, $team['headers']['status-code']);
 
         $project2 = $this->client->call(Client::METHOD_POST, '/projects', $consoleHeaders, [
             'projectId' => ID::unique(),

--- a/tests/e2e/Services/VCSGitea/VCSGiteaConsoleClientTest.php
+++ b/tests/e2e/Services/VCSGitea/VCSGiteaConsoleClientTest.php
@@ -622,26 +622,16 @@ final class VCSGiteaConsoleClientTest extends Scope
         $this->assertEquals(201, $session['headers']['status-code']);
         $sessionCookie = $session['cookies']['a_session_console'];
 
-        // Sessions propagate slowly under parallel load, so retry 401s
-        $team = null;
-        for ($i = 0; $i < 5; $i++) {
-            $team = $this->client->call(Client::METHOD_POST, '/teams', [
-                'origin' => 'http://localhost',
-                'content-type' => 'application/json',
-                'cookie' => 'a_session_console=' . $sessionCookie,
-                'x-appwrite-project' => 'console',
-            ], [
-                'teamId' => ID::unique(),
-                'name' => 'VCS Tenant Team',
-            ]);
-
-            if ($team['headers']['status-code'] !== 401) {
-                break;
-            }
-
-            \usleep(500000);
-        }
-        $this->assertEquals(201, $team['headers']['status-code']);
+        $team = $this->createTeamFixture([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'cookie' => 'a_session_console=' . $sessionCookie,
+            'x-appwrite-project' => 'console',
+        ], [
+            'teamId' => ID::unique(),
+            'name' => 'VCS Tenant Team',
+        ]);
+        $this->assertEquals(200, $team['headers']['status-code']);
 
         $project = null;
         for ($i = 0; $i < 5; $i++) {


### PR DESCRIPTION
## Summary

Enforce one console organization per self-hosted instance, rather than relying on the frontend restriction or an account-scoped limit that can be bypassed by signing up again.

- Allow creation only while the console `teams` collection is empty, checked without caller permission filtering.
- Serialize the check and creation transaction with an instance-wide distributed lock. Lock contention returns `409 general_resource_locked`; it never falls back to unlocked creation.
- Return `403 organization_creation_prohibited` with invitation guidance once an organization exists.
- Preserve existing multi-org installations, invitations, project ownership/access, and application-project teams. No consolidation migration.
- **No production toggle or test bypass.** The policy remains enforced when `_APP_LOCKING_ENABLED=disabled`.

Frontend guidance, retry suppression, and corrected self-hosting docs: https://github.com/appwrite/vibes/pull/326. This intentionally tightens the API policy beyond the console behavior discussed in [vibes #251](https://github.com/appwrite/vibes/pull/251).

## Tests and fixtures

The focused policy regression stays in the existing `TeamsConsoleClientTest.php`; no new backend test file.

Console organizations needed as prerequisites by existing tests are now seeded as **pre-existing database fixtures**, with a confirmed owner membership and user-cache invalidation. The fixture response is a real authorized `GET /teams/{id}` (200), not a fabricated successful create response. Application teams still use the real create API (201). Existing permission, membership, project, and failure assertions remain; fixture setup no longer expects a prohibited console create to succeed.

CI runs the fresh-instance policy method before parallel Teams tests seed legacy organizations. `_APP_E2E_FRESH_INSTANCE` only selects that test in the test runner; production code does not read it.

## Verification

### Passing

| Platform database | Fresh-instance policy regression | Teams, four parallel processes |
| --- | --- | --- |
| PostgreSQL | Passed | 47 passed; fresh-instance method skipped here |
| MariaDB 10.11 | Passed | 47 passed; fresh-instance method skipped here |
| MongoDB 8 | Passed, with `_APP_LOCKING_ENABLED=disabled` | 47 passed; fresh-instance method skipped here |

The separately run policy test covers four concurrent requests across two accounts, exactly one created organization, owner rejection, and rejection for a newly registered account that sees zero organizations.

```sh
docker compose exec -T -e _APP_E2E_FRESH_INSTANCE=enabled appwrite \
  test tests/e2e/Services/Teams/TeamsConsoleClientTest.php --filter=testCreateOrganization

docker compose exec -T appwrite vendor/bin/paratest \
  --processes 4 --functional tests/e2e/Services/Teams
```

Additional PostgreSQL checks:

- Projects `projectsCRUD` group: **5 tests, 241 assertions passed** (creation, transfer, listing, select queries, mock numbers).
- Project schedules: **4 tests, 78 assertions passed**.
- Account deletion with organization membership: **1 test, 7 assertions passed**.
- Users: **54 tests passed** both in four-process functional mode (753 assertions) and sequentially (701 assertions). CI exposed shared-project contamination in the cursor test; that test now gets a fresh project, with every cursor assertion retained.
- Pint and PHPStan on changed PHP files, plus `git diff --check`: passed.
- Legacy-state verification: created two organizations/projects through the pre-change API, switched to the patched action without resetting data, and verified both remained accessible/writable with original project ownership while a third organization was rejected.

### Real self-hosted UI and API

Ran Playwright against a fresh isolated PostgreSQL instance, the companion frontend, a real mail worker, and a local mail catcher:

1. First signup provisioned one **Personal Projects** organization and **My first project**.
2. A second signup made exactly one denied organization-create request and landed on `/account` with persistent invitation guidance, including after reload. Authenticated API reads returned zero visible organizations/projects.
3. The owner sent an invitation through the real API. The recipient opened the delivered email link and accepted through the UI.
4. The recipient saw the original project ID; the owner's project count stayed one. Invitation guidance disappeared after access was granted.

First account:

![First account with the instance organization and initial project](https://github.com/user-attachments/assets/aaf7ef2a-93ac-4e95-853c-5ed8bca70f46)

Uninvited account after reload:

![Persistent invitation guidance](https://github.com/user-attachments/assets/e163c7f8-652d-40d8-a549-16c4ce35bace)

After accepting the email invitation:

![Invited account accessing the original project](https://github.com/user-attachments/assets/0bb3d979-0da9-4fd9-8851-76f54480b862)

Synthetic accounts only. These are application screenshots, not generated evidence pages. Usage collection was disabled in the isolated stack, hence “Usage unavailable.”

## Known baseline failures / scope of verification

- The separate `Services/Organization` suite still has **7 failures**. Reproduced failures using the **pre-policy Teams handler and original test setup**: it requests console teams in project-admin mode, which returns `400 Admin mode is not allowed for console project`. The suite also contains duplicated `/v1` URL prefixes. Its contract assertions were not removed or weakened to turn it green.
- The companion frontend's global typecheck fails on the base revision too; comparison against unchanged HEAD found **zero additional diagnostics**.
- The entire Appwrite E2E matrix was not run locally; Git-provider integration and other unrelated service suites are not claimed as passing. The affected shared fixture and the targeted suites above were verified.

