### PR TITLE
fix(queue): pass Redis DSN credentials to the publisher pool

### DIFF
--- a/app/init/registers.php
+++ b/app/init/registers.php
@@ -252,7 +252,14 @@ $register->set('pools', function () {
                         // Publishers never block on receive, so one connection backs both broker slots.
                         return match ($dsn->getScheme()) {
                             'redis' => (function () use ($dsn) {
-                                $connection = new Queue\Connection\Redis($dsn->getHost(), $dsn->getPort());
+                                // Pass the DSN credentials through: without them every
+                                // publish fails with NOAUTH on password-protected Redis.
+                                $connection = new Queue\Connection\Redis(
+                                    $dsn->getHost(),
+                                    $dsn->getPort(),
+                                    $dsn->getUser() ?: null,
+                                    $dsn->getPassword() ?: null,
+                                );
                                 return new Queue\Broker\Redis($connection, $connection);
                             })(),
                             default => null


### PR DESCRIPTION
Fixes #13554.

## Root cause

The shared Redis DSN (`app/init/registers.php:51-57`) carries `_APP_REDIS_USER`/`_APP_REDIS_PASS`, and the sibling pools authenticate with them (`$redis->auth($dsnPass)` in the default resource factory). The publisher pool, however, constructs its queue connection with host and port only - so against a password-protected Redis (`requirepass` / ACL), every publish fails with `NOAUTH`. Because the combined worker borrows the publisher pool for its consumer (`worker.php`, `BrokerPool(publisher, consumer: publisher)`), queue messages pile up too, which matches the reporter's task-scheduler symptoms exactly.

One layer down, `utopia-php/queue`'s `Connection\Redis` accepts `?user`/`?password` in its constructor but never calls `auth()` - the library half is fixed in utopia-php/monorepo#247 (composer pin `^2.0.0` admits the patch release).

## Fix

The publisher pool passes the DSN credentials through (`$dsn->getUser() ?: null`, `$dsn->getPassword() ?: null` - the getters are already used a few lines up). Inert-but-correct against current `utopia-php/queue` releases (the constructor ignores them today); live as soon as utopia-php/monorepo#247 ships.

## Verification

DSN construction, the authenticating sibling factory, the publisher pool construction, the `worker.php` pool borrowing, and the library constructor signature all confirmed in source at `main` (f31509d). **Not run:** no PHP runtime or live password-protected Redis in the author's environment - external red proof is the reporter's hourly `NOAUTH` log with every other pool authenticating.

> Built by breken, your AI support engineer - breken.ai - this one's on us.
