### PR TITLE
fix(functions): persist providerRootDirectory on VCS deployments and refresh it on redeploy

### DIFF
--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -182,6 +182,13 @@ readonly class Deployments
 
     private function submit(Document $resource, Document $deployment, ?array $source): Document
     {
+        // Snapshot the source root onto the deployment: the Duplicate
+        // endpoint and the APPWRITE_VCS_ROOT_DIRECTORY runtime variable read
+        // it back from here, and nothing else writes it for VCS sources.
+        if (is_array($source) && array_key_exists('subdir', $source)) {
+            $deployment->setAttribute('providerRootDirectory', $source['subdir'] ?? '');
+        }
+
         // The caller may have been holding this deployment for a while (the
         // Builds worker pushes a template commit first), so its status is stale
         // by now — dropping it keeps upload() from writing a cancel away, and

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
@@ -135,6 +135,12 @@ class Create extends Action
             'entrypoint' => $function->getAttribute('entrypoint'),
             'buildCommands' => $function->getAttribute('commands', ''),
             'startCommand' => $function->getAttribute('startCommand', ''),
+            // Same treatment as entrypoint/commands above: a redeploy rebuilds
+            // with the function's current configuration. Deployments created
+            // before this attribute was persisted carry NULL, which the VCS
+            // clone path turns into a '*' wildcard - the build then runs at
+            // the repository root and monorepo functions fail.
+            'providerRootDirectory' => $function->getAttribute('providerRootDirectory', ''),
             'buildStartedAt' => null,
             'buildEndedAt' => null,
             'buildDuration' => null,


### PR DESCRIPTION
Fixes #13587.

## Root cause (the reporter's, confirmed at HEAD)

@AlimFreight traced this end to end; verified independently here:

1. `Deployments/Duplicate/Create.php` refreshes `entrypoint`/`buildCommands`/`startCommand` from the function on redeploy but inherits `providerRootDirectory` from the old deployment.
2. Nothing in 2.0 writes `providerRootDirectory` onto VCS deployments - only the template flow (`Deployments/Template/Create.php:184`) does - so the duplicate gets NULL.
3. `utopia-php/vcs` (`Adapter/Git/GitHub.php`, `generateCloneCommand`): an empty root directory becomes a `*` sparse checkout, so the whole repo is checked out, the build runs at the repository root, and monorepo function code is missing - the ~1s build failure in the reporter's log.
4. The same missing write also empties `APPWRITE_VCS_ROOT_DIRECTORY` at runtime (`Executions/Create.php` and the build env in `Deployments.php:715` read it from the deployment).

## Fix (2 files, +13)

- **Duplicate/Create.php**: refresh `providerRootDirectory` from the function, same treatment as `entrypoint`/`commands` above it. A redeploy rebuilds with the function's current root directory - and because it overwrites the inherited NULL, this also heals every existing broken deployment on its next redeploy, no backfill needed (which matches the reporter's finding that backfilling wasn't a path forward).
- **Deployments.php `submit()`**: snapshot `$source['subdir']` as `providerRootDirectory` on new VCS deployments so the value persists going forward. The upload flow (`submit(null)`) is untouched.

## Verification

Every step of the chain re-traced in source at `main` (f31509d), including the `'*'` wildcard in the vcs library and all read sites. **Not run:** no PHP runtime or live Appwrite instance in the author's environment, so no lint or live redeploy test - the reporter offered to test a Redeploy on a subdirectory function, which would be the real-world green proof. (Their `POST /deployments/vcs` workaround is correct until this lands.)

> Built by breken, your AI support engineer - breken.ai - this one's on us.
