### PR TITLE
Drop the constant defines from the concurrency test

### DIFF
--- a/tests/unit/Usage/ConcurrencyTest.php
+++ b/tests/unit/Usage/ConcurrencyTest.php
@@ -17,14 +17,6 @@ final class ConcurrencyTest extends TestCase
     private const string BUCKET = '2026-09-08 11:55:00';
     private const string PREVIOUS_SAMPLE = '2026-09-08 11:50:00';
 
-    public static function setUpBeforeClass(): void
-    {
-        // app/init defines these when the suite boots through it; needed when this file runs alone.
-        \defined('METRIC_REALTIME_CONNECTIONS') || \define('METRIC_REALTIME_CONNECTIONS', 'realtime.connections');
-        \defined('REALTIME_CONCURRENCY_INTERVAL') || \define('REALTIME_CONCURRENCY_INTERVAL', '5m');
-        \defined('REALTIME_CONCURRENCY_LAG_SECONDS') || \define('REALTIME_CONCURRENCY_LAG_SECONDS', 300);
-    }
-
     public function testLevelIsTheWindowedSumNotTheCarriedGauge(): void
     {
         $written = $this->sample(


### PR DESCRIPTION
Follow-up to #13520. The test I added there defines three constants in `setUpBeforeClass`:

```php
\defined('METRIC_REALTIME_CONNECTIONS') || \define('METRIC_REALTIME_CONNECTIONS', 'realtime.connections');
```

They are dead in CI — `phpunit.xml` bootstraps `app/init.php`, which defines all three — and only existed so the file could be run standalone with `--no-configuration`.

## Why they are worth removing

`tests/**` has no `export-ignore` in `.gitattributes`, so it ships into `vendor/appwrite/server-ce/tests/`. Cloud's `phpstan.neon` lists `vendor/appwrite/server-ce` under `scanDirectories`, so it scans those tests for symbols. A conditional `define()` competing with the real `const` left PHPStan unable to resolve the constant at all, and Cloud's own files started failing:

```
Constant METRIC_REALTIME_CONNECTIONS not found.
```

14 errors across `app/controllers/api/project.php`, `Modules/Usage/Http/Gauges/XList.php`, `Tasks/VerifyBilledUsage.php` and `Workers/StatsUsage.php` — none of which this PR's branch touched. It surfaced on appwrite-labs/cloud#5748, the bump that pulls #13520 in.

## Verified

`vendor/bin/phpunit --filter ConcurrencyTest` through the project bootstrap: 7 assertions, green, constants resolving from `app/init.php`. Pint and Rector clean.

## Not done here

Two broader fixes exist and both are somebody's call rather than mine:

- `export-ignore` on `tests/**` so the suite stops shipping to consumers at all.
- Cloud excluding `vendor/appwrite/server-ce/tests` from its scan.

Either would stop a test file influencing a downstream consumer's static analysis, which is the actual sharp edge. This change just removes the specific collision.
