### PR TITLE
fix: use http for internal jobs endpoint regardless of FORCE_HTTPS

### DIFF
--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -366,10 +366,12 @@ readonly class Deployments
         $memory = \max((int) ($spec['memory'] ?? APP_COMPUTE_MEMORY_DEFAULT), $minMemory);
 
         // The jobs-service (and the containers it spawns) reach Appwrite over
-        // the internal Docker network, so the presigned + callback URLs use an
-        // internal endpoint when configured, falling back to the public host.
-        $protocol = System::getEnv('_APP_OPTIONS_FORCE_HTTPS') === 'disabled' ? 'http' : 'https';
-        $endpoint = System::getEnv('_APP_JOBS_ENDPOINT', "$protocol://{$platform['apiHostname']}");
+        // the internal Docker network, where only port 80 is exposed (TLS is
+        // terminated at Traefik). The presigned + callback URLs therefore use an
+        // internal endpoint when configured, falling back to plain HTTP on the
+        // platform host — _APP_OPTIONS_FORCE_HTTPS governs the public API only
+        // and must not bleed into internal URLs.
+        $endpoint = System::getEnv('_APP_JOBS_ENDPOINT', "http://{$platform['apiHostname']}");
 
         // Source artifacts, all ending in /mnt/code/source:
         //  - remote tarball ($source with url): templates (public codeload URL)

--- a/tests/unit/Deployment/DeploymentsTest.php
+++ b/tests/unit/Deployment/DeploymentsTest.php
@@ -177,22 +177,21 @@ final class DeploymentsTest extends TestCase
 
     public function testPayloadInternalEndpointIsHttpEvenWhenForceHttpsEnabled(): void
     {
+        // Regression: with the documented self-hosted default
+        // (_APP_OPTIONS_FORCE_HTTPS=enabled) and no _APP_JOBS_ENDPOINT override,
+        // the source presigned URL and the CloudEvents callback URL must reach
+        // Appwrite over plain HTTP. The jobs-service and its sidecars live on
+        // the internal Docker network where nothing listens on port 443 — an
+        // https://appwrite/... URL leaves deployments stuck in "waiting".
         $this->withEnv(
             ['_APP_OPTIONS_FORCE_HTTPS' => 'enabled', '_APP_JOBS_ENDPOINT' => ''],
             function (): void {
                 $payload = $this->buildPayload([]);
 
-                $this->assertStringStartsWith(
-                    'http://localhost/v1/jobs/event?',
-                    $payload['callback']->url,
-                    'CloudEvents callback must reach Appwrite over HTTP on the internal network'
-                );
-
-                $source = $this->findSourceArtifact($payload);
-                $this->assertStringStartsWith(
-                    'http://localhost/v1/functions/function1/deployments/deployment1/download',
-                    $source->in,
-                    'Source presigned download URL must use HTTP for the sidecar'
+                $this->assertInternalEndpoint($payload['callback']->url, 'localhost');
+                $this->assertInternalEndpoint(
+                    $this->findSourceArtifact($payload)->in,
+                    'localhost'
                 );
             }
         );
@@ -200,6 +199,9 @@ final class DeploymentsTest extends TestCase
 
     public function testPayloadRespectsExplicitJobsEndpointOverride(): void
     {
+        // _APP_JOBS_ENDPOINT stays the supported escape hatch for non-default
+        // internal topologies — its value must win regardless of the public
+        // _APP_OPTIONS_FORCE_HTTPS flag.
         $this->withEnv(
             [
                 '_APP_OPTIONS_FORCE_HTTPS' => 'enabled',
@@ -208,18 +210,31 @@ final class DeploymentsTest extends TestCase
             function (): void {
                 $payload = $this->buildPayload([]);
 
-                $this->assertStringStartsWith(
-                    'http://internal-appwrite:9000/v1/jobs/event?',
-                    $payload['callback']->url
+                $this->assertInternalEndpoint(
+                    $payload['callback']->url,
+                    'internal-appwrite:9000'
                 );
-
-                $source = $this->findSourceArtifact($payload);
-                $this->assertStringStartsWith(
-                    'http://internal-appwrite:9000/v1/functions/function1/deployments/deployment1/download',
-                    $source->in
+                $this->assertInternalEndpoint(
+                    $this->findSourceArtifact($payload)->in,
+                    'internal-appwrite:9000'
                 );
             }
         );
+    }
+
+    /**
+     * Asserts the URL is reachable over HTTP on the given internal authority
+     * (host[:port]). Treats the path, query, and any future route changes as
+     * opaque — the regression is the scheme + authority, not the URL shape.
+     */
+    private function assertInternalEndpoint(string $url, string $expectedAuthority): void
+    {
+        $parts = \parse_url($url);
+        $this->assertIsArray($parts, "Expected a valid URL, got: {$url}");
+        $this->assertSame('http', $parts['scheme'] ?? null, "Expected http scheme in {$url}");
+
+        $actualAuthority = ($parts['host'] ?? '') . (isset($parts['port']) ? ':' . $parts['port'] : '');
+        $this->assertSame($expectedAuthority, $actualAuthority, "Expected authority {$expectedAuthority} in {$url}");
     }
 
     /**

--- a/tests/unit/Deployment/DeploymentsTest.php
+++ b/tests/unit/Deployment/DeploymentsTest.php
@@ -174,6 +174,90 @@ final class DeploymentsTest extends TestCase
         $this->assertSame('v1', $payload['environment']['MY-VAR']);
         $this->assertSame('v2', $payload['environment']['MY_VAR']);
     }
+
+    public function testPayloadInternalEndpointIsHttpEvenWhenForceHttpsEnabled(): void
+    {
+        $this->withEnv(
+            ['_APP_OPTIONS_FORCE_HTTPS' => 'enabled', '_APP_JOBS_ENDPOINT' => ''],
+            function (): void {
+                $payload = $this->buildPayload([]);
+
+                $this->assertStringStartsWith(
+                    'http://localhost/v1/jobs/event?',
+                    $payload['callback']->url,
+                    'CloudEvents callback must reach Appwrite over HTTP on the internal network'
+                );
+
+                $source = $this->findSourceArtifact($payload);
+                $this->assertStringStartsWith(
+                    'http://localhost/v1/functions/function1/deployments/deployment1/download',
+                    $source->in,
+                    'Source presigned download URL must use HTTP for the sidecar'
+                );
+            }
+        );
+    }
+
+    public function testPayloadRespectsExplicitJobsEndpointOverride(): void
+    {
+        $this->withEnv(
+            [
+                '_APP_OPTIONS_FORCE_HTTPS' => 'enabled',
+                '_APP_JOBS_ENDPOINT' => 'http://internal-appwrite:9000',
+            ],
+            function (): void {
+                $payload = $this->buildPayload([]);
+
+                $this->assertStringStartsWith(
+                    'http://internal-appwrite:9000/v1/jobs/event?',
+                    $payload['callback']->url
+                );
+
+                $source = $this->findSourceArtifact($payload);
+                $this->assertStringStartsWith(
+                    'http://internal-appwrite:9000/v1/functions/function1/deployments/deployment1/download',
+                    $source->in
+                );
+            }
+        );
+    }
+
+    /**
+     * @param array<string, string> $overrides
+     */
+    private function withEnv(array $overrides, callable $then): void
+    {
+        $previous = [];
+        foreach ($overrides as $key => $value) {
+            $previous[$key] = \getenv($key);
+            if ($value === '') {
+                \putenv($key);
+            } else {
+                \putenv($key . '=' . $value);
+            }
+        }
+        try {
+            $then();
+        } finally {
+            foreach ($previous as $key => $value) {
+                if ($value === false) {
+                    \putenv($key);
+                } else {
+                    \putenv($key . '=' . $value);
+                }
+            }
+        }
+    }
+
+    private function findSourceArtifact(array $payload): object
+    {
+        foreach ($payload['artifacts'] as $artifact) {
+            if ($artifact->id === 'source') {
+                return $artifact;
+            }
+        }
+        $this->fail('No source artifact in payload');
+    }
 }
 
 final readonly class ExposedDeployments extends Deployments


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where the internal jobs endpoint could be generated with `https://` when `_APP_OPTIONS_FORCE_HTTPS` is enabled, causing deployment artifact downloads and job callbacks to fail on self-hosted installations where TLS is terminated externally.

The internal endpoint now defaults to `http://` while still respecting an explicitly configured `_APP_JOBS_ENDPOINT`.

## Test Plan

Added regression coverage for the internal endpoint behavior:

* Verified that with `_APP_OPTIONS_FORCE_HTTPS=enabled` and no `_APP_JOBS_ENDPOINT`, both the source artifact URL and CloudEvents callback URL use `http://`.
* Verified that an explicitly configured `_APP_JOBS_ENDPOINT` is still respected.
* `vendor/bin/phpunit tests/unit/Deployment/DeploymentsTest.php` passes: 13/13 tests, 19 assertions.
* Reverted the fix and confirmed the regression test fails with the expected `https://localhost/...` URL.
* `composer lint src/Appwrite/Deployment/Deployments.php tests/unit/Deployment/DeploymentsTest.php` passes.
* `composer analyze` (PHPStan level 4) passes for the changed files.

## Related PRs and Issues

* Fixes #13519

## Checklist

* [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)
* [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?