### PR TITLE
test(users): assert the cursor contract instead of the fixture's luck

### DIFF
--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -1149,32 +1149,38 @@ trait UsersBase
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
             'queries' => [
-                Query::cursorAfter(new Document(['$id' => $data['userId']]))->toString()
+                Query::cursorAfter(new Document(['$id' => $data['userId']]))->toString(),
+                Query::limit(100)->toString(),
             ]
         ]);
 
         $this->assertEquals($response['headers']['status-code'], 200);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['users']);
-        // CursorAfter should return results, count varies in parallel mode
-        $this->assertGreaterThanOrEqual(1, count($response['body']['users']));
-        // First result after cursor should be user1 (created right after setupUser)
-        $this->assertEquals($response['body']['users'][0]['$id'], 'user1');
+
+        // Every other method of this suite runs against the same project at the same
+        // time under --functional, so the only order this test can rely on is the one
+        // it establishes itself: setupUser() precedes setupUser1().
+        $after = array_column($response['body']['users'], '$id');
+        $this->assertNotContains($data['userId'], $after, 'cursorAfter returned the cursor itself');
+        $this->assertContains('user1', $after, 'cursorAfter dropped a user created after the cursor');
 
         $response = $this->client->call(Client::METHOD_GET, '/users', array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
             'queries' => [
-                Query::cursorBefore(new Document(['$id' => 'user1']))->toString()
+                Query::cursorBefore(new Document(['$id' => 'user1']))->toString(),
+                Query::limit(100)->toString(),
             ]
         ]);
 
         $this->assertEquals($response['headers']['status-code'], 200);
         $this->assertNotEmpty($response['body']['users']);
-        $this->assertCount(1, $response['body']['users']);
 
-        $this->assertEquals($response['body']['users'][0]['$id'], $data['userId']);
+        $before = array_column($response['body']['users'], '$id');
+        $this->assertNotContains('user1', $before, 'cursorBefore returned the cursor itself');
+        $this->assertContains($data['userId'], $before, 'cursorBefore dropped a user created before the cursor');
 
         /**
          * Test for SUCCESS searchUsers


### PR DESCRIPTION
## What

`Tests\E2E\Services\Users\UsersCustomServerTest::testListUsers` fails
intermittently:

```
Failed asserting that actual size 2 matches expected size 1.
/usr/src/code/tests/e2e/Services/Users/UsersBase.php:1175
```

Seen on [run 34445479253](https://github.com/appwrite/appwrite/actions/runs/34445479253),
`Tests / E2E / PostgreSQL (dedicated) / Users`. It passed on a re-run of the same
commit, and the lane is green on the last six `main` runs, so it is rare rather
than chronic. It is still a real defect, not a harness one.

## Why

The lane runs `paratest --processes $(nproc) --functional`, so **every test method
of the class runs concurrently against the same project**. `testListUsers` then
pinned the identity of the rows either side of its cursor:

```php
// First result after cursor should be user1 (created right after setupUser)
$this->assertEquals($response['body']['users'][0]['$id'], 'user1');
...
$this->assertCount(1, $response['body']['users']);
$this->assertEquals($response['body']['users'][0]['$id'], $data['userId']);
```

Both hold only while nothing sorts between `setupUser()`'s user and
`setupUser1()`'s. `testCreateUserTypes`, `testCreateScryptModified`,
`testCreateUserSessionHashed`, `testCreateToken`, `testCreateSession` and
`testGetMFAChallenge` are all creating users in that project at that moment, and
any one of them landing between the two breaks the assertion. CI has produced
both halves: the `assertCount` above, and an earlier run reading an unrelated id
where it demanded `user1`.

The rest of this test was already made parallel-safe - "Find our users by ID
instead of assuming position", "count varies in parallel mode" - and the cursor
block at 1156-1177 was missed.

## How

Assert what a cursor actually promises, using the only ordering this test
establishes itself (`setupUser()` runs before `setupUser1()`):

- neither page may contain its own cursor;
- the earlier user must appear on the `cursorBefore` page;
- the later user must appear on the `cursorAfter` page.

Nothing else about either page is pinned, so a neighbour created by another
process is free to appear. Both queries now ask for `Query::limit(100)` so the
pair being asserted cannot fall off the end of a default 25-row page.

## Verification

Against the local compose stack, creating a single user between `setupUser()`
and `setupUser1()` - exactly what another `--functional` process is free to do:

| | current assertions | these assertions |
|---|---|---|
| one neighbour user | **fail** - `'6aa257c32b4a16e909d9'` where it wanted `'user1'` | pass |
| same, with the identity assertion removed so the run reaches the count | **fail** - `Failed asserting that actual size 2 matches expected size 1`, verbatim the CI message | pass |
| no neighbour | pass | pass |

Full suite `paratest --processes 4 --functional tests/e2e/Services/Users`:
**54/54, 721 assertions**. `composer lint` clean.

## Not verified

Only the PostgreSQL adapter was run locally. The same trait backs the MariaDB and
MongoDB Users lanes; the change is adapter-independent (it removes assumptions
rather than adding queries), but CI is the first place all three run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
