### PR TITLE
Keep the tenant a string when sampling concurrency

### DIFF
--- a/src/Appwrite/Usage/Concurrency.php
+++ b/src/Appwrite/Usage/Concurrency.php
@@ -88,7 +88,11 @@ class Concurrency
         }
 
         $samples = [];
+        // Cast: a tenant is a project sequence, so PHP turned the array key into
+        // an int, and the store requires a non-empty string.
         foreach ($deltas as $tenant => $byBucket) {
+            $tenant = (string) $tenant;
+
             \ksort($byBucket);
             $buckets = \array_keys($byBucket);
             $count = \count($buckets);

--- a/tests/unit/Usage/ConcurrencyTest.php
+++ b/tests/unit/Usage/ConcurrencyTest.php
@@ -20,45 +20,45 @@ final class ConcurrencyTest extends TestCase
     public function testLevelIsTheWindowedSumNotTheCarriedGauge(): void
     {
         $written = $this->sample(
-            gauge: [self::metric('t1', 9999, self::PREVIOUS_SAMPLE)],
+            gauge: [self::metric('356187', 9999, self::PREVIOUS_SAMPLE)],
             events: [
-                self::metric('t1', 50, '2026-09-08 05:50:00'),   // older than the 6h window
-                self::metric('t1', 3, '2026-09-08 08:00:00'),
-                self::metric('t1', -1, self::BUCKET),
+                self::metric('356187', 50, '2026-09-08 05:50:00'),   // older than the 6h window
+                self::metric('356187', 3, '2026-09-08 08:00:00'),
+                self::metric('356187', -1, self::BUCKET),
             ],
         );
 
-        $this->assertSame([['tenant' => 't1', 'value' => 2, 'time' => self::BUCKET]], $written);
+        $this->assertSame([['tenant' => '356187', 'value' => 2, 'time' => self::BUCKET]], $written);
     }
 
     public function testLeakedOpensAgeOutOfTheWindow(): void
     {
         // The +40 sits exactly one window back, so it is outside (window is open at the start).
         $written = $this->sample(
-            gauge: [self::metric('t1', 40, self::PREVIOUS_SAMPLE)],
+            gauge: [self::metric('356187', 40, self::PREVIOUS_SAMPLE)],
             events: [
-                self::metric('t1', 40, '2026-09-08 05:55:00'),
-                self::metric('t1', 0, self::BUCKET),
+                self::metric('356187', 40, '2026-09-08 05:55:00'),
+                self::metric('356187', 0, self::BUCKET),
             ],
         );
 
-        $this->assertSame([['tenant' => 't1', 'value' => 0, 'time' => self::BUCKET]], $written);
+        $this->assertSame([['tenant' => '356187', 'value' => 0, 'time' => self::BUCKET]], $written);
     }
 
     public function testEachCatchUpBucketGetsItsOwnWindow(): void
     {
         $written = $this->sample(
-            gauge: [self::metric('t1', 0, '2026-09-08 11:45:00')],
+            gauge: [self::metric('356187', 0, '2026-09-08 11:45:00')],
             events: [
-                self::metric('t1', 7, '2026-09-08 05:55:00'),   // inside 11:50's window, outside 11:55's
-                self::metric('t1', 2, '2026-09-08 11:50:00'),
-                self::metric('t1', 1, self::BUCKET),
+                self::metric('356187', 7, '2026-09-08 05:55:00'),   // inside 11:50's window, outside 11:55's
+                self::metric('356187', 2, '2026-09-08 11:50:00'),
+                self::metric('356187', 1, self::BUCKET),
             ],
         );
 
         $this->assertSame([
-            ['tenant' => 't1', 'value' => 9, 'time' => '2026-09-08 11:50:00'],
-            ['tenant' => 't1', 'value' => 3, 'time' => self::BUCKET],
+            ['tenant' => '356187', 'value' => 9, 'time' => '2026-09-08 11:50:00'],
+            ['tenant' => '356187', 'value' => 3, 'time' => self::BUCKET],
         ], $written);
     }
 
@@ -66,8 +66,8 @@ final class ConcurrencyTest extends TestCase
     {
         // The window still holds the +3, but nothing happened in 11:55.
         $written = $this->sample(
-            gauge: [self::metric('t1', 3, self::PREVIOUS_SAMPLE)],
-            events: [self::metric('t1', 3, self::PREVIOUS_SAMPLE)],
+            gauge: [self::metric('356187', 3, self::PREVIOUS_SAMPLE)],
+            events: [self::metric('356187', 3, self::PREVIOUS_SAMPLE)],
         );
 
         $this->assertSame([], $written);
@@ -78,21 +78,21 @@ final class ConcurrencyTest extends TestCase
         // Page one fills mid-way through 11:55, so that bucket is dropped and
         // re-read whole on page two rather than sampled short.
         $written = $this->sample(
-            gauge: [self::metric('t1', 0, '2026-09-08 11:45:00')],
+            gauge: [self::metric('356187', 0, '2026-09-08 11:45:00')],
             events: [
-                self::metric('t1', 1, '2026-09-08 11:50:00'),
-                self::metric('t2', 1, '2026-09-08 11:50:00'),
-                self::metric('t1', 1, self::BUCKET),
-                self::metric('t2', -1, self::BUCKET),
+                self::metric('356187', 1, '2026-09-08 11:50:00'),
+                self::metric('478539', 1, '2026-09-08 11:50:00'),
+                self::metric('356187', 1, self::BUCKET),
+                self::metric('478539', -1, self::BUCKET),
             ],
             pageSize: 3,
         );
 
         $this->assertSame([
-            ['tenant' => 't1', 'value' => 1, 'time' => '2026-09-08 11:50:00'],
-            ['tenant' => 't1', 'value' => 2, 'time' => self::BUCKET],
-            ['tenant' => 't2', 'value' => 1, 'time' => '2026-09-08 11:50:00'],
-            ['tenant' => 't2', 'value' => 0, 'time' => self::BUCKET],
+            ['tenant' => '356187', 'value' => 1, 'time' => '2026-09-08 11:50:00'],
+            ['tenant' => '356187', 'value' => 2, 'time' => self::BUCKET],
+            ['tenant' => '478539', 'value' => 1, 'time' => '2026-09-08 11:50:00'],
+            ['tenant' => '478539', 'value' => 0, 'time' => self::BUCKET],
         ], $written);
     }
 
@@ -102,16 +102,16 @@ final class ConcurrencyTest extends TestCase
         // query returns nothing the first bucket can be sampled from, and since
         // the resume point never moves, every later run reads the same page.
         $written = $this->sample(
-            gauge: [self::metric('t1', 0, self::PREVIOUS_SAMPLE)],
+            gauge: [self::metric('356187', 0, self::PREVIOUS_SAMPLE)],
             events: [
-                self::metric('t1', 1, '2026-09-08 06:05:00'),
-                self::metric('t1', 1, '2026-09-08 06:10:00'),
-                self::metric('t1', 1, self::BUCKET),
+                self::metric('356187', 1, '2026-09-08 06:05:00'),
+                self::metric('356187', 1, '2026-09-08 06:10:00'),
+                self::metric('356187', 1, self::BUCKET),
             ],
             pageSize: 2,
         );
 
-        $this->assertSame([['tenant' => 't1', 'value' => 3, 'time' => self::BUCKET]], $written);
+        $this->assertSame([['tenant' => '356187', 'value' => 3, 'time' => self::BUCKET]], $written);
     }
 
     public function testSingleBucketOverThePageSizeIsNotSampled(): void
@@ -119,11 +119,11 @@ final class ConcurrencyTest extends TestCase
         // No page size gets past one bucket that fills a page, so the fold
         // writes nothing instead of sampling it short.
         $written = $this->sample(
-            gauge: [self::metric('t1', 0, self::PREVIOUS_SAMPLE)],
+            gauge: [self::metric('356187', 0, self::PREVIOUS_SAMPLE)],
             events: [
-                self::metric('t1', 1, self::BUCKET),
-                self::metric('t2', 1, self::BUCKET),
-                self::metric('t3', 1, self::BUCKET),
+                self::metric('356187', 1, self::BUCKET),
+                self::metric('478539', 1, self::BUCKET),
+                self::metric('605738', 1, self::BUCKET),
             ],
             pageSize: 2,
         );
@@ -180,7 +180,16 @@ final class ConcurrencyTest extends TestCase
 
         $written = [];
         $usage->method('addBatch')->willReturnCallback(function (array $rows) use (&$written): bool {
-            foreach ($rows as $row) {
+            foreach ($rows as $index => $row) {
+                // The ClickHouse adapter rejects a tenant that is not a non-empty
+                // string. Tenants are project sequences, so an array key holding
+                // one is an int, and a laxer double lets that reach production.
+                if (!\is_string($row['tenant']) || $row['tenant'] === '') {
+                    throw new \RuntimeException(
+                        "Metric #{$index}: 'tenant' is required (non-empty string) when shared tables are enabled"
+                    );
+                }
+
                 $written[] = [
                     'tenant' => $row['tenant'],
                     'value' => $row['value'],


### PR DESCRIPTION
Follow-up to #13520, which is live and currently sampling nothing.

## What is happening in production

Every `stats-resources` run since the deploy has logged:

```
stats resources: concurrency sample failed, continuing: Metric #0: 'tenant' is required (non-empty string) when shared tables are enabled
```

So `Concurrency::sample()` throws before `addBatch`, no gauge sample is written, and the newest `realtime.connections` sample is the last one the **old carried fold** left behind. Billing takes `max()` over the cycle, so it still reads the inflated carried peak — in fra1 the gauge sits at 28,988 against 1,930 connections actually open, and 699 is what the windowed fold would write for the current bucket.

## Cause

A tenant is a project sequence — a numeric string like `356187`. Grouping deltas per tenant:

```php
$deltas[$tenant][$bucket] = ...;      // PHP casts "356187" to int(356187)
foreach ($deltas as $tenant => $byBucket) {
    ...
    $samples[] = ['tenant' => $tenant, ...];   // int, and the adapter wants a string
}
```

`Adapter\ClickHouse::addBatch()` requires a non-empty string and throws. The carried fold read the tenant off the row inside the loop and never had an array key to be cast, which is why this only appeared with the paging refactor.

Fixed by casting once at the top of the loop.

## Why the tests missed it, and what changed

Two failures of fidelity, both now closed:

- **The double was laxer than the store.** The stub's `addBatch` recorded whatever it was handed. It now rejects a non-string or empty tenant with the adapter's own message, so any test would catch this.
- **The fixtures used a shape production cannot produce.** Tenants were `'t1'`, `'t2'` — non-numeric, so PHP keeps them as *string* keys and the cast never happens. They are now real project sequences (`356187`, `478539`, `605738`).

Verified: with the cast, 7 tests / 7 assertions green. Without it, the suite fails with the identical message the pods logged.

## Deploying this

Cloud needs a `composer.lock` bump to pick it up. Until then the realtime concurrency gauge does not advance at all, and the billing peak stays on pre-fix values.
