### PR TITLE
Fix TablesDB webhook event matching and delivery

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -883,7 +883,8 @@ Http::shutdown()
         // Generate events for this operation
         $generatedEvents = Event::generateEvents(
             $queueForEvents->getEvent(),
-            $queueForEvents->getParams()
+            $queueForEvents->getParams(),
+            $queueForEvents->getContext('database')
         );
 
         $allowedOnConsole = !empty(\array_intersect($route->getGroups(), Realtime::CONSOLE_ALLOWLIST));
@@ -905,6 +906,7 @@ Http::shutdown()
                         userId: $queueForEvents->getUserId(),
                         payload: $queueForEvents->getPayload(),
                         platform: $queueForEvents->getPlatform(),
+                        database: $queueForEvents->getContext('database'),
                     ));
                     break;
                 }

--- a/src/Appwrite/Event/Event.php
+++ b/src/Appwrite/Event/Event.php
@@ -386,7 +386,7 @@ class Event
             'userId' => $this->userId,
             'payload' => $this->payload,
             'context' => $this->context,
-            'events' => Event::generateEvents($this->getEvent(), $this->getParams())
+            'events' => Event::generateEvents($this->getEvent(), $this->getParams(), $this->getContext('database'))
         ];
     }
 

--- a/src/Appwrite/Event/Message/Func.php
+++ b/src/Appwrite/Event/Message/Func.php
@@ -35,13 +35,14 @@ final class Func extends Base
         ?string $userId = null,
         array $payload = [],
         array $platform = [],
+        ?Document $database = null,
     ): static {
         return new self(
             project: $project,
             user: $user,
             userId: $userId,
             payload: $payload,
-            events: $event !== '' ? Event::generateEvents($event, $params) : [],
+            events: $event !== '' ? Event::generateEvents($event, $params, $database) : [],
             platform: $platform,
         );
     }

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Action.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Action.php
@@ -500,7 +500,8 @@ abstract class Action extends DatabasesAction
             // Generate events for this document operation
             $generatedEvents = Event::generateEvents(
                 $queueForEvents->getEvent(),
-                $queueForEvents->getParams()
+                $queueForEvents->getParams(),
+                $queueForEvents->getContext('database')
             );
 
 
@@ -515,6 +516,7 @@ abstract class Action extends DatabasesAction
                             userId: $queueForEvents->getUserId(),
                             payload: $queueForEvents->getPayload(),
                             platform: $queueForEvents->getPlatform(),
+                            database: $queueForEvents->getContext('database'),
                         ));
                         break;
                     }

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Create.php
@@ -113,7 +113,9 @@ class Create extends Action
 
         $this->createMetadataCollection($dbForProject, $database);
 
-        $queueForEvents->setParam('databaseId', $database->getId());
+        $queueForEvents
+            ->setParam('databaseId', $database->getId())
+            ->setContext('database', $database);
 
         $response
             ->setStatusCode(SwooleResponse::STATUS_CODE_CREATED)

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Delete.php
@@ -81,6 +81,7 @@ class Delete extends Action
 
         $queueForEvents
             ->setParam('databaseId', $database->getId())
+            ->setContext('database', $database)
             ->setPayload($response->output($database, UtopiaResponse::MODEL_DATABASE));
 
         $publisherForDatabase->enqueue(new DatabaseMessage(

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Update.php
@@ -488,7 +488,8 @@ class Update extends Action
                     // Generate events for this document operation
                     $generatedEvents = Event::generateEvents(
                         $queueForEvents->getEvent(),
-                        $queueForEvents->getParams()
+                        $queueForEvents->getParams(),
+                        $queueForEvents->getContext('database')
                     );
 
                     $queueForRealtime->from($queueForEvents)->trigger();
@@ -505,6 +506,7 @@ class Update extends Action
                                     userId: $queueForEvents->getUserId(),
                                     payload: $queueForEvents->getPayload(),
                                     platform: $queueForEvents->getPlatform(),
+                                    database: $queueForEvents->getContext('database'),
                                 ));
                                 break;
                             }

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Update.php
@@ -83,7 +83,9 @@ class Update extends Action
             ->setAttribute('enabled', $enabled)
             ->setAttribute('search', implode(' ', [$databaseId, $searchName])));
 
-        $queueForEvents->setParam('databaseId', $database->getId());
+        $queueForEvents
+            ->setParam('databaseId', $database->getId())
+            ->setContext('database', $database);
 
         $response->dynamic($database, UtopiaResponse::MODEL_DATABASE);
     }

--- a/tests/e2e/Services/Webhooks/WebhooksBase.php
+++ b/tests/e2e/Services/Webhooks/WebhooksBase.php
@@ -13,6 +13,139 @@ trait WebhooksBase
 {
     use Async;
 
+    public function testTablesDBRows(): void
+    {
+        // Test for SUCCESS: single, bulk, and committed writes deliver both namespaces.
+        $headers = array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders());
+        $databaseId = ID::unique();
+        $tableId = ID::unique();
+        $path = "/tablesdb/{$databaseId}/tables/{$tableId}";
+        $database = $this->client->call(Client::METHOD_POST, '/tablesdb', $headers, [
+            'databaseId' => $databaseId, 'name' => 'Webhook rows',
+        ]);
+        $this->assertEquals(201, $database['headers']['status-code']);
+        $table = $this->client->call(Client::METHOD_POST, "/tablesdb/{$databaseId}/tables", $headers, [
+            'tableId' => $tableId, 'name' => 'Rows',
+            'columns' => [['key' => 'value', 'type' => 'string', 'size' => 100]],
+        ]);
+        $this->assertEquals(201, $table['headers']['status-code']);
+
+        $webhooks = [];
+        foreach (['tablesdb', 'databases'] as $prefix) {
+            $webhook = $this->createWebhook(ID::unique(), 'Row events', [
+                "{$prefix}.{$databaseId}.tables.{$tableId}.rows.*.create",
+                "{$prefix}.{$databaseId}.tables.{$tableId}.rows.*.update",
+            ], true, 'http://request-catcher-webhook:5000/', false, null, null);
+            $this->assertEquals(201, $webhook['headers']['status-code']);
+            $webhooks[$prefix] = $webhook['body']['$id'];
+        }
+
+        foreach (['single', 'bulk', 'transaction'] as $mode) {
+            $rowId = ID::unique();
+            $params = [];
+            if ($mode === 'transaction') {
+                $transaction = $this->client->call(Client::METHOD_POST, '/tablesdb/transactions', $headers, []);
+                $this->assertEquals(201, $transaction['headers']['status-code']);
+                $params['transactionId'] = $transaction['body']['$id'];
+            }
+            $create = $mode === 'bulk'
+                ? ['rows' => [['$id' => $rowId, 'value' => 'created']]]
+                : ['rowId' => $rowId, 'data' => ['value' => 'created']];
+            $row = $this->client->call(Client::METHOD_POST, $path . '/rows', $headers, array_merge($create, $params));
+            $this->assertEquals(201, $row['headers']['status-code']);
+
+            $update = ['data' => ['value' => 'updated']];
+            if ($mode === 'bulk') {
+                $update['queries'] = [Query::equal('$id', [$rowId])->toString()];
+            }
+            $row = $this->client->call(Client::METHOD_PATCH, $path . '/rows' . ($mode === 'bulk' ? '' : '/' . $rowId), $headers, array_merge($update, $params));
+            $this->assertEquals(200, $row['headers']['status-code']);
+            if ($mode === 'transaction') {
+                $commit = $this->client->call(Client::METHOD_PATCH, '/tablesdb/transactions/' . $params['transactionId'], $headers, ['commit' => true]);
+                $this->assertEquals(200, $commit['headers']['status-code']);
+            }
+
+            foreach ($webhooks as $prefix => $webhookId) {
+                foreach (['create', 'update'] as $action) {
+                    $this->assertWebhookEvent($webhookId, "{$prefix}.{$databaseId}.tables.{$tableId}.rows.{$rowId}.{$action}");
+                }
+            }
+            $persisted = $this->client->call(Client::METHOD_GET, $path . '/rows/' . $rowId, $headers);
+            $this->assertEquals(200, $persisted['headers']['status-code']);
+            $this->assertEquals('updated', $persisted['body']['value']);
+        }
+
+        foreach ($webhooks as $webhookId) {
+            $webhook = $this->getWebhook($webhookId);
+            $this->assertSame(0, $webhook['body']['attempts']);
+            $this->assertSame('', $webhook['body']['logs']);
+            $this->deleteWebhook($webhookId);
+        }
+        $this->client->call(Client::METHOD_DELETE, '/tablesdb/' . $databaseId, $headers);
+    }
+
+    public function testTablesDBResources(): void
+    {
+        // Test for SUCCESS: database, table, column, and index events retain their type.
+        $headers = array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders());
+        $databaseId = ID::unique();
+        $tableId = ID::unique();
+        $database = '/tablesdb/' . $databaseId;
+        $table = $database . '/tables/' . $tableId;
+        $event = "tablesdb.{$databaseId}";
+        $webhook = $this->createWebhook(ID::unique(), 'TablesDB resources', [$event], true, 'http://request-catcher-webhook:5000/', false, null, null);
+        $this->assertEquals(201, $webhook['headers']['status-code']);
+        $webhookId = $webhook['body']['$id'];
+
+        $operations = [
+            [Client::METHOD_POST, '/tablesdb', ['databaseId' => $databaseId, 'name' => 'Webhook resources'], 201, $event . '.create'],
+            [Client::METHOD_PUT, $database, ['name' => 'Updated'], 200, $event . '.update'],
+            [Client::METHOD_POST, $database . '/tables', ['tableId' => $tableId, 'name' => 'Table'], 201, $event . ".tables.{$tableId}.create"],
+            [Client::METHOD_PUT, $table, ['name' => 'Updated'], 200, $event . ".tables.{$tableId}.update"],
+            [Client::METHOD_POST, $table . '/columns/string', ['key' => 'value', 'size' => 100, 'required' => false], 202, $event . ".tables.{$tableId}.columns.*.create"],
+            [Client::METHOD_PATCH, $table . '/columns/string/value', ['required' => false, 'default' => 'test'], 200, $event . ".tables.{$tableId}.columns.*.update"],
+            [Client::METHOD_POST, $table . '/indexes', ['key' => 'value_index', 'type' => 'key', 'columns' => ['value']], 202, $event . ".tables.{$tableId}.indexes.*.create"],
+            // Index and column deletion currently use the update event label.
+            [Client::METHOD_DELETE, $table . '/indexes/value_index', [], 204, $event . ".tables.{$tableId}.indexes.*.update"],
+            [Client::METHOD_DELETE, $table . '/columns/value', [], 204, $event . ".tables.{$tableId}.columns.*.update"],
+            [Client::METHOD_DELETE, $table, [], 204, $event . ".tables.{$tableId}.delete"],
+            [Client::METHOD_DELETE, $database, [], 204, $event . '.delete'],
+        ];
+        foreach ($operations as [$method, $path, $params, $status, $expectedEvent]) {
+            $response = $this->client->call($method, $path, $headers, $params);
+            $this->assertEquals($status, $response['headers']['status-code'], $method . ' ' . $path);
+            $deleting = $method === Client::METHOD_DELETE && (str_contains($path, '/columns/') || str_contains($path, '/indexes/'));
+            $this->assertWebhookEvent($webhookId, $expectedEvent, $deleting ? ['status' => 'deleting'] : []);
+            if ($status === 202) {
+                $resource = str_contains($path, '/columns/') ? '/columns/value' : '/indexes/value_index';
+                $this->assertEventually(function () use ($table, $resource, $headers) {
+                    $response = $this->client->call(Client::METHOD_GET, $table . $resource, $headers);
+                    $this->assertEquals('available', $response['body']['status']);
+                }, 15000, 500);
+            }
+        }
+        $this->deleteWebhook($webhookId);
+    }
+
+    private function assertWebhookEvent(string $webhookId, string $event, array $payload = []): void
+    {
+        $delivery = $this->getLastRequestForProject($this->getProject()['$id'], queryParams: [
+            'header_X-Appwrite-Webhook-Id' => $webhookId,
+        ], maxAttempts: 30, probe: function (array $request) use ($event, $payload) {
+            $this->assertContains($event, explode(',', $request['headers']['X-Appwrite-Webhook-Events'] ?? ''));
+            foreach ($payload as $key => $value) {
+                $this->assertSame($value, $request['data'][$key] ?? null);
+            }
+        });
+        $this->assertNotEmpty($delivery, 'Missing webhook delivery: ' . $event);
+    }
+
     // Tests for all auth scenarios
 
     public function testCreateWebhook(): void

--- a/tests/e2e/Services/Webhooks/WebhooksBase.php
+++ b/tests/e2e/Services/Webhooks/WebhooksBase.php
@@ -15,7 +15,7 @@ trait WebhooksBase
 
     public function testTablesDBRows(): void
     {
-        // Test for SUCCESS: single, bulk, and committed writes deliver both namespaces.
+        // Test for SUCCESS: row writes deliver TablesDB events and legacy aliases.
         $headers = array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
@@ -43,107 +43,30 @@ trait WebhooksBase
             $webhooks[$prefix] = $webhook['body']['$id'];
         }
 
-        foreach (['single', 'bulk', 'transaction'] as $mode) {
-            $rowId = ID::unique();
-            $params = [];
-            if ($mode === 'transaction') {
-                $transaction = $this->client->call(Client::METHOD_POST, '/tablesdb/transactions', $headers, []);
-                $this->assertEquals(201, $transaction['headers']['status-code']);
-                $params['transactionId'] = $transaction['body']['$id'];
-            }
-            $create = $mode === 'bulk'
-                ? ['rows' => [['$id' => $rowId, 'value' => 'created']]]
-                : ['rowId' => $rowId, 'data' => ['value' => 'created']];
-            $row = $this->client->call(Client::METHOD_POST, $path . '/rows', $headers, array_merge($create, $params));
-            $this->assertEquals(201, $row['headers']['status-code']);
+        $rowId = ID::unique();
+        $row = $this->client->call(Client::METHOD_POST, $path . '/rows', $headers, [
+            'rowId' => $rowId, 'data' => ['value' => 'created'],
+        ]);
+        $this->assertEquals(201, $row['headers']['status-code']);
+        $row = $this->client->call(Client::METHOD_PATCH, $path . '/rows/' . $rowId, $headers, [
+            'data' => ['value' => 'updated'],
+        ]);
+        $this->assertEquals(200, $row['headers']['status-code']);
 
-            $update = ['data' => ['value' => 'updated']];
-            if ($mode === 'bulk') {
-                $update['queries'] = [Query::equal('$id', [$rowId])->toString()];
+        foreach ($webhooks as $prefix => $webhookId) {
+            foreach (['create' => 'created', 'update' => 'updated'] as $action => $value) {
+                $event = "{$prefix}.{$databaseId}.tables.{$tableId}.rows.{$rowId}.{$action}";
+                $delivery = $this->getLastRequestForProject($this->getProject()['$id'], queryParams: [
+                    'header_X-Appwrite-Webhook-Id' => $webhookId,
+                ], probe: function (array $request) use ($event) {
+                    $this->assertContains($event, explode(',', $request['headers']['X-Appwrite-Webhook-Events'] ?? ''));
+                });
+                $this->assertNotEmpty($delivery, 'Missing webhook delivery: ' . $event);
+                $this->assertSame($value, $delivery['data']['value']);
             }
-            $row = $this->client->call(Client::METHOD_PATCH, $path . '/rows' . ($mode === 'bulk' ? '' : '/' . $rowId), $headers, array_merge($update, $params));
-            $this->assertEquals(200, $row['headers']['status-code']);
-            if ($mode === 'transaction') {
-                $commit = $this->client->call(Client::METHOD_PATCH, '/tablesdb/transactions/' . $params['transactionId'], $headers, ['commit' => true]);
-                $this->assertEquals(200, $commit['headers']['status-code']);
-            }
-
-            foreach ($webhooks as $prefix => $webhookId) {
-                foreach (['create', 'update'] as $action) {
-                    $this->assertWebhookEvent($webhookId, "{$prefix}.{$databaseId}.tables.{$tableId}.rows.{$rowId}.{$action}");
-                }
-            }
-            $persisted = $this->client->call(Client::METHOD_GET, $path . '/rows/' . $rowId, $headers);
-            $this->assertEquals(200, $persisted['headers']['status-code']);
-            $this->assertEquals('updated', $persisted['body']['value']);
-        }
-
-        foreach ($webhooks as $webhookId) {
-            $webhook = $this->getWebhook($webhookId);
-            $this->assertSame(0, $webhook['body']['attempts']);
-            $this->assertSame('', $webhook['body']['logs']);
             $this->deleteWebhook($webhookId);
         }
         $this->client->call(Client::METHOD_DELETE, '/tablesdb/' . $databaseId, $headers);
-    }
-
-    public function testTablesDBResources(): void
-    {
-        // Test for SUCCESS: database, table, column, and index events retain their type.
-        $headers = array_merge([
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $this->getProject()['$id'],
-        ], $this->getHeaders());
-        $databaseId = ID::unique();
-        $tableId = ID::unique();
-        $database = '/tablesdb/' . $databaseId;
-        $table = $database . '/tables/' . $tableId;
-        $event = "tablesdb.{$databaseId}";
-        $webhook = $this->createWebhook(ID::unique(), 'TablesDB resources', [$event], true, 'http://request-catcher-webhook:5000/', false, null, null);
-        $this->assertEquals(201, $webhook['headers']['status-code']);
-        $webhookId = $webhook['body']['$id'];
-
-        $operations = [
-            [Client::METHOD_POST, '/tablesdb', ['databaseId' => $databaseId, 'name' => 'Webhook resources'], 201, $event . '.create'],
-            [Client::METHOD_PUT, $database, ['name' => 'Updated'], 200, $event . '.update'],
-            [Client::METHOD_POST, $database . '/tables', ['tableId' => $tableId, 'name' => 'Table'], 201, $event . ".tables.{$tableId}.create"],
-            [Client::METHOD_PUT, $table, ['name' => 'Updated'], 200, $event . ".tables.{$tableId}.update"],
-            [Client::METHOD_POST, $table . '/columns/string', ['key' => 'value', 'size' => 100, 'required' => false], 202, $event . ".tables.{$tableId}.columns.*.create"],
-            [Client::METHOD_PATCH, $table . '/columns/string/value', ['required' => false, 'default' => 'test'], 200, $event . ".tables.{$tableId}.columns.*.update"],
-            [Client::METHOD_POST, $table . '/indexes', ['key' => 'value_index', 'type' => 'key', 'columns' => ['value']], 202, $event . ".tables.{$tableId}.indexes.*.create"],
-            // Index and column deletion currently use the update event label.
-            [Client::METHOD_DELETE, $table . '/indexes/value_index', [], 204, $event . ".tables.{$tableId}.indexes.*.update"],
-            [Client::METHOD_DELETE, $table . '/columns/value', [], 204, $event . ".tables.{$tableId}.columns.*.update"],
-            [Client::METHOD_DELETE, $table, [], 204, $event . ".tables.{$tableId}.delete"],
-            [Client::METHOD_DELETE, $database, [], 204, $event . '.delete'],
-        ];
-        foreach ($operations as [$method, $path, $params, $status, $expectedEvent]) {
-            $response = $this->client->call($method, $path, $headers, $params);
-            $this->assertEquals($status, $response['headers']['status-code'], $method . ' ' . $path);
-            $deleting = $method === Client::METHOD_DELETE && (str_contains($path, '/columns/') || str_contains($path, '/indexes/'));
-            $this->assertWebhookEvent($webhookId, $expectedEvent, $deleting ? ['status' => 'deleting'] : []);
-            if ($status === 202) {
-                $resource = str_contains($path, '/columns/') ? '/columns/value' : '/indexes/value_index';
-                $this->assertEventually(function () use ($table, $resource, $headers) {
-                    $response = $this->client->call(Client::METHOD_GET, $table . $resource, $headers);
-                    $this->assertEquals('available', $response['body']['status']);
-                }, 15000, 500);
-            }
-        }
-        $this->deleteWebhook($webhookId);
-    }
-
-    private function assertWebhookEvent(string $webhookId, string $event, array $payload = []): void
-    {
-        $delivery = $this->getLastRequestForProject($this->getProject()['$id'], queryParams: [
-            'header_X-Appwrite-Webhook-Id' => $webhookId,
-        ], maxAttempts: 30, probe: function (array $request) use ($event, $payload) {
-            $this->assertContains($event, explode(',', $request['headers']['X-Appwrite-Webhook-Events'] ?? ''));
-            foreach ($payload as $key => $value) {
-                $this->assertSame($value, $request['data'][$key] ?? null);
-            }
-        });
-        $this->assertNotEmpty($delivery, 'Missing webhook delivery: ' . $event);
     }
 
     // Tests for all auth scenarios

--- a/tests/unit/Event/EventTest.php
+++ b/tests/unit/Event/EventTest.php
@@ -224,46 +224,34 @@ final class EventTest extends TestCase
         $this->assertNotContains('teams.jets.update.status', $membershipEvents);
     }
 
-    public static function databaseEvents(): array
+    public static function databaseEvents(): \Iterator
     {
-        return [
-            'TablesDB create' => ['tablesdb', 'collections', 'documents', 'create', 'tablesdb.db.tables.col.rows.row.create'],
-            'TablesDB update' => ['tablesdb', 'tables', 'rows', 'update', 'tablesdb.db.tables.col.rows.row.update'],
-            'DocumentsDB create' => ['documentsdb', 'collections', 'documents', 'create', 'documentsdb.db.collections.col.documents.row.create'],
-            'VectorsDB update' => ['vectorsdb', 'collections', 'documents', 'update', 'vectorsdb.db.collections.col.documents.row.update'],
-            'legacy create' => ['legacy', 'collections', 'documents', 'create', 'databases.db.collections.col.documents.row.create'],
-        ];
+        yield 'TablesDB' => ['tablesdb', 'tablesdb.db.tables.col.rows.row.create'];
+        yield 'DocumentsDB' => ['documentsdb', 'documentsdb.db.collections.col.documents.row.create'];
+        yield 'VectorsDB' => ['vectorsdb', 'vectorsdb.db.collections.col.documents.row.create'];
+        yield 'legacy' => ['legacy', 'databases.db.collections.col.documents.row.create'];
+        yield 'no context' => [null, 'databases.db.collections.col.documents.row.create'];
     }
 
     #[DataProvider('databaseEvents')]
-    public function testPublishDatabaseEvents(string $type, string $collection, string $document, string $action, string $expected): void
+    public function testPublishDatabaseEvents(?string $type, string $expected): void
     {
-        $database = new Document(['type' => $type]);
-        $pattern = "databases.[databaseId].{$collection}.[collectionId].{$document}.[documentId].{$action}";
+        $database = $type === null ? null : new Document(['type' => $type]);
+        $pattern = 'databases.[databaseId].collections.[collectionId].documents.[documentId].create';
         $params = ['databaseId' => 'db', 'collectionId' => 'col', 'documentId' => 'row'];
-        $this->object->setEvent($pattern)->setContext('database', $database);
+        $this->object->setEvent($pattern);
+        if ($database !== null) {
+            $this->object->setContext('database', $database);
+        }
         foreach ($params as $key => $value) {
             $this->object->setParam($key, $value);
         }
 
         $this->object->trigger();
+        $message = Func::fromEvent(event: $pattern, params: $params, database: $database);
 
         $events = $this->publisher->getEvents($this->queue)[0]['events'];
         $this->assertSame($expected, $events[0]);
-        $wildcard = explode('.', $expected);
-        foreach ([1, 3, 5] as $index) {
-            $wildcard[$index] = '*';
-        }
-        $this->assertContains(implode('.', $wildcard), $events);
-        if ($type === 'tablesdb') {
-            $this->assertContains("databases.db.tables.col.rows.row.{$action}", $events);
-            $this->assertContains("databases.db.collections.col.documents.row.{$action}", $events);
-        } elseif ($type !== 'legacy') {
-            $this->assertNotContains("tablesdb.db.tables.col.rows.row.{$action}", $events);
-            $this->assertNotContains("databases.db.collections.col.documents.row.{$action}", $events);
-        }
-
-        $message = Func::fromEvent(event: $pattern, params: $params, database: $database);
         $this->assertSame($events, $message->events);
     }
 

--- a/tests/unit/Event/EventTest.php
+++ b/tests/unit/Event/EventTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Tests\Unit\Event;
 
 use Appwrite\Event\Event;
+use Appwrite\Event\Message\Func;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Utopia\Database\Document;
 
@@ -220,6 +222,49 @@ final class EventTest extends TestCase
 
         // An attribute of a sub-resource does not also belong to its parent.
         $this->assertNotContains('teams.jets.update.status', $membershipEvents);
+    }
+
+    public static function databaseEvents(): array
+    {
+        return [
+            'TablesDB create' => ['tablesdb', 'collections', 'documents', 'create', 'tablesdb.db.tables.col.rows.row.create'],
+            'TablesDB update' => ['tablesdb', 'tables', 'rows', 'update', 'tablesdb.db.tables.col.rows.row.update'],
+            'DocumentsDB create' => ['documentsdb', 'collections', 'documents', 'create', 'documentsdb.db.collections.col.documents.row.create'],
+            'VectorsDB update' => ['vectorsdb', 'collections', 'documents', 'update', 'vectorsdb.db.collections.col.documents.row.update'],
+            'legacy create' => ['legacy', 'collections', 'documents', 'create', 'databases.db.collections.col.documents.row.create'],
+        ];
+    }
+
+    #[DataProvider('databaseEvents')]
+    public function testPublishDatabaseEvents(string $type, string $collection, string $document, string $action, string $expected): void
+    {
+        $database = new Document(['type' => $type]);
+        $pattern = "databases.[databaseId].{$collection}.[collectionId].{$document}.[documentId].{$action}";
+        $params = ['databaseId' => 'db', 'collectionId' => 'col', 'documentId' => 'row'];
+        $this->object->setEvent($pattern)->setContext('database', $database);
+        foreach ($params as $key => $value) {
+            $this->object->setParam($key, $value);
+        }
+
+        $this->object->trigger();
+
+        $events = $this->publisher->getEvents($this->queue)[0]['events'];
+        $this->assertSame($expected, $events[0]);
+        $wildcard = explode('.', $expected);
+        foreach ([1, 3, 5] as $index) {
+            $wildcard[$index] = '*';
+        }
+        $this->assertContains(implode('.', $wildcard), $events);
+        if ($type === 'tablesdb') {
+            $this->assertContains("databases.db.tables.col.rows.row.{$action}", $events);
+            $this->assertContains("databases.db.collections.col.documents.row.{$action}", $events);
+        } elseif ($type !== 'legacy') {
+            $this->assertNotContains("tablesdb.db.tables.col.rows.row.{$action}", $events);
+            $this->assertNotContains("databases.db.collections.col.documents.row.{$action}", $events);
+        }
+
+        $message = Func::fromEvent(event: $pattern, params: $params, database: $database);
+        $this->assertSame($events, $message->events);
     }
 
     public function testGenerateMirrorEvents(): void


### PR DESCRIPTION
## Summary

Tracks [DAT-2542](https://linear.app/appwrite/issue/DAT-2542).

Fix database event namespaces being lost between HTTP operations, subscription matching, and webhook queue payloads. TablesDB routes use `databases.…` event templates internally; `Event::generateEvents()` needs the database document to project them to `tablesdb.…` while retaining legacy aliases. Realtime already supplied that context, but webhook/function matching and publishing did not.

- Pass database context through HTTP shutdown, bulk row writes, and transaction commit event matching.
- Use that context when constructing webhook payloads and function event messages, so matching and worker-visible event names agree.
- Set database context for database create/update/delete, which previously omitted it entirely.
- Preserve existing TablesDB `databases.…tables.…rows.…` and collection/document aliases. Keep DocumentsDB and VectorsDB namespaces distinct.

No new routes or subscription syntax. Existing column/index identifiers and their deletion-as-update event labels are unchanged.

## End-to-end verification

Built an isolated local stack from this checkout (PHP 8.5.10, PostgreSQL, Redis, combined worker, local request catcher). Created a console account, project, API key, database, table, and enabled webhook through real HTTP APIs. Row creation returned 201, update returned 200, and GET confirmed persisted data.

For each phase, stopped the worker and inspected `utopia-queue.queue.v1-webhooks`, then restarted it and polled the catcher. Only the subscription prefix changed; the webhook and destination stayed the same.

| Subscription | Before: queued / delivered | After: queued / delivered |
| --- | --- | --- |
| `tablesdb.*.tables.*.rows.*.create` + `.update` | 0 / 0 | 2 / 2 |
| `databases.*.tables.*.rows.*.create` + `.update` | 2 / 2 | 2 / 2 |

Delivered requests received HTTP 200. Both successful and missing-delivery cases showed `attempts: 0` and empty `logs`: those fields describe failures, not total deliveries.

Focused committed regressions:
- One E2E test for row create/update delivery and payloads, with separate TablesDB and legacy webhook subscriptions (console and server-key access).
- One data-driven unit test for database-context propagation into webhook and function messages, including the no-context fallback. Uses a generator provider as required by Rector.

Broader local verification also passed bulk writes, transaction commits, database/table lifecycle, and column/index operations on the same production fix. Those exploratory tests were removed from the final diff to keep the regression focused (test additions reduced from 178 to 89 lines).

### Passing checks

Executed in the isolated stack using `docker compose -f /tmp/plush-webhook-compose.json exec -T appwrite` as the command prefix:

```text
test tests/unit/Event/
  OK: 19 tests, 291 assertions

test tests/e2e/Services/Webhooks/ --filter='testTablesDBRows|testSecretRotationZeroDowntime|testCreateWebhookWithCustomSecret'
  OK: 6 tests, 139 assertions (console and server-key suites)

vendor/bin/rector process --dry-run --config tests/tools/rector.php
  PASS: full configured test scope; no changes required

vendor/bin/pint --test --config pint.json <10 changed PHP files>
  PASS

vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=1G --no-progress <10 changed PHP files>
  No errors

git diff --check
  PASS
```

Before the fix, the new publishing unit regression demonstrated the missing database prefixes. The original HTTP/Redis/catcher reproduction above independently confirmed the dropped webhook jobs.

## Scope and limitations

- This is backend/API verification; no UI screenshots are applicable.
- No production data or settings were changed. The reported customer's deployed version and exact subscriptions still need confirmation.
- Function message generation is unit-tested, but full deployed function-runtime execution was not tested. DocumentsDB/VectorsDB coverage here is unit-level, not service E2E.
- The full repository test suite was not run.
