### PR TITLE
fix(migrations): report membership counts

### DIFF
--- a/src/Appwrite/Utopia/Response/Model/MigrationReport.php
+++ b/src/Appwrite/Utopia/Response/Model/MigrationReport.php
@@ -23,6 +23,12 @@ class MigrationReport extends Model
                 'default' => 0,
                 'example' => 20,
             ])
+            ->addRule(Resource::TYPE_MEMBERSHIP, [
+                'type' => self::TYPE_INTEGER,
+                'description' => 'Number of memberships to be migrated.',
+                'default' => 0,
+                'example' => 20,
+            ])
             ->addRule(Resource::TYPE_DATABASE, [
                 'type' => self::TYPE_INTEGER,
                 'description' => 'Number of databases to be migrated.',

--- a/tests/unit/Utopia/Response/Model/MigrationReportTest.php
+++ b/tests/unit/Utopia/Response/Model/MigrationReportTest.php
@@ -4,21 +4,45 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Utopia\Response\Model;
 
+use Appwrite\Utopia\Response;
 use Appwrite\Utopia\Response\Model\MigrationReport;
 use PHPUnit\Framework\TestCase;
+use Swoole\Http\Response as SwooleResponse;
+use Utopia\Database\Document;
 use Utopia\Migration\Resource;
 
 final class MigrationReportTest extends TestCase
 {
+    protected Response $response;
+
+    public function setUp(): void
+    {
+        $this->response = new Response(new SwooleResponse());
+        $this->response->setModel(new MigrationReport());
+    }
+
     /**
      * The Appwrite source counts memberships per team while building a report.
-     * Without a rule for them the count is computed and then dropped on the way
-     * out, so the wizard shows teams with no memberships behind them.
+     * The count used to be computed and then dropped on the way out, leaving a
+     * report that showed teams with nothing behind them.
      */
     public function testReportsMembershipCounts(): void
     {
-        $rules = (new MigrationReport())->getRules();
+        $output = $this->response->output(new Document([
+            Resource::TYPE_TEAM => 2,
+            Resource::TYPE_MEMBERSHIP => 3,
+        ]), Response::MODEL_MIGRATION_REPORT);
 
-        $this->assertArrayHasKey(Resource::TYPE_MEMBERSHIP, $rules);
+        $this->assertSame(3, $output[Resource::TYPE_MEMBERSHIP]);
+    }
+
+    public function testReportsNoMembershipsAsZero(): void
+    {
+        $output = $this->response->output(
+            new Document([Resource::TYPE_TEAM => 2]),
+            Response::MODEL_MIGRATION_REPORT
+        );
+
+        $this->assertSame(0, $output[Resource::TYPE_MEMBERSHIP]);
     }
 }

--- a/tests/unit/Utopia/Response/Model/MigrationReportTest.php
+++ b/tests/unit/Utopia/Response/Model/MigrationReportTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Utopia\Response\Model;
+
+use Appwrite\Utopia\Response\Model\MigrationReport;
+use PHPUnit\Framework\TestCase;
+use Utopia\Migration\Resource;
+
+final class MigrationReportTest extends TestCase
+{
+    /**
+     * The Appwrite source counts memberships per team while building a report.
+     * Without a rule for them the count is computed and then dropped on the way
+     * out, so the wizard shows teams with no memberships behind them.
+     */
+    public function testReportsMembershipCounts(): void
+    {
+        $rules = (new MigrationReport())->getRules();
+
+        $this->assertArrayHasKey(Resource::TYPE_MEMBERSHIP, $rules);
+    }
+}


### PR DESCRIPTION
## What

`MigrationReport` had no rule for memberships, so the count the Appwrite source already computes was dropped on the way out.

The source counts memberships per team while building a report (`reportAuth` walks each team and adds `listMemberships(...)->total`), but with no `addRule` for it the value never reaches the response. A report came back showing teams with nothing behind them, and a caller sizing up a migration had no way to see how many memberships it would move.

Observed against a real 1.9.6 source — the response carried `user`, `team`, `provider`, `topic`, `subscriber` and `message`, and no `membership` key at all despite it being requested:

```
{"user":3,"team":2,"provider":1,"topic":2,"subscriber":2,"message":2,...}
```

## Changes

- `MigrationReport.php` — one `addRule` for `Resource::TYPE_MEMBERSHIP`, next to the team rule it belongs with.
- `tests/unit/Utopia/Response/Model/MigrationReportTest.php` — new, following `ExecutionTest`.

## Testing

- `vendor/bin/phpunit tests/unit/Utopia/Response/Model/MigrationReportTest.php` — passes, and fails without the rule
- `composer lint` — passed on both files
- `phpstan --level 4` on both files — no errors

## Note

This adds a field to a response model, so the API specs want regenerating before release. The `Generate Specs` workflow is `workflow_dispatch`-only and publishes to `appwrite/specs`, so I have left it alone rather than running it from a PR branch.