### PR TITLE
fix(vcs): honour the console URL scheme in installation callback defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -943,6 +943,10 @@ services:
       - _APP_LOGGING_CONFIG
       - _APP_LOGGING_FORMAT
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_OPTIONS_FORCE_HTTPS
+      - _APP_DOMAIN
+      - _APP_CONSOLE_DOMAIN
+      - _APP_CONSOLE_URL_SCHEME=root
     extra_hosts:
       - host.docker.internal:host-gateway
 

--- a/src/Appwrite/Platform/Modules/VCS/Http/Callback/Base.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/Callback/Base.php
@@ -105,9 +105,13 @@ abstract class Base extends Action
         $protocol = System::getEnv('_APP_OPTIONS_FORCE_HTTPS') === 'disabled' ? 'http' : 'https';
         $hostname = $platform['consoleHostname'] ?? '';
 
+        $defaultRedirect = System::getEnv('_APP_CONSOLE_URL_SCHEME', 'legacy') !== 'root'
+            ? $protocol . '://' . $hostname . "/console/project-$region-$projectId/settings/git-installations"
+            : $protocol . '://' . $hostname . "/projects/$projectId/settings";
+
         $defaultState = [
-            'success' => $protocol . '://' . $hostname . "/console/project-$region-$projectId/settings/git-installations",
-            'failure' => $protocol . '://' . $hostname . "/console/project-$region-$projectId/settings/git-installations",
+            'success' => $defaultRedirect,
+            'failure' => $defaultRedirect,
         ];
 
         $redirectSuccess = empty($state['success']) ? $defaultState['success'] : $state['success'];

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Callback/Get.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Callback/Get.php
@@ -102,9 +102,13 @@ class Get extends Action
         $protocol = System::getEnv('_APP_OPTIONS_FORCE_HTTPS') === 'disabled' ? 'http' : 'https';
         $hostname = $platform['consoleHostname'] ?? '';
 
+        $defaultRedirect = System::getEnv('_APP_CONSOLE_URL_SCHEME', 'legacy') !== 'root'
+            ? $protocol . '://' . $hostname . "/console/project-$region-$projectId/settings/git-installations"
+            : $protocol . '://' . $hostname . "/projects/$projectId/settings";
+
         $defaultState = [
-            'success' => $protocol . '://' . $hostname . "/console/project-$region-$projectId/settings/git-installations",
-            'failure' => $protocol . '://' . $hostname . "/console/project-$region-$projectId/settings/git-installations",
+            'success' => $defaultRedirect,
+            'failure' => $defaultRedirect,
         ];
 
         $redirectSuccess = empty($state['success']) ? $defaultState['success'] : $state['success'];

--- a/src/Appwrite/Platform/Modules/VCS/Http/Origin/Callback/Get.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/Origin/Callback/Get.php
@@ -108,9 +108,13 @@ class Get extends Action
         $protocol = System::getEnv('_APP_OPTIONS_FORCE_HTTPS') === 'disabled' ? 'http' : 'https';
         $hostname = $platform['consoleHostname'] ?? '';
 
+        $defaultRedirect = System::getEnv('_APP_CONSOLE_URL_SCHEME', 'legacy') !== 'root'
+            ? $protocol . '://' . $hostname . "/console/project-$region-$projectId/settings/git-installations"
+            : $protocol . '://' . $hostname . "/projects/$projectId/settings";
+
         $defaultState = [
-            'success' => $protocol . '://' . $hostname . "/console/project-$region-$projectId/settings/git-installations",
-            'failure' => $protocol . '://' . $hostname . "/console/project-$region-$projectId/settings/git-installations",
+            'success' => $defaultRedirect,
+            'failure' => $defaultRedirect,
         ];
 
         $state = \array_merge($defaultState, \array_filter($state));

--- a/tests/e2e/Services/VCSGitea/VCSGiteaConsoleClientTest.php
+++ b/tests/e2e/Services/VCSGitea/VCSGiteaConsoleClientTest.php
@@ -312,15 +312,10 @@ final class VCSGiteaConsoleClientTest extends Scope
         ], true, false);
 
         $this->assertEquals(301, $callback['headers']['status-code']);
-        $location = (string) ($callback['headers']['location'] ?? '');
-
-        if ($redirects) {
-            $this->assertSame($consoleUrl, $location);
-        } else {
-            // Nothing was signed into state, so the callback falls back to its own
-            // console URL, whose shape follows _APP_CONSOLE_URL_SCHEME.
-            $this->assertStringContainsString($projectId, $location);
-        }
+        $this->assertSame(
+            $redirects ? $consoleUrl : $this->defaultRedirectUrl($projectId),
+            (string) ($callback['headers']['location'] ?? '')
+        );
 
         $installations = $this->client->call(Client::METHOD_GET, '/vcs/installations', \array_merge([
             'x-appwrite-project' => $projectId,
@@ -537,9 +532,7 @@ final class VCSGiteaConsoleClientTest extends Scope
         ]);
 
         $this->assertEquals(301, $response['headers']['status-code']);
-        $location = (string) $response['headers']['location'];
-        $this->assertStringContainsString($projectId, $location);
-        $this->assertStringContainsString('?error=', $location);
+        $this->assertStringStartsWith($this->defaultRedirectUrl($projectId) . '?error=', (string) $response['headers']['location']);
     }
 
     public function testCreateInstallationWithInvalidState(): void
@@ -587,6 +580,18 @@ final class VCSGiteaConsoleClientTest extends Scope
         $installation = $this->createInstallationHelper(redirects: false);
 
         $this->assertNotEmpty($installation['$id']);
+    }
+
+    /**
+     * The redirect the callback falls back to when state carries no URLs. The
+     * suite runs under both schemes -- server-ce sets root, cloud leaves the
+     * default -- and the tests share the appwrite container's environment.
+     */
+    private function defaultRedirectUrl(string $projectId): string
+    {
+        return System::getEnv('_APP_CONSOLE_URL_SCHEME', 'legacy') !== 'root'
+            ? $this->gitInstallationsUrl($projectId)
+            : "http://localhost/projects/{$projectId}/settings";
     }
 
     /**

--- a/tests/e2e/Services/VCSGitea/VCSGiteaConsoleClientTest.php
+++ b/tests/e2e/Services/VCSGitea/VCSGiteaConsoleClientTest.php
@@ -312,7 +312,15 @@ final class VCSGiteaConsoleClientTest extends Scope
         ], true, false);
 
         $this->assertEquals(301, $callback['headers']['status-code']);
-        $this->assertEquals($consoleUrl, $callback['headers']['location'] ?? '');
+        $location = (string) ($callback['headers']['location'] ?? '');
+
+        if ($redirects) {
+            $this->assertSame($consoleUrl, $location);
+        } else {
+            // Nothing was signed into state, so the callback falls back to its own
+            // console URL, whose shape follows _APP_CONSOLE_URL_SCHEME.
+            $this->assertStringContainsString($projectId, $location);
+        }
 
         $installations = $this->client->call(Client::METHOD_GET, '/vcs/installations', \array_merge([
             'x-appwrite-project' => $projectId,
@@ -529,7 +537,9 @@ final class VCSGiteaConsoleClientTest extends Scope
         ]);
 
         $this->assertEquals(301, $response['headers']['status-code']);
-        $this->assertStringStartsWith($this->gitInstallationsUrl($projectId) . '?error=', (string) $response['headers']['location']);
+        $location = (string) $response['headers']['location'];
+        $this->assertStringContainsString($projectId, $location);
+        $this->assertStringContainsString('?error=', $location);
     }
 
     public function testCreateInstallationWithInvalidState(): void
@@ -580,9 +590,9 @@ final class VCSGiteaConsoleClientTest extends Scope
     }
 
     /**
-     * The callback builds its fallback redirect from the project's region, so the
-     * expected URL follows the region the scope's project was created in: Cloud
-     * CI creates projects in a region other than default.
+     * A console git-installations URL of the shape the console signs into state.
+     * It carries the project's region, which Cloud CI sets to something other
+     * than default.
      */
     private function gitInstallationsUrl(string $projectId): string
     {


### PR DESCRIPTION
## What does this PR do?

Gates the VCS installation callbacks' default redirect on `_APP_CONSOLE_URL_SCHEME`, the same flag the commit statuses and the authorize-contributor link already use.

All three callbacks — the shared OAuth2 base, GitHub, and Origin — hardcoded their fallback to `/console/project-{region}-{projectId}/settings/git-installations`. On a root-scheme install that path does not exist, so the user landed on a dead page. Root scheme now falls back to `/projects/{projectId}/settings`.

The fallback only fires when `state` carries no `success` / `failure` URL. The console always signs those in, but an install started from the provider's side (installing the GitHub App straight from GitHub, for example) reaches the callback without them, which is exactly the path that was broken.

Cloud is a strict no-op: it sets no `_APP_CONSOLE_URL_SCHEME`, so its legacy branch is byte-identical to the string that was there before.

## Test Plan

`tests/e2e/Services/VCSGitea/VCSGiteaConsoleClientTest.php` covers the fallback in two places: `createInstallationHelper(redirects: false)` and `testCreateInstallationWithEmptyRedirects`.

That suite runs under both schemes — server-ce's `docker-compose.yml` sets `_APP_CONSOLE_URL_SCHEME=root`, cloud leaves it at the default. Both CI stacks exec the suite *inside* the appwrite container, so the tests share its environment; `defaultRedirectUrl()` reads the flag and asserts the exact expected URL for whichever scheme is running, the same way this file already reads `_APP_OPENSSL_KEY_V1` and `_APP_REGION`.

The second commit exists because the first one relaxed those assertions to substring checks on the project id, on the mistaken premise that a test could not see the flag. That relaxation was invariant along the one axis this PR changes — both URL shapes interpolate the project id — so inverting or deleting the ternary would have stayed green, and it dropped the region coverage cloud depends on. Now fixed.

Pint, PHPStan and Rector clean on all four changed files. Server-ce CI green on VCSGitea and VCSGitHub.

## Related PRs and Issues

Follow-up to ea34e448fd, which moved the commit statuses and the authorize-contributor link onto this flag but left the callbacks behind.

Note for review: the new console has no `settings/git-installations` route, so `/projects/{projectId}/settings` is the closest existing target. Happy to change it if a dedicated page is planned.