### PR TITLE
feat: orchestrator 2.2 — typed callbacks, errors in build logs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,7 @@
         "league/csv": "9.14.*",
         "enshrined/svg-sanitize": "0.22.*",
         "utopia-php/client": "^0.4.4",
-        "open-runtimes/sdk-for-php": "^1.0.1",
+        "open-runtimes/sdk-for-php": "^2.0",
         "utopia-php/schedule": "^0.2.0",
         "utopia-php/usage": "^0.16.4",
         "utopia-php/query": "0.6.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e13d1ffb302f53ff62d44044c950e39e",
+    "content-hash": "179b6295c070315f1d35007e2da5867d",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -1002,16 +1002,16 @@
         },
         {
             "name": "open-runtimes/sdk-for-php",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/open-runtimes/sdk-for-php.git",
-                "reference": "b3566132b2dea7995959e60e8b6d8d6c3745d711"
+                "reference": "97ae1280f9dcdbdebd7bf69a52d36f57807f2720"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/open-runtimes/sdk-for-php/zipball/b3566132b2dea7995959e60e8b6d8d6c3745d711",
-                "reference": "b3566132b2dea7995959e60e8b6d8d6c3745d711",
+                "url": "https://api.github.com/repos/open-runtimes/sdk-for-php/zipball/97ae1280f9dcdbdebd7bf69a52d36f57807f2720",
+                "reference": "97ae1280f9dcdbdebd7bf69a52d36f57807f2720",
                 "shasum": ""
             },
             "require": {
@@ -1039,9 +1039,9 @@
             "description": "PHP SDK for the Open Runtimes orchestrator: jobs, deployments, and sandboxes.",
             "support": {
                 "issues": "https://github.com/open-runtimes/sdk-for-php/issues",
-                "source": "https://github.com/open-runtimes/sdk-for-php/tree/1.0.1"
+                "source": "https://github.com/open-runtimes/sdk-for-php/tree/2.0.0"
             },
-            "time": "2026-09-09T15:05:02+00:00"
+            "time": "2026-09-10T11:51:16+00:00"
         },
         {
             "name": "open-telemetry/api",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1687,7 +1687,7 @@ services:
     # One image carrying every orchestrator control plane. Appwrite drives the
     # jobs plane today; the per-plane images exist for Kubernetes, where each
     # scales, fails and gets RBAC on its own.
-    image: ghcr.io/open-runtimes/orchestrator/orchestrator:2.1.1
+    image: ghcr.io/open-runtimes/orchestrator/orchestrator:2.2.0
     restart: unless-stopped
     user: root
     networks:

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -18,6 +18,11 @@ use Appwrite\Usage\Build as BuildUsage;
 use Appwrite\Usage\Context as UsageContext;
 use Appwrite\Utopia\Response\Model\Deployment;
 use Appwrite\Vcs\Factory as VcsFactory;
+use OpenRuntimes\Orchestrator\Callback\JobArtifact;
+use OpenRuntimes\Orchestrator\Callback\JobExit;
+use OpenRuntimes\Orchestrator\Callback\JobLog;
+use OpenRuntimes\Orchestrator\Enum\CallbackEvent;
+use OpenRuntimes\Orchestrator\Enum\ErrorCode;
 use Utopia\Bus\Bus;
 use Utopia\Cache\Cache;
 use Utopia\Database\Database;
@@ -134,11 +139,11 @@ class Jobs extends Action
 
             $statusBefore = $deployment->getAttribute('status');
 
-            $deployment = match ($event->event) {
-                'orchestrator.job.log' => $this->onLog($dbForProject, $dbForPlatform, $project, $deployment, $event->data, $vcsFactory, $platform),
-                'orchestrator.job.artifact' => $this->onArtifact($dbForProject, $dbForPlatform, $project, $deployment, $event->data, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
-                'orchestrator.job.exit' => $this->onExit($dbForProject, $dbForPlatform, $project, $deployment, $event->data, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
-                'orchestrator.job.complete' => $this->onComplete($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
+            $deployment = match (CallbackEvent::tryFrom($event->event)) {
+                CallbackEvent::Log => $this->onLog($dbForProject, $dbForPlatform, $project, $deployment, JobLog::fromArray($event->data), $vcsFactory, $platform),
+                CallbackEvent::Artifact => $this->onArtifact($dbForProject, $dbForPlatform, $project, $deployment, JobArtifact::fromArray($event->data), $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
+                CallbackEvent::Exit => $this->onExit($dbForProject, $dbForPlatform, $project, $deployment, JobExit::fromArray($event->data), $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
+                CallbackEvent::Complete => $this->onComplete($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
                 default => $this->onCallback($event->event, $dbForProject, $dbForPlatform, $project, $deployment, $event->data, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
             };
 
@@ -163,10 +168,9 @@ class Jobs extends Action
         }, self::LOCK_TIMEOUT);
     }
 
-    protected function onLog(Database $dbForProject, Database $dbForPlatform, Document $project, Document $deployment, array $data, VcsFactory $vcsFactory, array $platform): Document
+    protected function onLog(Database $dbForProject, Database $dbForPlatform, Document $project, Document $deployment, JobLog $log, VcsFactory $vcsFactory, array $platform): Document
     {
-        $lines = $data['lines'] ?? [];
-        $chunk = \is_array($lines) ? \implode("\n", $lines) : (string) $lines;
+        $chunk = \implode("\n", $log->lines);
         if ($chunk === '') {
             return $deployment;
         }
@@ -267,7 +271,7 @@ class Jobs extends Action
         Database $dbForPlatform,
         Document $project,
         Document $deployment,
-        array $data,
+        JobArtifact $artifact,
         UsageContext $usage,
         UsagePublisher $publisherForUsage,
         ScreenshotPublisher $publisherForScreenshots,
@@ -278,10 +282,11 @@ class Jobs extends Action
         array $plan,
         Bus $bus,
     ): Document {
-        if (($data['artifactId'] ?? '') === 'manifest') {
+        $failed = $artifact->status === 'failed';
+        if ($artifact->artifactId === 'manifest') {
             // A failed manifest degrades to an empty listing (detection
             // skipped), never a failed build.
-            $manifest = ($data['status'] ?? '') === 'success' ? ($data['content'] ?? null) : null;
+            $manifest = $artifact->status === 'success' ? $artifact->content : null;
             $files = \is_array($manifest) ? (array) ($manifest['files'] ?? []) : [];
             $cache->save('jobs-manifest-' . $deployment->getId(), ['files' => \array_values($files)]);
 
@@ -291,12 +296,12 @@ class Jobs extends Action
         // On a remote builds device the sidecar delivers the artifact. Join its
         // callback explicitly because complete is emitted after artifacts but
         // the queue can deliver those callbacks out of order.
-        if (($data['artifactId'] ?? '') === 'output') {
-            if (($data['status'] ?? '') === 'failed') {
-                return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, 'Build output upload failed: ' . self::failureMessage($data, 'unknown error'), $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
+        if ($artifact->artifactId === 'output') {
+            if ($failed) {
+                return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, 'Build output upload failed: ' . ($artifact->error?->message ?? 'unknown error'), $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
             }
 
-            if (($data['status'] ?? '') !== 'success') {
+            if ($artifact->status !== 'success') {
                 return $deployment;
             }
 
@@ -311,16 +316,16 @@ class Jobs extends Action
         // status) rather than waiting for the bare exit code. The build cache
         // upload is the one best-effort artifact: losing it costs the next
         // build time, not this one.
-        if (($data['status'] ?? '') === 'failed' && ($data['artifactId'] ?? '') !== 'cache') {
-            return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, self::failureMessage($data, 'Build failed.'), $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
+        if ($failed && $artifact->artifactId !== 'cache') {
+            return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, $artifact->error?->message ?? 'Build failed.', $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
         }
 
-        if (($data['artifactId'] ?? '') !== 'sourceSize' || ($data['status'] ?? '') !== 'success') {
+        if ($artifact->artifactId !== 'sourceSize' || $artifact->status !== 'success') {
             return $deployment;
         }
 
         // A stat artifact reports the file's byte size as its 'content'.
-        $size = (int) ($data['content'] ?? 0);
+        $size = (int) $artifact->content;
         if ($size <= 0) {
             return $deployment;
         }
@@ -343,7 +348,7 @@ class Jobs extends Action
         Database $dbForPlatform,
         Document $project,
         Document $deployment,
-        array $data,
+        JobExit $exit,
         UsageContext $usage,
         UsagePublisher $publisherForUsage,
         ScreenshotPublisher $publisherForScreenshots,
@@ -354,29 +359,19 @@ class Jobs extends Action
         array $plan,
         Bus $bus,
     ): Document {
-        $exitCode = (int) ($data['exitCode'] ?? 0);
-        if ($exitCode !== 0) {
+        if ($exit->error !== null) {
             // The build command's own exit stays an exit code; anything else
             // (out of memory, failed before it could start) is explained.
-            $message = ($data['error']['code'] ?? '') === 'job_exit_nonzero' ? '' : self::failureMessage($data, '');
+            $message = $exit->error->code === ErrorCode::JobExitNonzero
+                ? "Build failed with exit code {$exit->exitCode}."
+                : $exit->error->message;
 
-            return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, $message !== '' ? $message : "Build failed with exit code {$exitCode}.", $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
+            return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, $message, $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
         }
 
         $cache->save('jobs-exit-' . $deployment->getId(), true);
 
         return $this->ready($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus);
-    }
-
-    /**
-     * The message of a callback's `error`, or the fallback. Tolerates the bare
-     * string an orchestrator older than 2.2 sends in its place.
-     */
-    protected static function failureMessage(array $data, string $fallback): string
-    {
-        $message = $data['error']['message'] ?? '';
-
-        return \is_string($message) && $message !== '' ? $message : $fallback;
     }
 
     /**

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -127,11 +127,8 @@ class Jobs extends Action
                 $cache->save($key, true);
             }
 
-            // A build finalizes once. A failed artifact fails it with the
-            // artifact's own message, and the exit that follows must not
-            // overwrite that with a bare exit code.
             $deployment = $dbForProject->getDocument('deployments', $deploymentId);
-            if ($deployment->isEmpty() || \in_array($deployment->getAttribute('status'), ['ready', 'failed', 'canceled'], true)) {
+            if ($deployment->isEmpty() || $deployment->getAttribute('status') === 'canceled') {
                 return;
             }
 
@@ -296,7 +293,7 @@ class Jobs extends Action
         // the queue can deliver those callbacks out of order.
         if (($data['artifactId'] ?? '') === 'output') {
             if (($data['status'] ?? '') === 'failed') {
-                return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, 'Build output upload failed: ' . ($data['error'] ?? 'unknown error'), $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
+                return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, 'Build output upload failed: ' . self::failureMessage($data, 'unknown error'), $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
             }
 
             if (($data['status'] ?? '') !== 'success') {
@@ -536,6 +533,15 @@ class Jobs extends Action
         Bus $bus,
         int $buildSize = 0,
     ): Document {
+        // A build finalizes once. A failed artifact fails it with the
+        // artifact's own message, and the exit that follows must not overwrite
+        // that with a bare exit code. Late logs and metadata still land: only
+        // the outcome is sealed. Sound under the per-deployment lock, which
+        // serializes callbacks and re-reads the document for each.
+        if (\in_array($deployment->getAttribute('status'), ['ready', 'failed'], true)) {
+            return $deployment;
+        }
+
         $collection = $deployment->getAttribute('resourceType', 'functions');
         $resource = $dbForProject->getDocument($collection, $deployment->getAttribute('resourceId'));
 

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -298,7 +298,7 @@ class Jobs extends Action
         // the queue can deliver those callbacks out of order.
         if ($artifact->artifactId === 'output') {
             if ($failed) {
-                return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, 'Build output upload failed: ' . ($artifact->error?->message ?? 'unknown error'), $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
+                return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, 'Build output upload failed: ' . ($artifact->error->message ?? 'unknown error'), $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
             }
 
             if ($artifact->status !== 'success') {
@@ -317,7 +317,7 @@ class Jobs extends Action
         // upload is the one best-effort artifact: losing it costs the next
         // build time, not this one.
         if ($failed && $artifact->artifactId !== 'cache') {
-            return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, $artifact->error?->message ?? 'Build failed.', $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
+            return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, $artifact->error->message ?? 'Build failed.', $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
         }
 
         if ($artifact->artifactId !== 'sourceSize' || $artifact->status !== 'success') {

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -127,8 +127,11 @@ class Jobs extends Action
                 $cache->save($key, true);
             }
 
+            // A build finalizes once. A failed artifact fails it with the
+            // artifact's own message, and the exit that follows must not
+            // overwrite that with a bare exit code.
             $deployment = $dbForProject->getDocument('deployments', $deploymentId);
-            if ($deployment->isEmpty() || $deployment->getAttribute('status') === 'canceled') {
+            if ($deployment->isEmpty() || \in_array($deployment->getAttribute('status'), ['ready', 'failed', 'canceled'], true)) {
                 return;
             }
 
@@ -137,7 +140,7 @@ class Jobs extends Action
             $deployment = match ($event->event) {
                 'orchestrator.job.log' => $this->onLog($dbForProject, $dbForPlatform, $project, $deployment, $event->data, $vcsFactory, $platform),
                 'orchestrator.job.artifact' => $this->onArtifact($dbForProject, $dbForPlatform, $project, $deployment, $event->data, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
-                'orchestrator.job.exit' => $this->onExit($dbForProject, $dbForPlatform, $project, $deployment, (int) ($event->data['exitCode'] ?? 0), $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
+                'orchestrator.job.exit' => $this->onExit($dbForProject, $dbForPlatform, $project, $deployment, $event->data, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
                 'orchestrator.job.complete' => $this->onComplete($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
                 default => $this->onCallback($event->event, $dbForProject, $dbForPlatform, $project, $deployment, $event->data, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus),
             };
@@ -305,6 +308,16 @@ class Jobs extends Action
             return $this->ready($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus);
         }
 
+        // Any other artifact failing dooms the build — the orchestrator aborts
+        // the job on a pre-job failure, and a lost output has nothing to serve
+        // — so fail it now with the artifact's own message (which file, which
+        // status) rather than waiting for the bare exit code. The build cache
+        // upload is the one best-effort artifact: losing it costs the next
+        // build time, not this one.
+        if (($data['status'] ?? '') === 'failed' && ($data['artifactId'] ?? '') !== 'cache') {
+            return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, self::failureMessage($data, 'Build failed.'), $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
+        }
+
         if (($data['artifactId'] ?? '') !== 'sourceSize' || ($data['status'] ?? '') !== 'success') {
             return $deployment;
         }
@@ -333,7 +346,7 @@ class Jobs extends Action
         Database $dbForPlatform,
         Document $project,
         Document $deployment,
-        int $exitCode,
+        array $data,
         UsageContext $usage,
         UsagePublisher $publisherForUsage,
         ScreenshotPublisher $publisherForScreenshots,
@@ -344,13 +357,29 @@ class Jobs extends Action
         array $plan,
         Bus $bus,
     ): Document {
+        $exitCode = (int) ($data['exitCode'] ?? 0);
         if ($exitCode !== 0) {
-            return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, "Build failed with exit code {$exitCode}.", $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
+            // The build command's own exit stays an exit code; anything else
+            // (out of memory, failed before it could start) is explained.
+            $message = ($data['error']['code'] ?? '') === 'job_exit_nonzero' ? '' : self::failureMessage($data, '');
+
+            return $this->finalize($dbForProject, $dbForPlatform, $project, $deployment, false, $message !== '' ? $message : "Build failed with exit code {$exitCode}.", $usage, $publisherForUsage, $publisherForScreenshots, $vcsFactory, $platform, $bus);
         }
 
         $cache->save('jobs-exit-' . $deployment->getId(), true);
 
         return $this->ready($dbForProject, $dbForPlatform, $project, $deployment, $usage, $publisherForUsage, $publisherForScreenshots, $deviceForBuilds, $vcsFactory, $cache, $platform, $plan, $bus);
+    }
+
+    /**
+     * The message of a callback's `error`, or the fallback. Tolerates the bare
+     * string an orchestrator older than 2.2 sends in its place.
+     */
+    protected static function failureMessage(array $data, string $fallback): string
+    {
+        $message = $data['error']['message'] ?? '';
+
+        return \is_string($message) && $message !== '' ? $message : $fallback;
     }
 
     /**


### PR DESCRIPTION
## Summary

Bumps the orchestrator to [v2.2.0](https://github.com/open-runtimes/orchestrator/releases/tag/v2.2.0) and `open-runtimes/sdk-for-php` to [2.0](https://github.com/open-runtimes/sdk-for-php/pull/17), whose callbacks report a failed job's `error` as `{code, message}` — the message saying what actually went wrong (`Unrecognized archive format for source.tar.gz`, `Download failed with status 404`, `Job was killed because it ran out of memory`).

The jobs worker now decodes callbacks into the SDK's typed `JobLog` / `JobArtifact` / `JobExit` and puts that message in the build logs where users previously saw only `Build failed with exit code -1.`:

- **Failed artifact** (source download, extraction, output upload): the build fails on the artifact callback with `$artifact->error->message`. The orchestrator aborts the job on a pre-job failure anyway, so this only moves the failure earlier and makes it specific. The build cache upload is exempt — losing it costs the next build time, not this one.
- **Exit**: `ErrorCode::JobExitNonzero` keeps `Build failed with exit code N.`; an OOM kill or a job that failed before starting uses the orchestrator's message.
- **A build finalizes once**: `finalize()` refuses a second outcome for a deployment already `ready`/`failed`, so the exit that follows a failed artifact cannot overwrite its message. Late log and `sourceSize` callbacks still apply.
- `onCallback()` (the subclass hook for events this worker doesn't know) keeps its raw `array $data`; `onLog`/`onArtifact`/`onExit` now take the typed callback.

SDK 1.0 → 2.0 removes nothing Appwrite uses (`Jobs`, artifact models, `Callback`, `Signature`, `CallbackEvent` are unchanged).

## Test plan

- [ ] Deploy with a non-archive source → build logs end with `Unrecognized archive format for source.tar.gz`
- [ ] Build with a failing command → still `Build failed with exit code 1.`
- [ ] Successful build → `ready`, unchanged
- [x] `php -l`, `pint --test`; `composer update open-runtimes/sdk-for-php` resolves to 2.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
