### PR TITLE
chore: use console 1.1.74 for migration resource selection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -266,7 +266,7 @@ services:
         max-file: "5"
         max-size: 10m
     container_name: appwrite-console
-    image: appwrite/new:1.1.72
+    image: appwrite/new:1.1.74
     restart: unless-stopped
     networks:
       - appwrite


### PR DESCRIPTION
Points self-hosted at console `1.1.74`, which carries the import wizard fix from appwrite/vibes#328.

## Why

The wizard built its migration request itself and only ever named users, databases and storage. The "Include teams" checkbox and all three Functions checkboxes were wired to nothing, and messaging had no group at all. Since a migration transfers exactly the resources it is asked for and skips the rest without raising anything, the result was silent — the resources were missing and the migration still reported `completed` with an empty error list.

Reported by a self-hoster migrating 1.9.6 → 2.0.0, who saw teams and messages left behind.

Verified against real instances before the console fix landed: same server, same worker, same API key, only the `resources` array differing.

| `resources` sent | Result |
|---|---|
| full list | teams 2/2, memberships 3/3, messages 2/2, topics 2/2, subscribers 2/2, providers 1/1, `errors: []` |
| what the wizard sent | users 3, teams **0**, messages **0**, topics **0**, providers **0** — status `completed` |

The server was never at fault; it transfers all of these correctly when asked.

## Scope

One line. `appwrite/new` is pinned in exactly one place, and this is a console image change rather than an Appwrite version bump, so `APP_VERSION_STABLE`, the README install snippets and `Migration.php` are untouched — same shape as 78213c7844 (`1.1.16` → `1.1.72`).

## Do not merge until the image is published

At the time of opening, `appwrite/new:1.1.74` is **not yet on Docker Hub** — its Production deployment job is queued behind `1.1.73`. Merging before it publishes would break `docker compose up` for anyone pulling.

Check with:

    docker manifest inspect appwrite/new:1.1.74

Latest published when this was opened: `1.1.73` (11:52 UTC).