### PR TITLE
fix(teams): limit console organizations only on the self-hosted edition

### DIFF
--- a/src/Appwrite/Platform/Modules/Teams/Http/Teams/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Teams/Create.php
@@ -24,6 +24,7 @@ use Utopia\Lock\Distributed;
 use Utopia\Lock\Exception\Contention;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Pools\Group;
+use Utopia\System\System;
 use Utopia\Validator\ArrayList;
 use Utopia\Validator\Text;
 
@@ -80,10 +81,15 @@ class Create extends Action
 
         $teamId = $teamId == 'unique()' ? ID::unique() : $teamId;
 
-        $create = function () use ($dbForProject, $authorization, $teamId, $name, $roles, $user, $isPrivilegedUser, $isAppUser, $project) {
+        // Only the default self-hosted run limits the console to a single organization.
+        // Cloud sets _APP_EDITION=cloud and governs organizations through billing plans instead.
+        $limitOrganizations = $project->getId() === 'console'
+            && System::getEnv('_APP_EDITION', 'self-hosted') === 'self-hosted';
+
+        $create = function () use ($dbForProject, $authorization, $teamId, $name, $roles, $user, $isPrivilegedUser, $isAppUser, $limitOrganizations) {
             // The seeded total only holds if the owner membership lands with the team.
-            return $dbForProject->withTransaction(function () use ($dbForProject, $authorization, $teamId, $name, $roles, $user, $isPrivilegedUser, $isAppUser, $project) {
-                if ($project->getId() === 'console') {
+            return $dbForProject->withTransaction(function () use ($dbForProject, $authorization, $teamId, $name, $roles, $user, $isPrivilegedUser, $isAppUser, $limitOrganizations) {
+                if ($limitOrganizations) {
                     $organization = $authorization->skip(fn () => $dbForProject->findOne('teams'));
 
                     if (!$organization->isEmpty()) {
@@ -141,7 +147,7 @@ class Create extends Action
         };
 
         try {
-            if ($project->getId() === 'console') {
+            if ($limitOrganizations) {
                 if ($user->isEmpty()) {
                     throw new Exception(Exception::USER_UNAUTHORIZED);
                 }

--- a/tests/e2e/Scopes/Scope.php
+++ b/tests/e2e/Scopes/Scope.php
@@ -69,6 +69,18 @@ abstract class Scope extends TestCase
 
         // Read console fixtures as their owner, not in project admin mode.
         unset($headers['x-appwrite-mode']);
+
+        // Cloud does not limit organizations per instance, so the public create API
+        // seeds the fixture there and only the GET below is shared with self-hosted.
+        if (System::getEnv('_APP_EDITION', 'self-hosted') !== 'self-hosted') {
+            $team = $this->client->call(Client::METHOD_POST, '/teams', $headers, $params);
+            $this->assertSame(201, $team['headers']['status-code']);
+
+            $response = $this->client->call(Client::METHOD_GET, '/teams/' . $team['body']['$id'], $headers);
+            $this->assertSame(200, $response['headers']['status-code']);
+            return $response;
+        }
+
         $account = [];
         $this->assertEventually(function () use ($headers, &$account) {
             $account = $this->client->call(Client::METHOD_GET, '/account', $headers);

--- a/tests/e2e/Services/Teams/TeamsBase.php
+++ b/tests/e2e/Services/Teams/TeamsBase.php
@@ -7,6 +7,7 @@ use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\Datetime as DatetimeValidator;
+use Utopia\System\System;
 
 trait TeamsBase
 {
@@ -121,7 +122,7 @@ trait TeamsBase
             'name' => 'Manchester United'
         ]);
 
-        if ($this->getProject()['$id'] === 'console') {
+        if ($this->getProject()['$id'] === 'console' && System::getEnv('_APP_EDITION', 'self-hosted') === 'self-hosted') {
             $this->assertEquals(403, $response2['headers']['status-code']);
             $this->assertEquals('organization_creation_prohibited', $response2['body']['type']);
 


### PR DESCRIPTION
## Summary

#13585 made `POST /teams` on the console project refuse a second organization per instance. That policy is right for self-hosted, but Appwrite Cloud runs the same action with `_APP_EDITION=cloud` and governs organizations through billing plans, so every cloud E2E flow that creates a console team started failing with `403 organization_creation_prohibited` (appwrite-labs/cloud#5755).

- The single-organization check and its distributed lock now run only when `_APP_EDITION` is `self-hosted` (the default). Any other edition creates console teams exactly as before #13585. This reuses the edition switch `app/realtime.php` already reads.
- `Scope::createTeamFixture()` seeds console organizations through the public create API when the edition is not self-hosted, then returns the same authorized `GET /teams/{id}` (200) so callers see one response shape. The row-seeding path stays for self-hosted, where it is the only way to obtain a second organization. In cloud that path also crashed with `No adapters provided`, because it reads `pools-cache` from the self-hosted registry.
- `TeamsBase` asserts the 403 only on the self-hosted edition and the regular 201 otherwise.

## Coverage

The self-hosted policy is still covered by the fresh-instance run of `TeamsConsoleClientTest::testCreateOrganization` in CI. The cloud path cannot be observed from this repository, because the edition is fixed at server start. It is exercised by the cloud E2E suites that create multiple console teams per test process (`Tests\Cloud\E2E\General\UsageTest::testTenantIsolation`, `ProjectUsageTest`, `RealtimeOriginTest`, and the CE suites run inside cloud), which fail on `1ded023` and are expected to pass once cloud points at this branch.

## Verification

- Pint and `php -l` on the changed files, `git diff --check`.
- appwrite-labs/cloud#5755 is pointed at this branch to run the full cloud CE and Cloud E2E matrices against it.
