### PR TITLE
fix(teams): let editions override the per-instance organization limit

### DIFF
--- a/src/Appwrite/Platform/Modules/Teams/Http/Teams/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Teams/Create.php
@@ -79,11 +79,12 @@ class Create extends Action
         $isAppUser = $user->isKey($authorization->getRoles());
 
         $teamId = $teamId == 'unique()' ? ID::unique() : $teamId;
+        $limited = $this->isOrganizationLimited($project);
 
-        $create = function () use ($dbForProject, $authorization, $teamId, $name, $roles, $user, $isPrivilegedUser, $isAppUser, $project) {
+        $create = function () use ($dbForProject, $authorization, $teamId, $name, $roles, $user, $isPrivilegedUser, $isAppUser, $limited) {
             // The seeded total only holds if the owner membership lands with the team.
-            return $dbForProject->withTransaction(function () use ($dbForProject, $authorization, $teamId, $name, $roles, $user, $isPrivilegedUser, $isAppUser, $project) {
-                if ($project->getId() === 'console') {
+            return $dbForProject->withTransaction(function () use ($dbForProject, $authorization, $teamId, $name, $roles, $user, $isPrivilegedUser, $isAppUser, $limited) {
+                if ($limited) {
                     $organization = $authorization->skip(fn () => $dbForProject->findOne('teams'));
 
                     if (!$organization->isEmpty()) {
@@ -141,7 +142,7 @@ class Create extends Action
         };
 
         try {
-            if ($project->getId() === 'console') {
+            if ($limited) {
                 if ($user->isEmpty()) {
                     throw new Exception(Exception::USER_UNAUTHORIZED);
                 }
@@ -170,5 +171,15 @@ class Create extends Action
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
             ->dynamic($team, Response::MODEL_TEAM);
+    }
+
+    /**
+     * Whether this instance allows only a single console organization.
+     * Self-hosted enforces it for every console request; editions that govern
+     * organizations elsewhere (cloud through its billing plans) override this.
+     */
+    protected function isOrganizationLimited(Document $project): bool
+    {
+        return $project->getId() === 'console';
     }
 }

--- a/tests/e2e/Scopes/Scope.php
+++ b/tests/e2e/Scopes/Scope.php
@@ -69,6 +69,19 @@ abstract class Scope extends TestCase
 
         // Read console fixtures as their owner, not in project admin mode.
         unset($headers['x-appwrite-mode']);
+
+        // The first organization of a self-hosted instance, and every organization on an
+        // edition without the instance limit, comes from the public API. Only a refusal
+        // falls through to seeding the rows directly.
+        $team = $this->client->call(Client::METHOD_POST, '/teams', $headers, $params);
+        if ($team['headers']['status-code'] === 201) {
+            $response = $this->client->call(Client::METHOD_GET, '/teams/' . $team['body']['$id'], $headers);
+            $this->assertSame(200, $response['headers']['status-code']);
+            return $response;
+        }
+        $this->assertSame(403, $team['headers']['status-code']);
+        $this->assertSame('organization_creation_prohibited', $team['body']['type']);
+
         $account = [];
         $this->assertEventually(function () use ($headers, &$account) {
             $account = $this->client->call(Client::METHOD_GET, '/account', $headers);


### PR DESCRIPTION
## Summary

#13585 made `POST /teams` on the console project refuse a second organization per instance. That policy is right for self-hosted, but Appwrite Cloud runs the same action and governs organizations through its billing plans, so every cloud E2E flow that creates a console team started failing with `403 organization_creation_prohibited`, and CE's own E2E suites crashed inside the cloud pod (appwrite-labs/cloud#5755).

- The console check moves into a protected `isOrganizationLimited(Document $project): bool` on the Teams `Create` action. The limit, its distributed lock and the unauthenticated-user guard all key off that method. Self-hosted behaviour is unchanged and there is no environment switch, so a self-hosted operator cannot turn the limit off; cloud overrides the method in its subclass, the same way it already overrides the membership `Delete` action.
- `Scope::createTeamFixture()` calls the public create API first. A 201 is followed by the same authorized `GET /teams/{id}` and returned. Anything else must be `403 organization_creation_prohibited`, and only then are the rows seeded through the registry. The registry path reads `pools-cache`, which cloud's bootstrap does not define, so it failed with `No adapters provided` whenever CE suites ran in cloud.

## Coverage

The self-hosted policy is still covered by the fresh-instance run of `TeamsConsoleClientTest::testCreateOrganization` and by the 403 assertions in `TeamsBase`. The override path cannot be observed from this repository; it is exercised by the cloud E2E matrix (CE suites run inside cloud plus `Tests\Cloud\E2E\General\UsageTest::testTenantIsolation`, `ProjectUsageTest`, `RealtimeOriginTest` and others), which fails on `1ded023` and is run against this branch from appwrite-labs/cloud.

## Verification

- Pint and `php -l` on the changed files, `git diff --check`.
- Cloud CI against this branch is linked from appwrite-labs/cloud.
