### PR TITLE
fix(ci): keep security report uploads off PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,25 @@ jobs:
       security-events: write
       contents: read
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@c51854704019a247608d928f370c98740469d4b5" # v2.3.5
+    with:
+      upload-sarif: false
+      fail-on-vuln: true
+
+  dependencies-main:
+    name: Security / Dependencies
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      actions: read
+      security-events: write
+      contents: read
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@c51854704019a247608d928f370c98740469d4b5" # v2.3.5
+    with:
+      upload-sarif: true
+      fail-on-vuln: true
 
   security:
     name: Checks / Image
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -53,6 +68,7 @@ jobs:
           submodules: 'recursive'
 
       - name: Build the Docker image
+        id: image-build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -68,8 +84,11 @@ jobs:
           format: 'sarif'
           output: 'trivy-image-results.sarif'
           severity: 'CRITICAL,HIGH'
+          limit-severities-for-sarif: true
+          exit-code: '1'
 
       - name: Run Trivy vulnerability scanner on source code
+        if: ${{ !cancelled() && steps.image-build.outcome == 'success' }}
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
@@ -77,18 +96,32 @@ jobs:
           format: 'sarif'
           output: 'trivy-fs-results.sarif'
           severity: 'CRITICAL,HIGH'
+          limit-severities-for-sarif: true
+          exit-code: '1'
           skip-setup-trivy: true
 
+      - name: Upload scan artifacts
+        if: ${{ !cancelled() && steps.image-build.outcome == 'success' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trivy-results
+          path: |
+            trivy-image-results.sarif
+            trivy-fs-results.sarif
+          retention-days: 5
+          if-no-files-found: error
+
+      # Dashboard publishing runs only on main, so API outages cannot block PR scans.
       - name: Upload image scan results
         uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
-        if: always() && hashFiles('trivy-image-results.sarif') != ''
+        if: ${{ !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' && hashFiles('trivy-image-results.sarif') != '' }}
         with:
           sarif_file: 'trivy-image-results.sarif'
           category: 'trivy-image'
 
       - name: Upload source code scan results
         uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
-        if: always() && hashFiles('trivy-fs-results.sarif') != ''
+        if: ${{ !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' && hashFiles('trivy-fs-results.sarif') != '' }}
         with:
           sarif_file: 'trivy-fs-results.sarif'
           category: 'trivy-source'


### PR DESCRIPTION
## What does this PR do?

Keeps GitHub Code Scanning report uploads out of PR security checks, while retaining vulnerability gates and downloadable reports. Publishes Security-tab results on pushes to `main` instead.

### Why this exists

While investigating #13608, two security checks failed because GitHub returned `API rate limit exceeded for installation` during SARIF upload:

- [OSV job](https://github.com/appwrite/appwrite/actions/runs/34477930386/job/102873281403): the base/PR comparison reported **No issues found**, and all report artifacts uploaded successfully. The subsequent Code Scanning upload failed.
- [Image job](https://github.com/appwrite/appwrite/actions/runs/34477930386/job/102873281127): the Docker build and both Trivy scans completed successfully. Uploading the image and source reports failed with the same rate-limit error.

Replacing scanners would not address the failing API. This separates the PR security decision from dashboard publishing without adding retry orchestration or suppressing scanner failures.

### Changes

- Disable OSV SARIF dashboard uploads on PRs; retain its new-vulnerability gate, annotations, and existing report artifacts.
- Add a full OSV scan with dashboard publishing on `main` pushes.
- Run Trivy on PRs and `main`; retain SARIF artifacts for five days, including when scans report findings.
- Publish Trivy reports to the Security tab only on `main` pushes. Publishing failures remain visible there rather than failing PR checks.
- Explicitly fail Trivy on HIGH/CRITICAL findings and limit SARIF severities accordingly. Previously these scans were report-only: successful execution did not imply zero findings.
- Continue the source scan after image vulnerability findings, and skip it after a failed build or cancellation.

### Review blocker: existing vulnerability baseline

This intentionally changes Trivy from report-only to blocking. A local source scan found **39 HIGH/CRITICAL finding instances**: each of the three Astro fixture lockfiles has 12 HIGH and 1 CRITICAL findings. These files are unchanged by this PR.

The affected fixtures are `tests/resources/sites/{astro,astro-static,astro-custom-start-command}/package-lock.json`. Examples include `GHSA-26w7-cxv4-gfx2` and `CVE-2026-54299` in Astro.

**Draft until the baseline is remediated or an explicit baseline policy is agreed.** No ignores or exclusions have been added to make checks green. PR artifacts also do not replace the Security tab's per-PR alert integration; dashboard results now reflect `main`.

## Test Plan

- **PASS:** `git diff --check`.
- **PASS:** `actionlint /tmp/pr13608-security-workflow.yml`, using the unchanged workflow header plus the three affected jobs extracted from `.github/workflows/ci.yml`. Full-file lint is not clean at baseline because of existing `parallel:` steps and unrelated ShellCheck findings; this is not a full-workflow lint pass.
- **PASS:** temporary Node assertion harness against the parsed YAML: PR, `main` push, `1.9.x` push, and manual-dispatch conditions; cancelled runs; missing reports; failed builds; and scanner severity/exit-code configuration. This is a local expression/configuration check, not execution in GitHub Actions.
- **FINDINGS / exit 1:** `trivy fs --scanners vuln --severity HIGH,CRITICAL --format json --output /tmp/pr13608-trivy-source.json --exit-code 1 .` from the isolated worktree. Found the 39 baseline instances described above. Local Trivy is **0.74.0**, while the pinned CI action defaults to **0.70.0**; this is supplementary evidence, not an exact CI reproduction. Secret scanning was not included in this local command.
- **NOT RUN:** Docker image build/scan locally; the Docker daemon is unavailable.
- **NOT RUN locally:** end-to-end GitHub runner execution, artifact persistence, and `main` Security-tab publishing. PR CI can verify the PR path; the `main`-only path needs a post-merge run.

Workflow-only change; no application UI screenshots are applicable.

## Related PRs and Issues

- Discovered while debugging #13608. This branch is based on `main` and contains only the workflow change, not that PR's Teams changes.
