### PR TITLE
Align bundled PostgreSQL max_connections with the app-side connection budget

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1809,6 +1809,8 @@ services:
       start_period: 10s
     command:
       - postgres
+      - -c
+      - max_connections=${_APP_CONNECTIONS_MAX:-151}
   appwrite-embedding:
     image: appwrite/embedding:0.3.1
     profiles:

--- a/tests/unit/Docker/Compose/GeneratorTest.php
+++ b/tests/unit/Docker/Compose/GeneratorTest.php
@@ -150,7 +150,11 @@ final class GeneratorTest extends TestCase
         ]);
 
         $this->assertSame(['mysqld', '--innodb-flush-method=fsync'], $mariadb['services']['mariadb']['command']);
-        $this->assertSame(['postgres'], $postgresql['services']['postgresql']['command']);
+        $this->assertSame([
+            'postgres',
+            '-c',
+            'max_connections=${_APP_CONNECTIONS_MAX:-151}',
+        ], $postgresql['services']['postgresql']['command']);
         $this->assertSame([
             'redis-server',
             '--maxmemory',


### PR DESCRIPTION
Fixes #13517.

## The bug

@maciejdudek92 reported and measured this on self-hosted: Sites return HTTP 500 above ~36 concurrent connections, with 7-43 failures per 160 requests at 40-48 parallel and full collapse at 64+ - and zero failures after raising PostgreSQL's `max_connections`. The mechanism: the app-side connection pool budgets `_APP_CONNECTIONS_MAX` (default **151**, `app/init/registers.php`), but the bundled PostgreSQL in `docker-compose.yml` starts with the upstream default `max_connections=100`. Under load the database starts refusing connections (`SQLSTATE[08006]`) well before the app's own budget is exhausted, so the ceiling the operator configured never takes effect where it matters.

## The fix

Pass the ceiling to the server:

```yaml
command:
  - postgres
  - -c
  - max_connections=${_APP_CONNECTIONS_MAX:-151}
```

`${_APP_CONNECTIONS_MAX:-151}` keeps the server ceiling aligned with the app-side default, and an operator who sets `_APP_CONNECTIONS_MAX` in their environment raises (or lowers) both sides through the same key. Updates the Compose generator contract test, which renders the root `docker-compose.yml`.

## Tests

- `GeneratorTest::testKeepsLongCommandsReadable` now asserts the postgresql command is `['postgres', '-c', 'max_connections=${_APP_CONNECTIONS_MAX:-151}']`.
- Verified by parsing the patched `docker-compose.yml`: the postgresql service command is exactly `['postgres', '-c', 'max_connections=${_APP_CONNECTIONS_MAX:-151}']`; Compose interpolation semantics for `${VAR:-default}` match the documented behavior (the stock `.env` does not set the key, so 151 applies unless the operator overrides).
- **Not run:** the PHP suite (no PHP runtime in our build environment) - the change is a two-line compose addition plus the assertion update; CI will run it.

> Built by breken, your AI support engineer - breken.ai - this one's on us.