### PR TITLE
fix(deployments): scope sourceSize to the extracted tree, not the provider archive

### DIFF
--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -5,9 +5,11 @@ namespace Appwrite\Deployment;
 use Ahc\Jwt\JWT;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Validator\VariableKey;
+use OpenRuntimes\Orchestrator\Enum\ArchiveFormat;
 use OpenRuntimes\Orchestrator\Enum\CallbackEvent;
 use OpenRuntimes\Orchestrator\Enum\ReadFormat;
 use OpenRuntimes\Orchestrator\Jobs;
+use OpenRuntimes\Orchestrator\Model\Artifact\ArchiveArtifact;
 use OpenRuntimes\Orchestrator\Model\Artifact\CloneArtifact;
 use OpenRuntimes\Orchestrator\Model\Artifact\DownloadArtifact;
 use OpenRuntimes\Orchestrator\Model\Artifact\ReadArtifact;
@@ -395,10 +397,15 @@ readonly class Deployments
                 new DownloadArtifact(id: 'source', in: $source['url'], out: 'source.tar.gz', headers: $source['headers'] ?? []),
                 new UnarchiveArtifact(id: 'extract', in: 'source.tar.gz', out: 'source', subdir: $subdir !== '' ? $subdir : null, strip: true, depends: 'source'),
                 // Appwrite never sees the remote source (the sidecar fetches it),
-                // so unlike the uploaded-tarball path it can't size it. Stat the
-                // downloaded archive so the orchestrator reports its byte size in
-                // an artifact callback, which the worker records as sourceSize.
-                new StatArtifact(id: 'sourceSize', in: 'source.tar.gz', depends: 'source'),
+                // so unlike the uploaded-tarball path it can't size it. But the
+                // provider archive spans the whole repository: recording its byte
+                // size as sourceSize inflates every monorepo deployment (and the
+                // storage totals that sum it) with the rest of the repo. Stat the
+                // extracted tree instead, already scoped to rootDirectory with
+                // the forge wrapper stripped. Stat rejects directories, so
+                // re-pack 'source' into a plain tar first.
+                new ArchiveArtifact(id: 'sourceSizeArchive', in: 'source', out: 'source-size.tar', format: ArchiveFormat::Tar, depends: 'extract'),
+                new StatArtifact(id: 'sourceSize', in: 'source-size.tar', depends: 'sourceSizeArchive'),
             ];
         } else {
             // Presigned source-download URL (GET, no request-body cap), fetched by


### PR DESCRIPTION
Fixes #13586.

## Root cause (the reporter's, confirmed at HEAD)

@AlimFreight traced this; verified independently:

1. `Deployments.php` (~:398-409): the VCS path downloads the whole-repo provider archive, and `StatArtifact(id: 'sourceSize', in: 'source.tar.gz')` records the entire archive - while the extracted tree is already scoped to `rootDirectory` via `subdir` + `strip`.
2. `Workers/Jobs.php:308-319`: the worker writes that stat into `sourceSize`/`totalSize`.
3. `Workers/StatsResources.php:262/290/307`: `sum(sourceSize)` becomes `DEPLOYMENTS_STORAGE`, with `sourcePath` NULL on VCS deployments so nothing corrects it - the reporter's ~525MB phantom across 94 functions.

Sharpening (confirmed): deployments reporting `sourceSize` all went through the archive path (the clone path reports none), and forge archives carry no `.git` - so this is whole-repo-archive vs subdirectory, not a `.git` effect. The reporter's numbers back it (4.33MB reported vs ~4.46MB whole-worktree estimate).

## Fix (1 file, +11/-4)

Re-pack the extracted, `rootDirectory`-scoped tree into a plain tar and stat that instead:

- `ArchiveArtifact(id: 'sourceSizeArchive', in: 'source', out: 'source-size.tar', format: Tar, depends: 'extract')`
- `StatArtifact(id: 'sourceSize', in: 'source-size.tar', depends: 'sourceSizeArchive')`

Only existing orchestrator primitives are used - `Stat.Apply` rejects directories, `Archive.Apply` packs them (both verified in the orchestrator Go source), and `ArchiveArtifact`/`ArchiveFormat::Tar` exist in `open-runtimes/sdk-for-php` 0.13.0, which appwrite pins. Zero orchestrator or SDK changes.

## Semantic change (disclosed)

`sourceSize` becomes uncompressed subdir bytes (+512B/file tar overhead) instead of compressed whole-repo bytes; existing rows keep inflated values until the next redeploy. Alternative for maintainers who prefer minimal blast radius: gate the three `StatsResources.php` sums on `sourcePath IS NOT NULL` - a one-liner that fixes accounting but leaves per-deployment display wrong, hence the artifact fix instead.

## Verification

Every step re-traced in source at `main` (f31509d) plus the orchestrator (Go) and sdk-for-php 0.13.0 pinned ref. **Not run:** no PHP runtime or live Appwrite/orchestrator build in the author's environment - the reporter offered to verify storage totals after a redeploy.

**Overlap note:** this touches `src/Appwrite/Deployment/Deployments.php` (~:395-409), about 200 lines from #13589's change (~:182) in the same file; both apply independently against current main, but whichever lands second will need a trivial rebase.

> Built by breken, your AI support engineer - breken.ai - this one's on us.
