### PR TITLE
test(avatars): point the remote image fixture at a backend-served asset

### DIFF
--- a/tests/e2e/Services/Avatars/AvatarsBase.php
+++ b/tests/e2e/Services/Avatars/AvatarsBase.php
@@ -212,7 +212,7 @@ trait AvatarsBase
             $response = $this->client->call(Client::METHOD_GET, '/avatars/image', [
                 'x-appwrite-project' => $this->getProject()['$id'],
             ], [
-                'url' => 'https://appwrite.io/images/open-graph/website.avif',
+                'url' => 'https://cloud.appwrite.io/images/github.png',
             ]);
 
             $this->assertEquals(200, $response['headers']['status-code']);
@@ -224,7 +224,7 @@ trait AvatarsBase
             $response = $this->client->call(Client::METHOD_GET, '/avatars/image', [
                 'x-appwrite-project' => $this->getProject()['$id'],
             ], [
-                'url' => 'https://appwrite.io/images/open-graph/website.avif',
+                'url' => 'https://cloud.appwrite.io/images/github.png',
                 'width' => 200,
                 'height' => 200,
             ]);
@@ -238,7 +238,7 @@ trait AvatarsBase
             $response = $this->client->call(Client::METHOD_GET, '/avatars/image', [
                 'x-appwrite-project' => $this->getProject()['$id'],
             ], [
-                'url' => 'https://appwrite.io/images/open-graph/website.avif',
+                'url' => 'https://cloud.appwrite.io/images/github.png',
                 'width' => 300,
                 'height' => 300,
                 'quality' => 30,
@@ -255,7 +255,7 @@ trait AvatarsBase
         $response = $this->client->call(Client::METHOD_GET, '/avatars/image', [
             'x-appwrite-project' => $this->getProject()['$id'],
         ], [
-            'url' => 'https://appwrite.io/images/unknown.png',
+            'url' => 'https://cloud.appwrite.io/images/unknown.png',
             'width' => 300,
             'height' => 300,
             'quality' => 30,
@@ -277,7 +277,7 @@ trait AvatarsBase
         $response = $this->client->call(Client::METHOD_GET, '/avatars/image', [
             'x-appwrite-project' => $this->getProject()['$id'],
         ], [
-            'url' => 'https://appwrite.io/images/open-graph/website.avif',
+            'url' => 'https://cloud.appwrite.io/images/github.png',
             'width' => 2001,
             'height' => 300,
             'quality' => 30,

--- a/tests/e2e/Services/GraphQL/AvatarsTest.php
+++ b/tests/e2e/Services/GraphQL/AvatarsTest.php
@@ -92,7 +92,7 @@ final class AvatarsTest extends Scope
             'query' => $query,
             'variables' => [
                 // Same URL as REST AvatarsBase::testGetImage (Google logo fetches flake in CI)
-                'url' => 'https://appwrite.io/images/open-graph/website.avif',
+                'url' => 'https://cloud.appwrite.io/images/github.png',
             ],
         ];
 


### PR DESCRIPTION
## What does this PR do?

`testGetImage` in the three Avatars suites and `testGetImageFromURL` in the GraphQL suite fetch `https://appwrite.io/images/open-graph/website.avif`, which now returns 404 from appwrite.io, so the suites fail on every run.

`cdn.appwrite.io` was checked as a replacement: it only serves content-hashed Vite output from the console build (`appwrite-console` R2 bucket), and the `appwrite-labs/assets` service only exposes fonts, so neither has a stable un-hashed image path.

The fixture now points at `https://cloud.appwrite.io/images/github.png`. That is `public/images/github.png` from this repository, served by the Appwrite backend itself on Cloud, so the test depends on an asset this repo owns rather than on the marketing site. The negative fixtures (`unknown.png`, `robots.txt`, invalid scheme) keep the same behavior and were moved to the same host for consistency.

## Test Plan

Local fresh install from `main`: `tests/e2e/Services/Avatars` (46 tests) and `tests/e2e/Services/GraphQL/AvatarsTest.php` (13 tests) pass with this change and both failed before it.

## Related PRs and Issues

Surfaced while preparing the 2.1.0 release (#13615).

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
