### PR TITLE
chore(deps): require utopia-php/auth ^0.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "utopia-php/abuse": "2.0.*",
         "utopia-php/agents": "2.*",
         "utopia-php/audit": "^4.0",
-        "utopia-php/auth": "^0.11",
+        "utopia-php/auth": "^0.12",
         "utopia-php/balancer": "0.4.*",
         "utopia-php/cache": "^5.0.0",
         "utopia-php/cdn": "^0.0.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6b38ddd955c8809275256b63e5899c2",
+    "content-hash": "334eead499308d545da180a7a842d158",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -2930,16 +2930,16 @@
         },
         {
             "name": "utopia-php/auth",
-            "version": "0.11.1",
+            "version": "0.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/auth.git",
-                "reference": "cf89893531e39f98058b75fb86683770a9d79b64"
+                "reference": "580e41d69b0248b79fa419dca5bab4abce0d32c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/auth/zipball/cf89893531e39f98058b75fb86683770a9d79b64",
-                "reference": "cf89893531e39f98058b75fb86683770a9d79b64",
+                "url": "https://api.github.com/repos/utopia-php/auth/zipball/580e41d69b0248b79fa419dca5bab4abce0d32c4",
+                "reference": "580e41d69b0248b79fa419dca5bab4abce0d32c4",
                 "shasum": ""
             },
             "require": {
@@ -2982,10 +2982,10 @@
                 "security"
             ],
             "support": {
-                "source": "https://github.com/utopia-php/auth/tree/0.11.1",
+                "source": "https://github.com/utopia-php/auth/tree/0.12.0",
                 "issues": "https://github.com/utopia-php/auth/issues"
             },
-            "time": "2026-09-09T15:02:50+00:00"
+            "time": "2026-09-10T18:16:47+00:00"
         },
         {
             "name": "utopia-php/balancer",


### PR DESCRIPTION
Bumps `utopia-php/auth` from `^0.11` to `^0.12` and refreshes the lock to 0.12.0.

0.12.0 adds `AuthorizationDetails::restrict()` and `toArray()` (utopia-php/monorepo#257) plus a generic HS256 issuer already merged upstream. Nothing in this repository references the changed class; the bump exists so appwrite-labs/cloud, which resolves `utopia-php/auth` through `appwrite/server-ce`, can pick up 0.12.0 and issue access tokens carrying only the RAR grants the user can still reach.

Lock diff is the single package version and reference.