### PR TITLE
fix(redis): honour _APP_REDIS_USER and pass credentials to the queue publisher

### DIFF
--- a/app/init/registers.php
+++ b/app/init/registers.php
@@ -210,11 +210,11 @@ $register->set('pools', function () {
                         \PDO::ATTR_STRINGIFY_FETCHES => true
                     ));
                 },
-                default => function () use ($dsnHost, $dsnPort, $dsnPass) {
+                default => function () use ($dsnHost, $dsnPort, $dsnUser, $dsnPass) {
                     $redis = new \Redis();
                     @$redis->pconnect($dsnHost, (int)$dsnPort);
                     if ($dsnPass) {
-                        $redis->auth($dsnPass);
+                        $redis->auth($dsnUser ? [$dsnUser, $dsnPass] : $dsnPass);
                     }
                     $redis->setOption(\Redis::OPT_READ_TIMEOUT, -1);
 
@@ -252,7 +252,12 @@ $register->set('pools', function () {
                         // Publishers never block on receive, so one connection backs both broker slots.
                         return match ($dsn->getScheme()) {
                             'redis' => (function () use ($dsn) {
-                                $connection = new Queue\Connection\Redis($dsn->getHost(), $dsn->getPort());
+                                $connection = new Queue\Connection\Redis(
+                                    $dsn->getHost(),
+                                    $dsn->getPort(),
+                                    $dsn->getUser() ?: null,
+                                    $dsn->getPassword() ?: null,
+                                );
                                 return new Queue\Broker\Redis($connection, $connection);
                             })(),
                             default => null

--- a/app/init/registers.php
+++ b/app/init/registers.php
@@ -44,32 +44,32 @@ $register->set('pools', function () {
         'scheme' => System::getEnv('_APP_DB_ADAPTER', 'postgresql'),
         'host' => System::getEnv('_APP_DB_HOST', 'postgresql'),
         'port' => System::getEnv('_APP_DB_PORT', '5432'),
-        'user' => System::getEnv('_APP_DB_USER', ''),
-        'pass' => System::getEnv('_APP_DB_PASS', ''),
+        'user' => \rawurlencode(System::getEnv('_APP_DB_USER', '')),
+        'pass' => \rawurlencode(System::getEnv('_APP_DB_PASS', '')),
         'path' => System::getEnv('_APP_DB_SCHEMA', ''),
     ]);
     $fallbackForRedis = 'redis_main=' . AppwriteURL::unparse([
         'scheme' => 'redis',
         'host' => System::getEnv('_APP_REDIS_HOST', 'redis'),
         'port' => System::getEnv('_APP_REDIS_PORT', '6379'),
-        'user' => System::getEnv('_APP_REDIS_USER', ''),
-        'pass' => System::getEnv('_APP_REDIS_PASS', ''),
+        'user' => \rawurlencode(System::getEnv('_APP_REDIS_USER', '')),
+        'pass' => \rawurlencode(System::getEnv('_APP_REDIS_PASS', '')),
     ]);
 
     $fallbackForDocumentsDB = 'db_main=' . AppwriteURL::unparse([
         'scheme' => System::getEnv('_APP_DB_ADAPTER_DOCUMENTSDB', 'mongodb'),
         'host' => System::getEnv('_APP_DB_HOST_DOCUMENTSDB', 'mongodb'),
         'port' => System::getEnv('_APP_DB_PORT_DOCUMENTSDB', '27017'),
-        'user' => System::getEnv('_APP_DB_USER_DOCUMENTSDB', '') ?: System::getEnv('_APP_DB_USER', ''),
-        'pass' => System::getEnv('_APP_DB_PASS_DOCUMENTSDB', '') ?: System::getEnv('_APP_DB_PASS', ''),
+        'user' => \rawurlencode(System::getEnv('_APP_DB_USER_DOCUMENTSDB', '') ?: System::getEnv('_APP_DB_USER', '')),
+        'pass' => \rawurlencode(System::getEnv('_APP_DB_PASS_DOCUMENTSDB', '') ?: System::getEnv('_APP_DB_PASS', '')),
         'path' => System::getEnv('_APP_DB_SCHEMA_DOCUMENTSDB', '') ?: System::getEnv('_APP_DB_SCHEMA', ''),
     ]);
     $fallbackForVectorsDB = 'db_main=' . AppwriteURL::unparse([
         'scheme' => System::getEnv('_APP_DB_ADAPTER_VECTORSDB', 'postgresql'),
         'host' => System::getEnv('_APP_DB_HOST_VECTORSDB', 'postgresql'),
         'port' => System::getEnv('_APP_DB_PORT_VECTORSDB', '5432'),
-        'user' => System::getEnv('_APP_DB_USER_VECTORSDB', '') ?: System::getEnv('_APP_DB_USER', ''),
-        'pass' => System::getEnv('_APP_DB_PASS_VECTORSDB', '') ?: System::getEnv('_APP_DB_PASS', ''),
+        'user' => \rawurlencode(System::getEnv('_APP_DB_USER_VECTORSDB', '') ?: System::getEnv('_APP_DB_USER', '')),
+        'pass' => \rawurlencode(System::getEnv('_APP_DB_PASS_VECTORSDB', '') ?: System::getEnv('_APP_DB_PASS', '')),
         'path' => System::getEnv('_APP_DB_SCHEMA_VECTORSDB', '') ?: System::getEnv('_APP_DB_SCHEMA', ''),
     ]);
 
@@ -213,8 +213,8 @@ $register->set('pools', function () {
                 default => function () use ($dsnHost, $dsnPort, $dsnUser, $dsnPass) {
                     $redis = new \Redis();
                     @$redis->pconnect($dsnHost, (int)$dsnPort);
-                    if ($dsnPass) {
-                        $redis->auth($dsnUser ? [$dsnUser, $dsnPass] : $dsnPass);
+                    if ($dsnPass !== null && $dsnPass !== '') {
+                        $redis->auth($dsnUser !== null && $dsnUser !== '' ? [$dsnUser, $dsnPass] : $dsnPass);
                     }
                     $redis->setOption(\Redis::OPT_READ_TIMEOUT, -1);
 
@@ -255,8 +255,8 @@ $register->set('pools', function () {
                                 $connection = new Queue\Connection\Redis(
                                     $dsn->getHost(),
                                     $dsn->getPort(),
-                                    $dsn->getUser() ?: null,
-                                    $dsn->getPassword() ?: null,
+                                    $dsn->getUser() === '' ? null : $dsn->getUser(),
+                                    $dsn->getPassword() === '' ? null : $dsn->getPassword(),
                                 );
                                 return new Queue\Broker\Redis($connection, $connection);
                             })(),

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -311,8 +311,8 @@ $container->set('redis', function () {
 
     $redis = new \Redis();
     @$redis->pconnect($host, (int) $port);
-    if ($pass) {
-        $redis->auth($user ? [$user, $pass] : $pass);
+    if ($pass !== '') {
+        $redis->auth($user !== '' ? [$user, $pass] : $pass);
     }
     $redis->setOption(\Redis::OPT_READ_TIMEOUT, -1);
 

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -306,12 +306,13 @@ $container->set('cacheControlForStorage', fn () => fn (StorageCacheControl $conf
 $container->set('redis', function () {
     $host = System::getEnv('_APP_REDIS_HOST', 'localhost');
     $port = System::getEnv('_APP_REDIS_PORT', 6379);
+    $user = System::getEnv('_APP_REDIS_USER', '');
     $pass = System::getEnv('_APP_REDIS_PASS', '');
 
     $redis = new \Redis();
     @$redis->pconnect($host, (int) $port);
     if ($pass) {
-        $redis->auth($pass);
+        $redis->auth($user ? [$user, $pass] : $pass);
     }
     $redis->setOption(\Redis::OPT_READ_TIMEOUT, -1);
 

--- a/app/realtime.php
+++ b/app/realtime.php
@@ -240,12 +240,13 @@ if (!function_exists('getRedis')) {
 
         $host = System::getEnv('_APP_REDIS_HOST', 'localhost');
         $port = System::getEnv('_APP_REDIS_PORT', 6379);
+        $user = System::getEnv('_APP_REDIS_USER', '');
         $pass = System::getEnv('_APP_REDIS_PASS', '');
 
         $redis = new \Redis();
         @$redis->pconnect($host, (int)$port);
         if ($pass) {
-            $redis->auth($pass);
+            $redis->auth($user ? [$user, $pass] : $pass);
         }
         $redis->setOption(\Redis::OPT_READ_TIMEOUT, -1);
 

--- a/app/realtime.php
+++ b/app/realtime.php
@@ -245,8 +245,8 @@ if (!function_exists('getRedis')) {
 
         $redis = new \Redis();
         @$redis->pconnect($host, (int)$port);
-        if ($pass) {
-            $redis->auth($user ? [$user, $pass] : $pass);
+        if ($pass !== '') {
+            $redis->auth($user !== '' ? [$user, $pass] : $pass);
         }
         $redis->setOption(\Redis::OPT_READ_TIMEOUT, -1);
 

--- a/src/Appwrite/URL/URL.php
+++ b/src/Appwrite/URL/URL.php
@@ -66,9 +66,9 @@ class URL
 
         $parts['port'] = isset($url['port']) ? ':' . $url['port'] : '';
 
-        $parts['user'] = isset($url['user']) ? \rawurlencode($url['user']) : '';
+        $parts['user'] = isset($url['user']) ? $url['user'] : '';
 
-        $parts['pass'] = !empty($url['pass']) ? ':' . \rawurlencode($url['pass']) : '';
+        $parts['pass'] = !empty($url['pass']) ? ':' . $url['pass'] : '';
 
         $parts['pass'] = ($parts['user'] || !empty($parts['pass'])) ? $parts['pass'] . '@' : '';
 

--- a/src/Appwrite/URL/URL.php
+++ b/src/Appwrite/URL/URL.php
@@ -66,9 +66,9 @@ class URL
 
         $parts['port'] = isset($url['port']) ? ':' . $url['port'] : '';
 
-        $parts['user'] = isset($url['user']) ? $url['user'] : '';
+        $parts['user'] = isset($url['user']) ? \rawurlencode($url['user']) : '';
 
-        $parts['pass'] = !empty($url['pass']) ? ':' . $url['pass'] : '';
+        $parts['pass'] = !empty($url['pass']) ? ':' . \rawurlencode($url['pass']) : '';
 
         $parts['pass'] = ($parts['user'] || !empty($parts['pass'])) ? $parts['pass'] . '@' : '';
 


### PR DESCRIPTION
## What does this PR do?

Self-hosted installs with an external Redis that requires a user and password cannot log in. Three separate gaps, all reproduced against a Redis with `requirepass` plus an ACL user and the `default` user disabled:

- **`_APP_REDIS_USER` was read but never used.** The pooled Redis resource in `app/init/registers.php`, the `redis` container resource in `app/init/resources.php` and `getRedis()` in `app/realtime.php` all called `auth($pass)`. That works for `requirepass` but an ACL user fails with `WRONGPASS`. They now call `auth([$user, $pass])` when a user is set.
- **The queue publisher never received credentials.** `registers.php` built `Queue\Connection\Redis` with host and port only, so every publish (and, through `app/worker.php`, every consume) failed with `NOAUTH` on any password-protected Redis (#13554). The DSN user and password are now passed through. Same change as #13588.
- **Credentials with URL delimiters broke the DSN.** `URL::unparse()` did not percent-encode user or password, while `Utopia\DSN` `urldecode()`s them, so a password containing `@ : / ? #` failed at boot with `Unable to parse DSN`. `unparse()` now `rawurlencode()`s both. `registers.php` is its only caller, so nothing else changes.

The publisher half depends on `utopia-php/queue` actually calling `auth()`, which utopia-php/monorepo#260 adds. Until that is released and bumped here, cache, pubsub, lock and realtime authenticate correctly with this PR and the publisher still reports `NOAUTH`. The bump will be added to this PR once the tag exists.

## Test Plan

Probe from inside the `appwrite` container against a Redis with `requirepass secretpw` and `ACL SETUSER appwrite on >userpw ~* &* +@all`, before this change:

```
OK    phpredis auth(pass) as default user            => true
FAIL  phpredis auth(pass) with ACL user password     => WRONGPASS invalid username-password pair or user is disabled.
OK    phpredis auth([user,pass]) ACL                 => true
FAIL  queue Connection\Redis host+port only          => NOAUTH Authentication required.
FAIL  queue Connection\Redis with user+pass          => NOAUTH Authentication required.
FAIL  DSN round-trip pass='p@ss:w/rd?x#y'            => Unable to parse DSN: redis://appwrite:p@ss:w/rd?x#y@redis-acl:6379
```

Then the stack (`appwrite`, `appwrite-worker`, `appwrite-realtime`, `appwrite-task-scheduler`) recreated with `_APP_REDIS_HOST=redis-acl _APP_REDIS_USER=appwrite _APP_REDIS_PASS=userpw` and the `default` user disabled, with this change applied:

- Console account creation succeeds; no `NOAUTH` / `WRONGPASS` in the API or realtime logs.
- `CLIENT LIST` on the Redis shows the API, cache, pubsub, lock and realtime connections as `user=appwrite` (`hget`, `hset`, `get`, `evalsha`, `subscribe`).
- The publisher and consumer still fail, which is the library gap:

```
appwrite-task-scheduler   [StatsResources] Failed to publish stats resources message: NOAUTH Authentication required.
redis CLIENT LIST         15 × user=default cmd=brpop   (worker consumers, unauthenticated)
```

Unit: `tests/unit/URL/URLTest.php` passes. `composer lint` and PHPStan clean on the changed files.

## Related PRs and Issues

- Fixes #13554
- Supersedes #13588 (publisher credentials)
- Depends on utopia-php/monorepo#260 for the queue library half

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] Bump `utopia-php/queue` once #260 is tagged
