### PR TITLE
Add detailed scopes for organization project key management

### DIFF
--- a/app/config/roles.php
+++ b/app/config/roles.php
@@ -92,6 +92,8 @@ $admins = [
     'projects.write',
     'keys.read',
     'keys.write',
+    'organization.projects.keys.read',
+    'organization.projects.keys.write',
     'devKeys.read',
     'devKeys.write',
     'webhooks.read',

--- a/app/config/scopes/organization.php
+++ b/app/config/scopes/organization.php
@@ -12,6 +12,15 @@ return [
             "Access to create, update, and delete organization projects",
         "category" => "Projects",
     ],
+    "organization.projects.keys.read" => [
+        "description" => 'Access to read organization projects\' API keys',
+        "category" => "Projects",
+    ],
+    "organization.projects.keys.write" => [
+        "description" =>
+            "Access to create, update, and delete organization projects' API keys",
+        "category" => "Projects",
+    ],
     "devKeys.read" => [
         "description" => 'Access to read project\'s development keys',
         "category" => "Other",

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Keys/Create.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Keys/Create.php
@@ -42,7 +42,7 @@ class Create extends Action
             ->setHttpPath('/v1/organization/projects/:projectId/keys')
             ->desc('Create project key')
             ->groups(['api', 'organization'])
-            ->label('scope', 'keys.write')
+            ->label('scope', ['organization.projects.keys.write', 'keys.write'])
             ->label('event', 'keys.[keyId].create')
             ->label('audits.event', 'project.key.create')
             ->label('audits.resource', 'project.key/{response.$id}')

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Keys/Delete.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Keys/Delete.php
@@ -33,7 +33,7 @@ class Delete extends Action
             ->setHttpPath('/v1/organization/projects/:projectId/keys/:keyId')
             ->desc('Delete project key')
             ->groups(['api', 'organization'])
-            ->label('scope', 'keys.write')
+            ->label('scope', ['organization.projects.keys.write', 'keys.write'])
             ->label('event', 'keys.[keyId].delete')
             ->label('audits.event', 'project.key.delete')
             ->label('audits.resource', 'project.key/{request.keyId}')

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Keys/Ephemeral/Create.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Keys/Ephemeral/Create.php
@@ -40,7 +40,7 @@ class Create extends Action
             ->setHttpPath('/v1/organization/projects/:projectId/keys/ephemeral')
             ->desc('Create ephemeral project key')
             ->groups(['api', 'organization'])
-            ->label('scope', 'keys.write')
+            ->label('scope', ['organization.projects.keys.write', 'keys.write'])
             ->label('event', 'keys.[keyId].create')
             ->label('audits.event', 'project.key.create')
             ->label('audits.resource', 'project.key/{response.$id}')

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Keys/Get.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Keys/Get.php
@@ -30,7 +30,7 @@ class Get extends Action
             ->setHttpPath('/v1/organization/projects/:projectId/keys/:keyId')
             ->desc('Get project key')
             ->groups(['api', 'organization'])
-            ->label('scope', 'keys.read')
+            ->label('scope', ['organization.projects.keys.read', 'keys.read'])
             ->label('sdk', new Method(
                 namespace: 'organization',
                 group: 'keys',

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Keys/Update.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Keys/Update.php
@@ -40,7 +40,7 @@ class Update extends Action
             ->setHttpPath('/v1/organization/projects/:projectId/keys/:keyId')
             ->desc('Update project key')
             ->groups(['api', 'organization'])
-            ->label('scope', 'keys.write')
+            ->label('scope', ['organization.projects.keys.write', 'keys.write'])
             ->label('event', 'keys.[keyId].update')
             ->label('audits.event', 'project.key.update')
             ->label('audits.resource', 'project.key/{response.$id}')

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Keys/XList.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Keys/XList.php
@@ -36,7 +36,7 @@ class XList extends Action
             ->setHttpPath('/v1/organization/projects/:projectId/keys')
             ->desc('List project keys')
             ->groups(['api', 'organization'])
-            ->label('scope', 'keys.read')
+            ->label('scope', ['organization.projects.keys.read', 'keys.read'])
             ->label('sdk', new Method(
                 namespace: 'organization',
                 group: 'keys',

--- a/tests/e2e/Services/Console/ConsoleConsoleClientTest.php
+++ b/tests/e2e/Services/Console/ConsoleConsoleClientTest.php
@@ -196,6 +196,8 @@ final class ConsoleConsoleClientTest extends Scope
         // Well-known scopes must be present
         $this->assertContains('projects.read', $scopeIds);
         $this->assertContains('projects.write', $scopeIds);
+        $this->assertContains('organization.projects.keys.read', $scopeIds);
+        $this->assertContains('organization.projects.keys.write', $scopeIds);
 
         // Every scope has the expected shape
         foreach ($response['body']['scopes'] as $scope) {

--- a/tests/e2e/Services/Console/ConsoleCustomServerTest.php
+++ b/tests/e2e/Services/Console/ConsoleCustomServerTest.php
@@ -93,6 +93,8 @@ final class ConsoleCustomServerTest extends Scope
 
         $scopeIds = \array_column($response['body']['scopes'], '$id');
         $this->assertContains('projects.read', $scopeIds);
+        $this->assertContains('organization.projects.keys.read', $scopeIds);
+        $this->assertContains('organization.projects.keys.write', $scopeIds);
 
         $projectsRead = null;
         foreach ($response['body']['scopes'] as $scope) {


### PR DESCRIPTION
## What does this PR do?

Stacked on #13621. Adds dedicated organization scopes for the project key routes under `/v1/organization/projects/:projectId/keys`:

- `organization.projects.keys.read` — list and get project keys
- `organization.projects.keys.write` — create, update, delete project keys and create ephemeral keys

The routes accept either the new scope or the legacy `keys.read` / `keys.write`, so existing keys and sessions keep working. The new scopes are added to `app/config/scopes/organization.php` (available to organization API keys and the console scope picker) and to the console admin roles in `app/config/roles.php`.

## Test Plan

- `tests/e2e/Services/Console/*::testListOrganizationScopes` assert the new scopes are listed.
- `tests/e2e/Services/Organization/KeysConsoleClientTest` and `tests/e2e/Services/Project/KeysCustomServerTest` pass, covering the legacy scope path.

## Related PRs and Issues

- Base: #13621

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? — scopes are not part of the generated specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)