### PR TITLE
chore(deps): require utopia-php/queue ^2.2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,7 @@
         "utopia-php/platform": "1.0.0-rc20",
         "utopia-php/pools": "2.*",
         "utopia-php/span": "^4.2",
-        "utopia-php/queue": "^2.2.1",
+        "utopia-php/queue": "^2.2.3",
         "utopia-php/servers": "0.4.*",
         "utopia-php/registry": "0.5.*",
         "utopia-php/storage": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "334eead499308d545da180a7a842d158",
+    "content-hash": "e13d1ffb302f53ff62d44044c950e39e",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -4484,16 +4484,16 @@
         },
         {
             "name": "utopia-php/queue",
-            "version": "2.2.1",
+            "version": "2.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/queue.git",
-                "reference": "24457432495dac8b0bbffc573f02134d84f43d82"
+                "reference": "9474bc419fef9680a60ebd7d6773b730402d7446"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/queue/zipball/24457432495dac8b0bbffc573f02134d84f43d82",
-                "reference": "24457432495dac8b0bbffc573f02134d84f43d82",
+                "url": "https://api.github.com/repos/utopia-php/queue/zipball/9474bc419fef9680a60ebd7d6773b730402d7446",
+                "reference": "9474bc419fef9680a60ebd7d6773b730402d7446",
                 "shasum": ""
             },
             "require": {
@@ -4544,9 +4544,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/queue/issues",
-                "source": "https://github.com/utopia-php/queue/tree/2.2.1"
+                "source": "https://github.com/utopia-php/queue/tree/2.2.3"
             },
-            "time": "2026-09-10T10:48:03+00:00"
+            "time": "2026-09-11T10:05:23+00:00"
         },
         {
             "name": "utopia-php/registry",


### PR DESCRIPTION
## What does this PR do?

Bumps `utopia-php/queue` from 2.2.1 to 2.2.3. 2.2.3 (utopia-php/monorepo#260) makes `Connection\Redis` call `auth()` after `connect()`, using the ACL `[user, password]` pair when a user is set. #13622 already passes the DSN credentials into that constructor, so with this bump the queue publisher and the worker consumers authenticate against a password-protected or ACL-secured Redis. This closes the last gap behind #13554.

## Test Plan

Dev image rebuilt with this lock, then `appwrite`, `appwrite-worker`, `appwrite-realtime` and `appwrite-task-scheduler` recreated with `_APP_REDIS_HOST=redis-acl _APP_REDIS_USER=appwrite _APP_REDIS_PASS=userpw`, where the Redis has `requirepass`, an ACL user `appwrite`, and the `default` user disabled.

Before this bump (with #13622 merged), the queue paths were the only ones still failing:

```
appwrite-task-scheduler   [StatsResources] Failed to publish stats resources message: NOAUTH Authentication required.
redis CLIENT LIST         15 × user=default cmd=brpop   (worker consumers, unauthenticated)
```

After this bump, console account creation succeeds, the worker picks up the resulting jobs, and every Redis client is the ACL user:

```
redis CLIENT LIST
  26 user=appwrite
  15 cmd=brpop      (worker consumers)
   4 cmd=hget
   1 cmd=lpush      (publisher)
   1 cmd=subscribe  (realtime)
   1 cmd=evalsha    (lock)

NOAUTH / WRONGPASS in the last 3 minutes of logs:
  appwrite 0, appwrite-worker 0, appwrite-realtime 0, appwrite-task-scheduler 0

appwrite-worker
  webhooks  v1-webhooks  8
  jobs      v1-jobs      8
  mails     v1-mails     1
```

`composer validate` passes; the lock diff is the `utopia-php/queue` entry only.

## Related PRs and Issues

- Closes #13554
- Follows #13622 (Appwrite side) and utopia-php/monorepo#260 (library side)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
