### PR TITLE
fix(errors): return JSON errors to SDK requests on redirect routes

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -1416,7 +1416,12 @@ Http::error()
             ->addHeader('Pragma', 'no-cache')
             ->setStatusCode($code);
 
-        $template = $error->getView() ?? (($route) ? $route->getLabel('error', null) : null);
+        $template = $error->getView();
+
+        // SDKs send `accept: text/html` to these routes too, so only non-SDK requests get the error page
+        if ($template === null && $route && $request->getHeaderLine('x-sdk-name') === '') {
+            $template = $route->getLabel('error', null);
+        }
 
         // TODO: Ideally use group 'api' here, but all wildcard routes seem to have 'api' at the moment
         if (empty($route) || !\str_starts_with($route->getPath(), '/v1')) {


### PR DESCRIPTION
## What does this PR do?

Routes with an `error` view label (OAuth2 session and token creation, VCS authorize and callback) rendered the HTML error page for every failure. That included requests from server SDKs, which read the redirect themselves. A `createOAuth2Token` call with an invalid API key or an unknown project came back as `text/html`, and node-appwrite reported only `Invalid redirect`.

The error handler now renders the route's view only when the request has no `x-sdk-name` header, so SDK requests get the standard JSON error. `Accept` can't be the signal here: the Node SDK sends `accept: text/html` to these routes because the spec declares a `text/html` response. Browser navigations and plain HTTP clients still get the HTML page. Explicit exception views (router protection, unknown domains) are unchanged.

Fixes #8090. appwrite/sdk-generator#1900 makes the Node SDK read the error body. The dotnet, kotlin, python and php clients already do.

## Test Plan

Local stack, `GET /v1/account/tokens/oauth2/github` against a real project, with this change running on a second HTTP server:

| Request | main | this PR |
|---|---|---|
| browser `Accept`, no SDK headers | `text/html` | `text/html` |
| curl with an invalid key, no SDK headers | `text/html` | `text/html` |
| node-appwrite with the #1900 `redirect()` fix, invalid key | message is the HTML page | `user_unauthorized`: "The current user is not authorized to perform the requested action." |
| node-appwrite 29.0.0, invalid key | `Invalid redirect` | `Invalid redirect` (needs the SDK release) |
