### PR TITLE
chore: bump utopia-php/queue to 2.2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,7 @@
         "utopia-php/platform": "1.0.0-rc20",
         "utopia-php/pools": "2.*",
         "utopia-php/span": "^4.2",
-        "utopia-php/queue": "^2.2.3",
+        "utopia-php/queue": "^2.2.4",
         "utopia-php/servers": "0.4.*",
         "utopia-php/registry": "0.5.*",
         "utopia-php/storage": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "179b6295c070315f1d35007e2da5867d",
+    "content-hash": "c3061710f7b567210d14fb97e6744ef9",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -4484,16 +4484,16 @@
         },
         {
             "name": "utopia-php/queue",
-            "version": "2.2.3",
+            "version": "2.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/queue.git",
-                "reference": "9474bc419fef9680a60ebd7d6773b730402d7446"
+                "reference": "c6994fe68c58d48f303693dad2762d1f80d5bf97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/queue/zipball/9474bc419fef9680a60ebd7d6773b730402d7446",
-                "reference": "9474bc419fef9680a60ebd7d6773b730402d7446",
+                "url": "https://api.github.com/repos/utopia-php/queue/zipball/c6994fe68c58d48f303693dad2762d1f80d5bf97",
+                "reference": "c6994fe68c58d48f303693dad2762d1f80d5bf97",
                 "shasum": ""
             },
             "require": {
@@ -4544,9 +4544,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/queue/issues",
-                "source": "https://github.com/utopia-php/queue/tree/2.2.3"
+                "source": "https://github.com/utopia-php/queue/tree/2.2.4"
             },
-            "time": "2026-09-11T10:05:23+00:00"
+            "time": "2026-09-11T17:50:20+00:00"
         },
         {
             "name": "utopia-php/registry",


### PR DESCRIPTION
## What

Bumps `utopia-php/queue` from 2.2.3 to 2.2.4. Lock-only apart from the constraint.

## Why

2.2.4 ([utopia-php/monorepo#262](https://github.com/utopia-php/monorepo/pull/262)) fixes the Swoole adapter's consume loops, which checked the stop flag only before blocking on the concurrency slot. A SIGTERM that landed mid-job was noticed only after the slot came free, and by then the loop had already called `receive()` and claimed the next message. Every handler process took one more job after being told to stop, so a rolling restart drained for two job durations per process, and a long job accepted after SIGTERM could be SIGKILLed at the pod's grace period with its claim stranded.

With 2.2.4 the loop re-checks the flag once the slot is held and exits without receiving. Jobs already in flight still complete and commit.

## Test

Pinned upstream by `SwooleRestartTest::testShutdownDrainsJobWithoutRestartingWorkers`, which now runs against both the single-queue and multi-queue loops and was red on both before the fix. No code change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)