### PR TITLE
fix(databases): widen integer column when updateIntegerAttribute widens the range

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Action.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Action.php
@@ -493,6 +493,17 @@ abstract class Action extends DatabasesAction
         return $attribute;
     }
 
+    /**
+     * The SQL column for an integer range attribute is sized at create time
+     * to fit the promised range: 4 bytes when the range fits in INT32, 8
+     * bytes otherwise. The same boundary must govern updates, so the stored
+     * formatOptions cannot promise values the column cannot hold.
+     */
+    public static function intRangeColumnSize(int $min, int $max): int
+    {
+        return $min >= -2147483648 && $max <= 2147483647 ? 4 : 8;
+    }
+
     protected function updateAttribute(string $databaseId, string $collectionId, string $key, Database $dbForProject, Event $queueForEvents, Authorization $authorization, string $type, ?int $size = null, ?string $filter = null, string|bool|int|float|array|null $default = null, ?bool $required = null, int|float|null $min = null, int|float|null $max = null, ?array $elements = null, array $options = [], ?string $newKey = null): Document
     {
         $db = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
@@ -566,6 +577,21 @@ abstract class Action extends DatabasesAction
                 } else {
                     // intRange and bigintRange share the same integer range semantics
                     $validator = new Range($min, $max, Range::TYPE_INTEGER);
+
+                    // The column was sized at create time to fit the range
+                    // promised then; widen it (never narrow) when the updated
+                    // range no longer fits 4 bytes, so formatOptions cannot
+                    // promise values the column would reject.
+                    if (
+                        $attribute->getAttribute('format') === APP_DATABASE_ATTRIBUTE_INT_RANGE
+                        && !$attribute->getAttribute('array', false)
+                    ) {
+                        $intSize = self::intRangeColumnSize((int) $min, (int) $max);
+                        if ($intSize > (int) ($attribute->getAttribute('size', 4))) {
+                            $size = $intSize;
+                            $attribute->setAttribute('size', $intSize);
+                        }
+                    }
                 }
 
                 if (!is_null($default) && !$validator->isValid($default)) {

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Integer/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Integer/Create.php
@@ -97,7 +97,7 @@ class Create extends Action
         // The 4 byte column only holds a range that fits INT32. min counts: a
         // column bounded below -2147483648 has to be able to store that value,
         // and with min left out the bound is PHP_INT_MIN.
-        $size = $min >= -2147483648 && $max <= 2147483647 ? 4 : 8;
+        $size = self::intRangeColumnSize($min, $max);
 
         $attribute = $this->createAttribute($databaseId, $collectionId, new Document([
             'key' => $key,

--- a/tests/unit/Platform/Modules/Databases/Http/Databases/Collections/Attributes/ActionTest.php
+++ b/tests/unit/Platform/Modules/Databases/Http/Databases/Collections/Attributes/ActionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Appwrite\Platform\Modules\Databases\Http\Databases\Collections\Attributes;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class ActionTest extends TestCase
+{
+    public static function provideIntRanges(): array
+    {
+        return [
+            'int32 bounds inclusive' => [-2147483648, 2147483647, 4],
+            'small range' => [-1, 1, 4],
+            'zero range' => [0, 0, 4],
+            'one above int32 max' => [0, 2147483648, 8],
+            'one below int32 min' => [-2147483649, 0, 8],
+            'full 64-bit range' => [\PHP_INT_MIN, \PHP_INT_MAX, 8],
+            'int32 min with 64-bit max' => [-2147483648, \PHP_INT_MAX, 8],
+        ];
+    }
+
+    #[DataProvider('provideIntRanges')]
+    public function testIntRangeColumnSize(int $min, int $max, int $expected): void
+    {
+        $this->assertSame($expected, Action::intRangeColumnSize($min, $max));
+    }
+}


### PR DESCRIPTION
Fixes #13633

## Problem

`createIntegerAttribute` sizes the SQL column from the requested range: 4 bytes (`INT`) when `min`/`max` fit INT32, 8 bytes (`BIGINT`) otherwise. `updateIntegerAttribute` accepts new `min`/`max` values (the endpoint validators allow the full 64-bit range) but never passes a `size`, so:

- the column keeps the width chosen at create time,
- `formatOptions` are overwritten with the wider range,
- a document write beyond INT32 passes attribute validation but overflows the column, surfacing as an opaque database error.

In `utopia-php/database`, `Database::updateAttribute` falls back to the stored size when the caller passes `null` and only issues the `ALTER TABLE ... MODIFY` when a new size is supplied, so the width can never change through this endpoint today.

## Fix

- Extract the INT32 boundary check shared by both endpoints into `Action::intRangeColumnSize()` and use it in `createIntegerAttribute`.
- In the shared attributes `Action::updateAttribute`, when the stored format is `APP_DATABASE_ATTRIBUTE_INT_RANGE` and the attribute is not an array, compute the required size from the new `min`/`max` and pass it down when it exceeds the stored size, so the adapter issues the lossless `INT -> BIGINT` widen. Narrowing is never applied, to avoid truncating existing data.

## Tests

New unit test `tests/unit/Platform/Modules/Databases/Http/Databases/Collections/Attributes/ActionTest.php` covers the boundary (INT32 bounds inclusive, one value outside either side, full 64-bit range), 7 cases via data provider.

Verified in the repo's `appwrite/base:2.0.5` container (PHP 8.5): new test 7/7, `pint --test` PASS on changed files, `phpstan analyse` no errors on changed files, full `tests/unit` run shows only one pre-existing unrelated error (`Auth/KeyTest`, `adhocore/jwt` vs PHP 8.5), reproduced on the clean tree.