### PR TITLE
fix(abuse): lease the rate limiter's Redis connection from a pool

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3125,13 +3125,12 @@ Http::post('/v1/account/tokens/phone')
     ->inject('queueForEvents')
     ->inject('publisherForMessaging')
     ->inject('locale')
-    ->inject('timelimit')
     ->inject('usage')
     ->inject('plan')
     ->inject('store')
     ->inject('proofForCode')
     ->inject('authorization')
-    ->action(function (string $userId, string $phone, Request $request, Response $response, User $user, Document $project, array $platform, Database $dbForProject, Event $queueForEvents, MessagingPublisher $publisherForMessaging, Locale $locale, callable $timelimit, Context $usage, array $plan, Store $store, ProofsCode $proofForCode, Authorization $authorization) {
+    ->action(function (string $userId, string $phone, Request $request, Response $response, User $user, Document $project, array $platform, Database $dbForProject, Event $queueForEvents, MessagingPublisher $publisherForMessaging, Locale $locale, Context $usage, array $plan, Store $store, ProofsCode $proofForCode, Authorization $authorization) {
         if (empty(System::getEnv('_APP_SMS_PROVIDER'))) {
             throw new Exception(Exception::GENERAL_PHONE_DISABLED, 'Phone provider not configured');
         }
@@ -4541,12 +4540,11 @@ Http::post('/v1/account/verifications/phone')
     ->inject('publisherForMessaging')
     ->inject('project')
     ->inject('locale')
-    ->inject('timelimit')
     ->inject('usage')
     ->inject('plan')
     ->inject('proofForCode')
                 ->inject('authorization')
-    ->action(function (Request $request, Response $response, User $user, Database $dbForProject, Event $queueForEvents, MessagingPublisher $publisherForMessaging, Document $project, Locale $locale, callable $timelimit, Context $usage, array $plan, ProofsCode $proofForCode, Authorization $authorization) {
+    ->action(function (Request $request, Response $response, User $user, Database $dbForProject, Event $queueForEvents, MessagingPublisher $publisherForMessaging, Document $project, Locale $locale, Context $usage, array $plan, ProofsCode $proofForCode, Authorization $authorization) {
         if (empty(System::getEnv('_APP_SMS_PROVIDER'))) {
             throw new Exception(Exception::GENERAL_PHONE_DISABLED, 'Phone provider not configured');
         }

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -26,6 +26,7 @@ use Appwrite\Utopia\Database\Documents\User;
 use Appwrite\Utopia\Request;
 use Appwrite\Utopia\Response;
 use Utopia\Abuse\Abuse;
+use Utopia\Abuse\Adapters\TimeLimit;
 use Utopia\Bus\Bus;
 use Utopia\Cache\Adapter\Filesystem;
 use Utopia\Cache\Cache;
@@ -567,38 +568,37 @@ Http::init()
             try {
                 $start = $request->getContentRangeStart();
                 $end = $request->getContentRangeEnd();
-                $timeLimit = $timelimit($abuseKey, $abuseLimit, $route->getLabel('abuse-time', 3600));
-                $timeLimit
-                    ->setParam('{projectId}', $project->getId())
-                    ->setParam('{userId}', $user->getId())
-                    ->setParam('{userAgent}', $request->getUserAgent(''))
-                    ->setParam('{ip}', $request->getIP())
-                    ->setParam('{url}', $request->getHostname() . $route->getPath())
-                    ->setParam('{method}', $request->getMethod())
-                    ->setParam('{chunkId}', (int) ($start / ($end + 1 - $start)));
+                $isRateLimited = $timelimit($abuseKey, $abuseLimit, $route->getLabel('abuse-time', 3600), function (TimeLimit $timeLimit) use ($route, $request, $response, $project, $user, $start, $end, $shouldCheckAbuse, &$closestLimit): bool {
+                    $timeLimit
+                        ->setParam('{projectId}', $project->getId())
+                        ->setParam('{userId}', $user->getId())
+                        ->setParam('{userAgent}', $request->getUserAgent(''))
+                        ->setParam('{ip}', $request->getIP())
+                        ->setParam('{url}', $request->getHostname() . $route->getPath())
+                        ->setParam('{method}', $request->getMethod())
+                        ->setParam('{chunkId}', (int) ($start / ($end + 1 - $start)));
 
-                foreach ($request->getParams() as $key => $value) {
-                    if (! empty($value)) {
-                        $timeLimit->setParam('{param-' . $key . '}', (\is_array($value) || \is_object($value)) ? \json_encode($value) : $value);
+                    foreach ($request->getParams() as $key => $value) {
+                        if (! empty($value)) {
+                            $timeLimit->setParam('{param-' . $key . '}', (\is_array($value) || \is_object($value)) ? \json_encode($value) : $value);
+                        }
                     }
-                }
 
-                $abuse = new Abuse($timeLimit);
-                $remaining = $timeLimit->remaining();
-                $limit = $timeLimit->limit();
-                $time = $timeLimit->time() + $route->getLabel('abuse-time', 3600);
+                    $abuse = new Abuse($timeLimit);
+                    $remaining = $timeLimit->remaining();
+                    $limit = $timeLimit->limit();
+                    $time = $timeLimit->time() + $route->getLabel('abuse-time', 3600);
 
-                if ($limit && ($remaining < $closestLimit || is_null($closestLimit))) {
-                    $closestLimit = $remaining;
-                    $response
-                        ->addHeader('X-RateLimit-Limit', $limit)
-                        ->addHeader('X-RateLimit-Remaining', $remaining)
-                        ->addHeader('X-RateLimit-Reset', $time);
-                }
+                    if ($limit && ($remaining < $closestLimit || is_null($closestLimit))) {
+                        $closestLimit = $remaining;
+                        $response
+                            ->addHeader('X-RateLimit-Limit', $limit)
+                            ->addHeader('X-RateLimit-Remaining', $remaining)
+                            ->addHeader('X-RateLimit-Reset', $time);
+                    }
 
-                if ($shouldCheckAbuse) {
-                    $isRateLimited = $abuse->check();
-                }
+                    return $shouldCheckAbuse && $abuse->check();
+                });
             } catch (\Throwable $th) {
                 \error_log((string) $th);
 
@@ -949,24 +949,24 @@ Http::shutdown()
         foreach ($abuseKeyLabel as $abuseKey) {
             $start = $request->getContentRangeStart();
             $end = $request->getContentRangeEnd();
-            $timeLimit = $timelimit($abuseKey, $route->getLabel('abuse-limit', 0), $route->getLabel('abuse-time', 3600));
-            $timeLimit
-                ->setParam('{projectId}', $project->getId())
-                ->setParam('{userId}', $user->getId())
-                ->setParam('{userAgent}', $request->getUserAgent(''))
-                ->setParam('{ip}', $request->getIP())
-                ->setParam('{url}', $request->getHostname() . $route->getPath())
-                ->setParam('{method}', $request->getMethod())
-                ->setParam('{chunkId}', (int) ($start / ($end + 1 - $start)));
+            $timelimit($abuseKey, $route->getLabel('abuse-limit', 0), $route->getLabel('abuse-time', 3600), function (TimeLimit $timeLimit) use ($route, $request, $project, $user, $start, $end): void {
+                $timeLimit
+                    ->setParam('{projectId}', $project->getId())
+                    ->setParam('{userId}', $user->getId())
+                    ->setParam('{userAgent}', $request->getUserAgent(''))
+                    ->setParam('{ip}', $request->getIP())
+                    ->setParam('{url}', $request->getHostname() . $route->getPath())
+                    ->setParam('{method}', $request->getMethod())
+                    ->setParam('{chunkId}', (int) ($start / ($end + 1 - $start)));
 
-            foreach ($request->getParams() as $key => $value) { // Set request params as potential abuse keys
-                if (! empty($value)) {
-                    $timeLimit->setParam('{param-' . $key . '}', (\is_array($value) || \is_object($value)) ? \json_encode($value) : $value);
+                foreach ($request->getParams() as $key => $value) { // Set request params as potential abuse keys
+                    if (! empty($value)) {
+                        $timeLimit->setParam('{param-' . $key . '}', (\is_array($value) || \is_object($value)) ? \json_encode($value) : $value);
+                    }
                 }
-            }
 
-            $abuse = new Abuse($timeLimit);
-            $abuse->reset();
+                (new Abuse($timeLimit))->reset();
+            });
         }
     });
 

--- a/app/init/registers.php
+++ b/app/init/registers.php
@@ -128,10 +128,19 @@ $register->set('pools', function () {
             'multiple' => false,
             'schemes' => ['redis'],
         ],
+        // Abuse gets its own pool rather than sharing 'lock': lock leases are
+        // held for the whole guarded callback, which for storage chunk uploads
+        // spans the transfer. Rate limit checks must not queue behind those.
+        'abuse' => [
+            'type' => 'abuse',
+            'dsns' => $fallbackForRedis,
+            'multiple' => false,
+            'schemes' => ['redis'],
+        ],
     ];
 
     $maxConnections = (int) System::getEnv('_APP_CONNECTIONS_MAX', 151);
-    $instanceConnections = $maxConnections / (int) System::getEnv('_APP_POOL_CLIENTS', 14);
+    $instanceConnections = $maxConnections / (int) System::getEnv('_APP_POOL_CLIENTS', 15);
 
     $workerCount = intval(System::getEnv('_APP_CPU_NUM', swoole_cpu_num())) * intval(System::getEnv('_APP_WORKER_PER_CORE', 6));
     $poolSize = max(1, (int)($instanceConnections / $workerCount));
@@ -274,6 +283,7 @@ $register->set('pools', function () {
                         }
 
                         return $adapter;
+                    case 'abuse':
                     case 'lock':
                         return $resource();
                     default:

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -303,22 +303,6 @@ $container->set('cache', function (Group $pools, Telemetry $telemetry) {
 
 $container->set('cacheControlForStorage', fn () => fn (StorageCacheControl $config): string => \sprintf('private, max-age=%d', $config->maxAge));
 
-$container->set('redis', function () {
-    $host = System::getEnv('_APP_REDIS_HOST', 'localhost');
-    $port = System::getEnv('_APP_REDIS_PORT', 6379);
-    $user = System::getEnv('_APP_REDIS_USER', '');
-    $pass = System::getEnv('_APP_REDIS_PASS', '');
-
-    $redis = new \Redis();
-    @$redis->pconnect($host, (int) $port);
-    if ($pass !== '') {
-        $redis->auth($user !== '' ? [$user, $pass] : $pass);
-    }
-    $redis->setOption(\Redis::OPT_READ_TIMEOUT, -1);
-
-    return $redis;
-});
-
 $container->set('locks', fn (Group $pools) => fn (string $key, int $ttl, callable $callback, float $timeout = 0.0): mixed => $pools->get('lock')->use(
     function (\Redis $redis) use ($key, $ttl, $callback, $timeout): mixed {
         // The callback receives the lock so long-running holders can refresh
@@ -329,7 +313,13 @@ $container->set('locks', fn (Group $pools) => fn (string $key, int $ttl, callabl
     }
 ), ['pools']);
 
-$container->set('timelimit', fn (\Redis $redis) => fn (string $key, int $limit, int $time) => new TimeLimitRedis($key, $limit, $time, $redis), ['redis']);
+// The lease spans the whole callback because a TimeLimit issues several round
+// trips (remaining, limit, check, reset) and must hold one connection for all of
+// them. Do not throw from the callback: the pool treats that as a failed lease
+// and reconnects the socket before returning it.
+$container->set('timelimit', fn (Group $pools) => fn (string $key, int $limit, int $time, callable $callback): mixed => $pools->get('abuse')->use(
+    fn (\Redis $redis): mixed => $callback(new TimeLimitRedis($key, $limit, $time, $redis))
+), ['pools']);
 
 $container->set('deviceForLocal', fn (Telemetry $telemetry) => new Device\Telemetry($telemetry, new Local()), ['telemetry']);
 

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Create.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Create.php
@@ -105,7 +105,6 @@ class Create extends Action
             ->inject('queueForEvents')
             ->inject('publisherForMessaging')
             ->inject('publisherForMails')
-            ->inject('timelimit')
             ->inject('usage')
             ->inject('plan')
             ->inject('proofForToken')
@@ -125,7 +124,6 @@ class Create extends Action
         Event $queueForEvents,
         MessagingPublisher $publisherForMessaging,
         MailPublisher $publisherForMails,
-        callable $timelimit,
         Context $usage,
         array $plan,
         ProofsToken $proofForToken,

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Create.php
@@ -28,6 +28,7 @@ use Appwrite\Utopia\Response\Model\Rule;
 use Appwrite\Vcs\Factory as VcsFactory;
 use Appwrite\Vcs\RepositoryWebhooks;
 use Utopia\Abuse\Abuse;
+use Utopia\Abuse\Adapters\TimeLimit;
 use Utopia\Bus\Bus;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
@@ -194,28 +195,32 @@ class Create extends Base
     ) {
 
         // Temporary abuse check
-        $abuseCheck = function () use ($project, $timelimit, $response) {
+        $abuseCheck = function () use ($project, $timelimit, $response): void {
             $abuseKey = "projectId:{projectId},url:{url}";
             $abuseLimit = System::getEnv('_APP_FUNCTIONS_CREATION_ABUSE_LIMIT', 50);
             $abuseTime = 86400; // 1 day
 
-            $timeLimit = $timelimit($abuseKey, $abuseLimit, $abuseTime);
-            $timeLimit
-                ->setParam('{projectId}', $project->getId())
-                ->setParam('{url}', '/v1/functions');
+            $isRateLimited = $timelimit($abuseKey, $abuseLimit, $abuseTime, function (TimeLimit $timeLimit) use ($project, $response, $abuseTime): bool {
+                $timeLimit
+                    ->setParam('{projectId}', $project->getId())
+                    ->setParam('{url}', '/v1/functions');
 
-            $abuse = new Abuse($timeLimit);
-            $remaining = $timeLimit->remaining();
-            $limit = $timeLimit->limit();
-            $time = $timeLimit->time() + $abuseTime;
+                $abuse = new Abuse($timeLimit);
+                $remaining = $timeLimit->remaining();
+                $limit = $timeLimit->limit();
+                $time = $timeLimit->time() + $abuseTime;
 
-            $response
-                ->addHeader('X-RateLimit-Limit', $limit)
-                ->addHeader('X-RateLimit-Remaining', $remaining)
-                ->addHeader('X-RateLimit-Reset', $time);
+                $response
+                    ->addHeader('X-RateLimit-Limit', $limit)
+                    ->addHeader('X-RateLimit-Remaining', $remaining)
+                    ->addHeader('X-RateLimit-Reset', $time);
 
-            $enabled = System::getEnv('_APP_OPTIONS_ABUSE', 'enabled') !== 'disabled';
-            if ($enabled && $abuse->check()) {
+                $enabled = System::getEnv('_APP_OPTIONS_ABUSE', 'enabled') !== 'disabled';
+
+                return $enabled && $abuse->check();
+            });
+
+            if ($isRateLimited) {
                 throw new Exception(Exception::GENERAL_RATE_LIMIT_EXCEEDED);
             }
         };

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
@@ -92,7 +92,6 @@ class Create extends Action
             ->inject('publisherForMails')
             ->inject('publisherForMessaging')
             ->inject('queueForEvents')
-            ->inject('timelimit')
             ->inject('usage')
             ->inject('plan')
             ->inject('platform')
@@ -101,7 +100,7 @@ class Create extends Action
             ->callback($this->action(...));
     }
 
-    public function action(string $teamId, ?string $email, ?string $userId, ?string $phone, array $roles, ?string $url, ?string $name, Response $response, Document $project, User $user, Database $dbForProject, Authorization $authorization, Locale $locale, MailPublisher $publisherForMails, MessagingPublisher $publisherForMessaging, Event $queueForEvents, callable $timelimit, Context $usage, array $plan, array $platform, Password $proofForPassword, Token $proofForToken)
+    public function action(string $teamId, ?string $email, ?string $userId, ?string $phone, array $roles, ?string $url, ?string $name, Response $response, Document $project, User $user, Database $dbForProject, Authorization $authorization, Locale $locale, MailPublisher $publisherForMails, MessagingPublisher $publisherForMessaging, Event $queueForEvents, Context $usage, array $plan, array $platform, Password $proofForPassword, Token $proofForToken)
     {
         $email ??= '';
         $userId ??= '';

--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -1832,6 +1832,119 @@ trait StorageBase
         ]);
     }
 
+    /**
+     * Concurrent unauthenticated uploads run the abuse rate limiter from many
+     * coroutines in one HTTP worker. A shared Redis socket there kills the
+     * worker with a fatal Swoole error instead of answering the requests.
+     */
+    public function testCreateBucketFileParallelUploads(): void
+    {
+        $total = 24;
+
+        $bucket = $this->client->call(Client::METHOD_POST, '/storage/buckets', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'bucketId' => ID::unique(),
+            'name' => 'Test Bucket Parallel Upload',
+            'antivirus' => false,
+            'encryption' => false,
+            'permissions' => [
+                Permission::read(Role::any()),
+                Permission::create(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+        ]);
+
+        $this->assertEquals(201, $bucket['headers']['status-code']);
+
+        $bucketId = $bucket['body']['$id'];
+        $tmpDirectory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'appwrite-parallel-uploads-' . $bucketId;
+        mkdir($tmpDirectory);
+
+        try {
+            $source = $tmpDirectory . DIRECTORY_SEPARATOR . 'parallel-upload.bin';
+            file_put_contents($source, str_repeat('parallel upload probe ', 32));
+
+            $endpoint = parse_url($this->client->getEndpoint());
+            $scheme = $endpoint['scheme'] ?? 'http';
+            $host = $endpoint['host'] ?? 'appwrite';
+            $port = $endpoint['port'] ?? ($scheme === 'https' ? 443 : 80);
+            $basePath = rtrim($endpoint['path'] ?? '', '/');
+
+            $responses = [];
+
+            \Swoole\Coroutine\run(function () use ($basePath, $bucketId, $host, $port, $scheme, $source, $total, &$responses): void {
+                $wg = new \Swoole\Coroutine\WaitGroup();
+
+                for ($index = 0; $index < $total; $index++) {
+                    $wg->add();
+                    \Swoole\Coroutine::create(function () use ($basePath, $bucketId, $host, $index, $port, &$responses, $scheme, $source, $wg): void {
+                        try {
+                            $client = new \Swoole\Coroutine\Http\Client($host, (int) $port, $scheme === 'https');
+                            $client->set([
+                                'timeout' => 60,
+                                'ssl_verify_peer' => false,
+                                'ssl_verify_host' => false,
+                            ]);
+                            // No API key or session: the abuse limiter only runs for unprivileged callers.
+                            $client->setHeaders(['x-appwrite-project' => $this->getProject()['$id']]);
+                            $client->setMethod(Client::METHOD_POST);
+                            $client->setData(['fileId' => ID::unique()]);
+                            $client->addFile($source, 'file', 'application/octet-stream', 'parallel-upload.bin');
+                            $client->execute($basePath . '/storage/buckets/' . $bucketId . '/files');
+
+                            $responses[$index] = [
+                                'error' => $client->errMsg,
+                                'statusCode' => $client->statusCode,
+                            ];
+
+                            $client->close();
+                        } finally {
+                            $wg->done();
+                        }
+                    });
+                }
+
+                $wg->wait();
+            });
+
+            $this->assertCount($total, $responses);
+
+            foreach ($responses as $index => $response) {
+                // A dead worker shows up as a transport error or a negative status code.
+                $this->assertSame('', $response['error'], 'Upload ' . $index . ' failed at the connection level');
+                $this->assertContains($response['statusCode'], [201, 429], 'Upload ' . $index . ' returned ' . $response['statusCode']);
+            }
+
+            $this->assertContains(201, array_column($responses, 'statusCode'));
+
+            // The worker must still be serving after the burst.
+            $alive = $this->client->call(Client::METHOD_GET, '/storage/buckets/' . $bucketId, [
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+                'x-appwrite-key' => $this->getProject()['apiKey'],
+            ]);
+
+            $this->assertEquals(200, $alive['headers']['status-code']);
+        } finally {
+            $this->client->call(Client::METHOD_DELETE, '/storage/buckets/' . $bucketId, [
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+                'x-appwrite-key' => $this->getProject()['apiKey'],
+            ]);
+
+            foreach (glob($tmpDirectory . DIRECTORY_SEPARATOR . '*') ?: [] as $file) {
+                unlink($file);
+            }
+
+            if (is_dir($tmpDirectory)) {
+                rmdir($tmpDirectory);
+            }
+        }
+    }
+
     public static function parallelChunksProvider(): array
     {
         return [


### PR DESCRIPTION
## What

Concurrent requests can kill a production HTTP worker. Any two requests that run the abuse rate limiter at the same time in one worker hit a fatal `Swoole\Error` and the worker exits with status 255.

```
Fatal error: Uncaught Swoole\Error: Socket#15 has already been bound to another
coroutine#53, reading of the same socket in coroutine#54 at the same time is not allowed
  in .../utopia-php/abuse/src/Abuse/Adapters/TimeLimit/Redis.php:49
#0 .../TimeLimit/Redis.php(49): Redis->get('abuse__ip:192.1...')
#1 .../TimeLimit.php(79): ...Redis->count('ip:192.168.167....', 1789233060)
#2 /usr/src/code/app/controllers/shared/api.php(587): ...TimeLimit->remaining()
#3 .../Http.php(642): {closure:.../app/controllers/shared/api.php:544}
```

This is B1 from the 2.1.0 release qualification.

## Why it happens

`app/init/resources.php` registered `redis` as a bare `\Redis` built with `pconnect()`, and `timelimit` built its `TimeLimit` on it. `Utopia\DI\Container::get()` memoizes on the parent container, and `pconnect` returns the same persistent socket per process anyway, so every coroutine in a worker shared one connection.

That was survivable until 2.1.0. `app/http.php` now uses `Mode::HYPERLOOP_B`, which sets `OPTION_HOOK_FLAGS => SWOOLE_HOOK_ALL`. 2.0.0 passed a plain settings array with no hook flags. phpredis connects over `php_stream`, so hooks make that socket coroutine-aware — and two coroutines reading it concurrently is exactly this error. Before the hooks, the shared socket simply blocked the worker and serialized.

`remaining()` at `api.php:587` runs before the `$shouldCheckAbuse` gate, so an API key does not avoid the path either.

Every other Redis consumer already leases from `Utopia\Pools\Group` — `locks`, `dbForProject`, the cache adapters. `timelimit` was the one path that never did.

**Docker cannot see this.** Through the whole failure the container reports `RestartCount 0` and `health=healthy`; only the in-container PIDs show the workers dying and respawning under the supervisor. Container-level checks in CI or production would never flag it.

## What changed

| File | Change |
|---|---|
| `app/init/registers.php` | New `abuse` Redis pool; `_APP_POOL_CLIENTS` default 14 → 15 for it |
| `app/init/resources.php` | Removed the process-global `redis` resource; `timelimit` now leases from the pool |
| `app/controllers/shared/api.php` | Both abuse hooks run inside the lease |
| `Functions/Http/Functions/Create.php` | Same, for its creation-rate check |
| `account.php` ×2, `Teams/…/Memberships/Create.php`, `Account/…/MFA/Challenges/Create.php` | Removed dead `timelimit` injections |
| `tests/e2e/Services/Storage/StorageBase.php` | New `testCreateBucketFileParallelUploads` |

Two decisions worth calling out:

**Abuse gets its own pool rather than sharing `lock`.** `locks` holds its lease for the whole guarded callback, and for storage chunk uploads that spans the transfer. Rate-limit checks must not queue behind uploads.

**Call sites must not throw inside the lease.** `Pool::use()` treats an exception as a failed lease and calls `recover()`, which runs `\Redis::reset()` and `reconnect()` — so throwing `GENERAL_RATE_LIMIT_EXCEEDED` from inside would tear down and rebuild the socket on every 429. Each call site returns its decision and throws outside. There is a comment at the resource saying so.

Four of the seven `timelimit` injections turned out to be dead — no `TimeLimit` or `Abuse` reference anywhere in those files — so they are gone.

## Verification

On the 2.1.0 production image (MariaDB lab, 2 HTTP workers), 64 concurrent unauthenticated multipart uploads to a `create("any")` bucket:

| | Before | After |
|---|---|---|
| N=64 × 3 rounds | 56, 55, 38 failed (60s timeouts) | 63 × 201, 1 × 429 |
| `Swoole\Error` fatals | 12 | **0** |
| Worker exits (255) | both workers, repeatedly | none — PIDs survived |

The single 429 is correct; the limit is 60 writes/60s.

The new e2e test, same command both ways on a 2-worker stack:

- without the fix: **fails 3/3** — `Upload 21 failed at the connection level: Operation timed out`, 12 fatals
- with the fix: **passes 3/3**, 0 fatals

Suites: unit 1202 tests / 6038 assertions clean · Storage CustomServer 31/31 including the duplicate-chunks case the qualification run had to interrupt · Teams 48/48 · Account `Phone` 6/6 and `MFA` 7/7, covering every signature touched · Pint and PHPStan clean on all 8 files.

## Notes for review

**The new test is probabilistic, not deterministic.** Its power scales as N²/workers, so on a very wide worker pool it can pass even unfixed. It is sized at 24 concurrent uploads: enough to catch the bug at 2 workers, light enough to pass on a 72-worker box. At 64 it also reproduces, but 72 workers × their DB pools exhausts a dev box's `max_connections=100`.

**Pool sizing is still wrong for default installs, separately from this PR.** `app/init/registers.php:132` computes `poolSize = (151/15) / (CPU × 6)`, which floors at 1 on any box with ≥2 cores. That was sized for one-request-per-worker and is now wrong under HYPERLOOP_B coroutines. It is not what caused this crash — the lab crashed with `poolSize=5`, because `timelimit` touched no pool at all — but it deserves a measured fix.

**`app/realtime.php:231-254` has the same shape** and is not fixed here. `getRedis()` caches in `Coroutine::getContext()` but calls `pconnect()`, so all connections share one socket, and `getTimelimit()` runs abuse checks on it at `:967`. Pre-existing — `SWOOLE_HOOK_ALL` was already set in 2.0.0's realtime — so not a 2.1 regression, but it is the same crash waiting on a busy realtime server. Worth its own issue.

**Worth a sweep before shipping 2.1.0.** The HYPERLOOP_B switch makes every unpooled long-lived client in the HTTP path suspect. `timelimit` was the only one reaching the shared `redis` resource, but nothing guarantees it is the only one of its kind.
